### PR TITLE
Avoid division by zero in posix targets

### DIFF
--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -107,23 +107,45 @@
    #define OS_USED 
 #endif
 
-#if defined(_ix86_)
+#include <stdint.h>
+#include <stdbool.h>
+
+#define int8 int8_t
+#define int16 int16_t
+#define int32 int32_t
+#define int64 int64_t
+#define uint8 uint8_t
+#define uint16 uint16_t
+#define uint32 uint32_t
+#define uint64 uint64_t
+
+#if defined(__i386)
 /* ----------------------- Intel x86 processor family -------------------------*/
   /* Little endian */
   #undef   _STRUCT_HIGH_BIT_FIRST_
   #define  _STRUCT_LOW_BIT_FIRST_
 
 #ifndef _USING_RTEMS_INCLUDES_
-  typedef unsigned char                         boolean;
+  #define boolean bool
 #endif
 
-  typedef signed char                           int8;
-  typedef short int                             int16;
-  typedef long int                              int32;
-  typedef unsigned char                         uint8;
-  typedef unsigned short int                    uint16;
-  typedef unsigned long int                     uint32;
-  _EXTENSION_ typedef unsigned long long int    uint64;
+#elif defined(__x86_64__)
+/* ----------------------- Intel x86 64 processor family -------------------------*/
+  /* Little endian */
+  #undef   _STRUCT_HIGH_BIT_FIRST_
+  #define  _STRUCT_LOW_BIT_FIRST_
+
+#ifndef _USING_RTEMS_INCLUDES_
+  #define boolean bool
+#endif
+
+#elif defined(__arm__)
+/* ----------------------- ARM processor family -------------------------*/
+  /* Little endian */
+  #undef   _STRUCT_HIGH_BIT_FIRST_
+  #define  _STRUCT_LOW_BIT_FIRST_
+
+  #define boolean bool
 
 #elif defined(__PPC__)
    /* ----------------------- Motorola Power PC family ---------------------------*/
@@ -132,14 +154,7 @@
    #define _STRUCT_HIGH_BIT_FIRST_
    #undef  _STRUCT_LOW_BIT_FIRST_
 
-   typedef unsigned char                        boolean;
-   typedef signed char                          int8;
-   typedef short int                            int16;
-   typedef long int                             int32;
-   typedef unsigned char                        uint8;
-   typedef unsigned short int                   uint16;
-   typedef unsigned long int                    uint32;
-   _EXTENSION_ typedef unsigned long long int   uint64;
+   #define boolean bool
 
 #elif defined(_m68k_)
    /* ----------------------- Motorola m68k/Coldfire family ---------------------------*/
@@ -147,14 +162,7 @@
    #define _STRUCT_HIGH_BIT_FIRST_
    #undef  _STRUCT_LOW_BIT_FIRST_
 
-   typedef unsigned char                        boolean;
-   typedef signed char                          int8;
-   typedef short int                            int16;
-   typedef long int                             int32;
-   typedef unsigned char                        uint8;
-   typedef unsigned short int                   uint16;
-   typedef unsigned long int                    uint32;
-   _EXTENSION_ typedef unsigned long long int   uint64;
+   #define boolean bool
 
 #elif defined(__SPARC__)
    /* ----------------------- SPARC/LEON family ---------------------------*/
@@ -162,14 +170,7 @@
    #define _STRUCT_HIGH_BIT_FIRST_
    #undef  _STRUCT_LOW_BIT_FIRST_
 
-   typedef unsigned char                        boolean;
-   typedef signed char                          int8;
-   typedef short int                            int16;
-   typedef long int                             int32;
-   typedef unsigned char                        uint8;
-   typedef unsigned short int                   uint16;
-   typedef unsigned long int                    uint32;
-   _EXTENSION_ typedef unsigned long long int   uint64;
+   #define boolean bool
 
 #else  /* not any of the above */
    #error undefined processor

--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -3378,7 +3378,8 @@ int32 OS_Tick2Micros (void)
    ** and how do we find out ?
    */
    /*return(10000);*/
-   return((1/(CLOCKS_PER_SEC))*1000);
+   int32 tick_duration_usec = (1/(CLOCKS_PER_SEC))*1000;
+   return((tick_duration_usec > 0) ? tick_duration_usec : 1);
 }
 
 


### PR DESCRIPTION
The tick duration in microseconds may be calculated to zero depending on the
processor clock speed.

Maybe another solution could be using BogoMips for calculating the tick duration or even querying sysfs (i.e. /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq). Both have drawbacks and in some case zero will be get as a result.

Also BogoMips has recently change and now it can be specified at build time.
