### PR TITLE
OS_QueueGet bugfix

### DIFF
--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -1430,12 +1430,14 @@ int32 OS_QueueGet (uint32 queue_id, void *data, uint32 size, uint32 *size_copied
          *size_copied = 0;
          return OS_ERROR;
       }
-      
-      /*
-      ** If rv == 0, then the select timed out with no data
-      */
-      *size_copied = 0;
-      return(OS_QUEUE_TIMEOUT);
+	  else
+	  {
+		  /*
+		  ** If rv == 0, then the select timed out with no data
+		  */
+		  *size_copied = 0;
+		  return(OS_QUEUE_TIMEOUT);
+	  }
      
    } /* END timeout */
 


### PR DESCRIPTION
When user uses OS_QueueGet  with timeout paramater, then always timeot fails even if actual data aquired