### PR TITLE
Fix #15 unit test warnings

### DIFF
--- a/src/unit-tests/oscore-test/ut_oscore_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_test.c
@@ -29,9 +29,9 @@ extern UT_OsLogInfo_t  g_logInfo;
 **--------------------------------------------------------------------------------*/
 
 int32  g_skipTestCase = -1;
-char*  g_skipTestCaseResult = " ";
+const char*  g_skipTestCaseResult = " ";
 
-char* g_task_names[UT_OS_TASK_LIST_LEN];
+const char* g_task_names[UT_OS_TASK_LIST_LEN];
 char  g_long_task_name[OS_MAX_API_NAME+5];
 
 /*--------------------------------------------------------------------------------*
@@ -49,6 +49,7 @@ void UT_os_setup_install_delete_handler_test(void);
 void UT_os_init_task_exit_test(void);
 void UT_os_init_task_delay_test(void);
 void UT_os_init_task_set_priority_test(void);
+void UT_os_init_task_register_test(void);
 void UT_os_init_task_get_id_test(void);
 void UT_os_init_task_get_id_by_name_test(void);
 void UT_os_init_task_get_info_test(void);

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -40,7 +40,7 @@ char  g_dirName[UT_OS_SM_TEXT_LEN];
 char  g_fileName[UT_OS_SM_TEXT_LEN];
 
 char  g_subdirNames[UT_OS_FILE_MAX_DIRS][UT_OS_SM_TEXT_LEN];
-char* g_tgtSubdirs[UT_OS_FILE_MAX_DIRS] = {"subdir1", "subdir2"};
+const char* g_tgtSubdirs[UT_OS_FILE_MAX_DIRS] = {"subdir1", "subdir2"};
 
 char  g_dirItems[UT_OS_FILE_MAX_DIRS][UT_OS_SM_TEXT_LEN];
 
@@ -520,7 +520,6 @@ void UT_os_readdir_test()
 {
     int32 idx=0;
     uint32 dirh;
-    os_dirent_t* dirEntry=NULL;
     UT_OsApiInfo_t apiInfo;
     const char* testDesc=NULL;
 

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -2091,7 +2091,7 @@ void UT_os_outputtofile_test()
 {
     int32 idx=0;
     UT_OsApiInfo_t apiInfo;
-	char* cmd=NULL;
+    const char* cmd=NULL;
     const char* testDesc=NULL;
 
     UT_OS_CLEAR_API_INFO_MACRO(apiInfo, idx)
@@ -2236,7 +2236,7 @@ void UT_os_getfdinfo_test()
     UT_OsApiInfo_t apiInfo;
     OS_file_prop_t fdProps;
     const char* testDesc=NULL;
-    char* fileName="GetInfo_Nom.txt";
+    const char* fileName="GetInfo_Nom.txt";
 
     UT_OS_CLEAR_API_INFO_MACRO(apiInfo, idx)
 

--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -31,14 +31,14 @@ extern UT_OsLogInfo_t  g_logInfo;
 char* g_fsAddrPtr = NULL;
 
 int32  g_skipTestCase = -1;
-char*  g_skipTestCaseResult = " ";
+const char*  g_skipTestCaseResult = " ";
 
 char  g_longPathName[OS_MAX_PATH_LEN+5];
 char  g_longFileName[OS_MAX_PATH_LEN];
 char  g_invalidPath[OS_MAX_PATH_LEN];
 
-char* g_devName = "/ramdev3";
-char* g_mntName = "/drive3";
+const char* g_devName = "/ramdev3";
+const char* g_mntName = "/drive3";
 
 /*--------------------------------------------------------------------------------*
 ** External function prototypes

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_test.c
@@ -37,7 +37,7 @@ int32 g_blkSize = UT_OS_FS_BLOCK_SIZE;
 int32 g_blkCnt  = UT_OS_FS_MAX_BLOCKS;
 
 int32  g_skipTestCase = -1;
-char*  g_skipTestCaseResult = " ";
+const char*  g_skipTestCaseResult = " ";
 
 char  g_fsLongName[OS_MAX_PATH_LEN+5];
 char  g_physDriveName[OS_MAX_PATH_LEN];

--- a/src/unit-tests/ostimer-test/ut_ostimer_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_test.c
@@ -29,9 +29,9 @@ extern UT_OsLogInfo_t  g_logInfo;
 **--------------------------------------------------------------------------------*/
 
 int32  g_skipTestCase = -1;
-char*  g_skipTestCaseResult = " ";
+const char*  g_skipTestCaseResult = " ";
 
-char*  g_timerNames[UT_OS_TIMER_LIST_LEN];
+const char*  g_timerNames[UT_OS_TIMER_LIST_LEN];
 char   g_longTimerName[OS_MAX_API_NAME+5];
 
 uint32  g_cbLoopCntMax = 5;


### PR DESCRIPTION
**Describe the contribution**
Fixes #15 
- Remove unused variable
- Add local function prototype where missing
- Qualify all pointers to string literals as `const`

**Testing performed**
Rebuild OSAL per default configuration with unit tests enabled
Re-ran all unit tests and confirm passage

**Expected behavior changes**
No warnings generated when using `-Wall -Werror -std=c99 -pedantic -Wwrite-strings -Wstrict-prototypes'

**System(s) tested on:**
Ubuntu 18.04 (64-bit)

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.
