### PR TITLE
Correct error checking for taskSpawn

### DIFF
--- a/src/os/vxworks/osapi.c
+++ b/src/os/vxworks/osapi.c
@@ -1759,7 +1759,7 @@ int32 OS_ConsoleCreate_Impl(uint32 local_id)
                     (FUNCPTR)OS_ConsoleTask_Entry,
                     local_id,0,0,0,0,0,0,0,0,0);
 
-            if (local->taskid == (TASK_ID)0)
+            if (local->taskid == (TASK_ID)ERROR)
             {
                 OS_DEBUG("taskSpawn() - vxWorks errno %d\n",errno);
                 return_code = OS_ERROR;


### PR DESCRIPTION
**Describe the contribution**
Fixes #269, Corrects the error check after taskSpawn in the vxworks implementation.

The test for failure of taskSpawn should be for the value of
ERROR, not 0, per the VxWorks API documentation.

Found when implementing the unit test improvements in #230.

This issue is generally only reproducible in UT where taskSpawn
can be made to fail.  In normal FSW/runtime use, the taskSpawn
call is not likely to fail, and this issue cannot be seen.

**Testing performed**
Build OSAL coverage tests (see #268) and confirm passage of all tests.

**Expected behavior changes**
All unit tests pass, fixes a failure in one test due to this incorrect error test.

**System(s) tested on:**
Ubuntu 18.04.2 LTS 64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.
