### PR TITLE
Fix #272: use 4K stack for sem-speed-test tasks

### DIFF
--- a/src/tests/sem-speed-test/sem-speed-test.c
+++ b/src/tests/sem-speed-test/sem-speed-test.c
@@ -150,10 +150,10 @@ void SemSetup(void)
    /*
    ** Create the tasks
    */
-   status = OS_TaskCreate( &task_1_id, "Task 1", task_1, NULL, 0, TASK_PRIORITY, 0);
+   status = OS_TaskCreate( &task_1_id, "Task 1", task_1, NULL, 4096, TASK_PRIORITY, 0);
    UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%u Rc=%d", (unsigned int)task_1_id, (int)status);
 
-   status = OS_TaskCreate( &task_2_id, "Task 2", task_2, NULL, 0, TASK_PRIORITY, 0);
+   status = OS_TaskCreate( &task_2_id, "Task 2", task_2, NULL, 4096, TASK_PRIORITY, 0);
    UtAssert_True(status == OS_SUCCESS, "Task 2 create Id=%u Rc=%d", (unsigned int)task_2_id, (int)status);
 
    /* A small delay just to allow the tasks


### PR DESCRIPTION
**Describe the contribution**
Fix issue #272
Use a nonzero stack size for this test.

**Testing performed**
Build and execute "sem-speed-test" on the MPC750 VxWorks platform.

**Expected behavior changes**
Test now runs and passes reliably with no odd/inconsistent behaviors

**System(s) tested on:**
MPC750 VxWorks 6.9

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

