### PR TITLE
Fix #273: Correct format code in debug message

### DIFF
--- a/src/os/rtems/osfilesys.c
+++ b/src/os/rtems/osfilesys.c
@@ -174,7 +174,7 @@ int32 OS_FileSysStartVolume_Impl (uint32 filesys_id)
         impl->mount_fstype = RTEMS_FILESYSTEM_TYPE_RFS;
 
         OS_DEBUG("OSAL: RAM disk initialized: volume=%s device=%s address=0x%08lX\n",
-                local->volume_name, impl->blockdev_name, local->address);
+                local->volume_name, impl->blockdev_name, (unsigned long)local->address);
 
         return_code = OS_SUCCESS;
         break;


### PR DESCRIPTION
**Describe the contribution**
Fixes issue #273
Just adds a typecast to avoid the warning

**Testing performed**
Build code on i686-rtems4.11 platform, with -Wall -Werror and OS_DEBUG_PRINTF option enabled.

**Expected behavior changes**
Observe no more warning about the format mismatch.

**System(s) tested on:**
Ubuntu 18.04.2 LTS 64 bit (build host) using i686-rtems4.11 cross toolchain

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

