### PR TITLE
Fix #274: Avoid possible deadlock of timer callback

### DIFF
--- a/src/os/shared/osapi-timebase.c
+++ b/src/os/shared/osapi-timebase.c
@@ -494,7 +494,7 @@ void OS_TimeBase_CallbackThread(uint32 timebase_id)
                 timecb = &OS_timecb_table[curr_cb_local_id];
                 saved_wait_time = timecb->wait_time;
                 timecb->wait_time -= tick_time;
-                if (timecb->wait_time <= 0)
+                while (timecb->wait_time <= 0)
                 {
                     timecb->wait_time += timecb->interval_time;
 
@@ -518,6 +518,14 @@ void OS_TimeBase_CallbackThread(uint32 timebase_id)
                     if (saved_wait_time > 0 && timecb->callback_ptr != NULL)
                     {
                         (*timecb->callback_ptr)(curr_cb_public_id, timecb->callback_arg);
+                    }
+
+                    /*
+                     * Do not repeat the loop unless interval_time is configured.
+                     */
+                    if (timecb->interval_time <= 0)
+                    {
+                        break;
                     }
                 }
                 curr_cb_local_id = timecb->next_ref;


### PR DESCRIPTION
**Describe the contribution**
Fix issue #274, avoids timer callback deadlock if actual tick_time is consistently bigger than the configured iinterval_time.

**Testing performed**
Modify `timer-test` to choose an interval that is not a multiple of the system clock tick, such that it will be rounded up to the next tick by the implementation.

Verify that evenually, two callbacks are generated in a single time tick, such that the long-term average of callbacks over time is consistent with the configured interval_time.

Confirm that callbacks continue normally until the application is stopped, as expected.

**Expected behavior changes**
Callbacks no longer cease once the "overrun" condition occurs (callbacks behind by >=1 full interval time)

Confirm consistent behavior on POSIX, RTEMS, and VxWorks

**System(s) tested on:**
Ubuntu 18.04.2 LTS 64-bit (POSIX/simulation)
RTEMS 4.11 pc686 BSP running in QEMU
MPC750 VxWorks 6.9

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

