### PR TITLE
Fix #280, fix misc. doxygen warning

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -226,7 +226,9 @@ uint32 OS_IdentifyObject       (uint32 object_id);
  * @note This does NOT verify the validity of the ID, that is left to the caller.
  * This is only the conversion logic.
  *
- * @param[in] object_id The object ID to operate on
+ * @param[in]  object_id    The object ID to operate on
+ *
+ * @param[out] *ArrayIndex  The Index to return 
  *
  * @returns OS_SUCCESS on success, or appropriate error code
  */
@@ -310,7 +312,7 @@ int32 OS_TaskInstallDeleteHandler(osal_task_entry function_pointer);
 /**
  * @brief Delay a task for specified amount of milliseconds
  *
- * @param[in]   milliseconds    Amount of time to delay
+ * @param[in]   millisecond    Amount of time to delay
  *
  * @returns OS_SUCCESS on success, or appropriate error code
  * OS_ERROR if sleep fails or millisecond = 0
@@ -322,7 +324,9 @@ int32 OS_TaskDelay             (uint32 millisecond);
 /**
  * @brief Sets the given task to a new priority
  *
- * @param[in] task_id The object ID to operate on
+ * @param[in] task_id        The object ID to operate on
+ *
+ * @param[in] new_priority   Set the new priority
  *
  * @returns OS_SUCCESS on success, or appropriate error code
  * OS_ERR_INVALID_ID if the ID passed to it is invalid

--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -230,8 +230,12 @@ int32           OS_creat  (const char *path, int32  access);
  * Opens a file. access parameters are OS_READ_ONLY, OS_WRITE_ONLY, or
  * OS_READ_WRITE
  *
- * @param[in] path File name to create
+ * @param[in] path   File name to create
  * @param[in] access Intended access mode - OS_READ_ONLY, OS_WRITE_ONLY or OS_READ_WRITE
+ * @param[in] mode   The file permissions. This parameter is passed through to the 
+ *		     native open call, but will be ignored. The file mode (or permissions)
+ *                   are ignored by the POSIX open call when the O_CREAT access flag is not passed in. 
+ *
  *
  * @note Valid handle IDs are never negative.  Failure of this
  * call can be checked by testing if the result is less than 0.


### PR DESCRIPTION
**Describe the contribution**
Fix #280, fix misc. doxygen warning

**Testing performed**
Steps taken to test the contribution:
1. make users guide
2. verify warning is gone

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04
 - doxygen 1.8.13, rc-6.7.0


**Contributor Info**
Anh Van, NASA Goddard


