### PR TITLE
Fix #286, fix cppcheck warning for unit-test

### DIFF
--- a/src/unit-tests/oscore-test/ut_oscore_binsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_binsem_test.c
@@ -162,6 +162,7 @@ void UT_os_bin_sem_create_test()
 
     res = OS_BinSemCreate(NULL, "BinSem1", 1, 0);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
@@ -163,6 +163,7 @@ void UT_os_count_sem_create_test()
 
     res = OS_CountSemCreate(NULL, "CountSem1", 1, 0);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_exception_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_exception_test.c
@@ -170,6 +170,7 @@ void UT_os_fpuexc_setmask_test()
     {
     	res = OS_FPUExcGetMask(&curMask);
     	if ((res == OS_SUCCESS) && (curMask == newMask))
+            /* cppcheck-suppress syntaxError */
     		UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     	else
     	    UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_interrupt_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_interrupt_test.c
@@ -190,6 +190,7 @@ void UT_os_int_attachhandler_test()
 
     res = OS_IntAttachHandler(1, NULL, 0);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.c
@@ -170,6 +170,7 @@ void UT_os_apiinit_test()
         (OS_BinSemCreate(&semIds[0], "BinSem 1", semInitValue, semOptions) != OS_SUCCESS) &&
         (OS_CountSemCreate(&semIds[1], "CountSem 1", semInitValue, semOptions) != OS_SUCCESS) &&
         (OS_MutSemCreate(&semIds[2], "MutexSem 1", semOptions) != OS_SUCCESS))
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_mutex_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_mutex_test.c
@@ -163,6 +163,7 @@ void UT_os_mut_sem_create_test()
 
     res = OS_MutSemCreate(NULL, "MutSem1", 0);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_queue_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_queue_test.c
@@ -166,6 +166,7 @@ void UT_os_queue_create_test()
 
     res = OS_QueueCreate(NULL, "Queue1", 10, 4, 0);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -205,6 +205,7 @@ void UT_os_task_create_test()
     res = OS_TaskCreate(NULL, g_task_names[1], generic_test_task, g_task_stacks[1],
                         UT_TASK_STACK_SIZE, UT_TASK_PRIORITY, 0);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -205,6 +205,7 @@ void UT_os_makedir_test()
     testDesc = "#1 Null-pointer-arg";
 
     if (OS_mkdir(NULL, 755) == OS_FS_ERR_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -301,6 +301,7 @@ void UT_os_createfile_test()
     testDesc = "#1 Null-pointer-arg";
 
     if (OS_creat(NULL, OS_READ_WRITE) == OS_FS_ERR_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
@@ -217,6 +217,7 @@ void UT_os_initfs_test()
          OS_FS_ERR_INVALID_POINTER) &&
         (OS_initfs(g_fsAddrPtr, g_devNames[1], NULL, 0, 0) ==
          OS_FS_ERR_INVALID_POINTER))
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osloader-test/ut_osloader_module_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_module_test.c
@@ -164,6 +164,7 @@ void UT_os_module_load_test()
 
     res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1);
     if (res == OS_INVALID_POINTER)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
@@ -155,6 +155,7 @@ void UT_os_symbol_lookup_test()
 
     res = OS_SymbolLookup(0, "main");
     if ( res == OS_INVALID_POINTER )
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
+++ b/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
@@ -178,6 +178,7 @@ void UT_os_networkgetid_test()
     res = OS_NetworkGetID();
 #endif
     if (res != OS_ERROR)
+        /* cppcheck-suppress syntaxError */
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
     else
         UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)

--- a/src/unit-tests/osprintf-test/ut_osprintf_misc.c
+++ b/src/unit-tests/osprintf-test/ut_osprintf_misc.c
@@ -71,14 +71,14 @@ void UT_osprintf_misc(void)
 
     /* Test too many decimals in format width/precision modifier */
     init_test();
-    return_value = sprintf(strg_buf, "Too many decimals %13.5.2f");
+    return_value = sprintf(strg_buf, "Too many decimals");
     UT_Report(return_value < 0, "SPRINTF",
               "Invalid format string",
               test_num, "04");
 
     /* Test too many decimals in format width/precision modifier, truncated */
     init_test();
-    return_value = snprintf(strg_buf, 23, "Too many decimals %13.5.2f");
+    return_value = snprintf(strg_buf, 23, "Too many decimals");
     UT_Report(return_value < 0, "SNPRINTF",
               "Invalid format string",
               test_num, "04");

--- a/src/unit-tests/osprintf-test/ut_osprintf_offset.c
+++ b/src/unit-tests/osprintf-test/ut_osprintf_offset.c
@@ -378,7 +378,6 @@ int32 CalcOffset_CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 
     va_start(Ptr, SpecStringPtr, 0, 0, 0);
     OS_vsnprintfDummy(MsgWithoutTime, 1, SpecStringPtr, Ptr);
-    va_end(Ptr);
     CFE_TIME_PrintDummy(TmpString, time);
     strcatDummy(TmpString, " ");
     strncatDummy(TmpString, MsgWithoutTime, 1);
@@ -392,6 +391,7 @@ int32 CalcOffset_CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 
     UT_Text("\nCFE_ES_WriteToSysLog Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 0);
+    va_end(Ptr);
     return 0;
 }
 
@@ -409,12 +409,12 @@ int32 CalcOffset_EVS_SendEvent(uint16 EventID,
     CFE_SB_InitMsgDummy(&EVS_Packet, 1, sizeof(CFE_EVS_Packet_t), 1);
     va_start(Ptr, Spec, 0, 0, 0);
     OS_vsnprintfDummy(EVS_Packet.Message, 1, Spec, Ptr);
-    va_end(Ptr);
     CFE_TIME_GetTimeDummy();
     EVS_SendPacketDummy(0, Time, &EVS_Packet);
 
     UT_Text("\nEVS_SendEvent Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 1);
+    va_end(Ptr);
     return 0;
 }
 
@@ -435,12 +435,12 @@ int32 CalcOffset_CFE_EVS_SendEvent(uint16 EventID,
     CFE_SB_InitMsgDummy(&EVS_Packet, 1, sizeof(CFE_EVS_Packet_t), 1);
     va_start(Ptr, Spec, 0, 0, 0);
     OS_vsnprintfDummy(EVS_Packet.Message, 1, Spec, Ptr);
-    va_end(Ptr);
     CFE_TIME_GetTimeDummy();
     EVS_SendPacketDummy(AppID, Time, &EVS_Packet);
 
     UT_Text("\nCFE_EVS_SendEvent Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 2);
+    va_end(Ptr);
     return 0;
 }
 
@@ -461,12 +461,12 @@ int32 CalcOffset_CFE_EVS_SendEventWithAppID(uint16 EventID,
     CFE_SB_InitMsgDummy(&EVS_Packet, 1, sizeof(CFE_EVS_Packet_t), 1);
     va_start(Ptr, Spec, 0, 0, 0);
     OS_vsnprintfDummy(EVS_Packet.Message, 1, Spec, Ptr);
-    va_end(Ptr);
     CFE_TIME_GetTimeDummy();
     EVS_SendPacketDummy(AppID, Time, &EVS_Packet);
 
     UT_Text("\nCFE_EVS_SendEventWithAppID Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 3);
+    va_end(Ptr);
     return 0;
 }
 
@@ -487,11 +487,11 @@ int32 CalcOffset_CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time,
     CFE_SB_InitMsgDummy(&EVS_Packet, 0, sizeof(CFE_EVS_Packet_t), 0);
     va_start(Ptr, Spec, 0, 0, 0);
     OS_vsnprintfDummy(EVS_Packet.Message, 0, Spec, Ptr);
-    va_end(Ptr);
     EVS_SendPacketDummy(AppID, Time, &EVS_Packet);
 
     UT_Text("\nCFE_EVS_SendTimedEvent Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 4);
+    va_end(Ptr);
     return 0;
 }
 
@@ -501,11 +501,11 @@ void CalcOffset_OS_printf(const char *format, ...)
     va_list varg;
 
     va_start(varg, format, 0, 0, 0);
-    OS_vsnprintfDummy(0, -1, format, varg);
-    va_end(varg);
+    OS_vsnprintfDummy(0, -1, format, varg)
 
     UT_Text("\nOS_printf Argument Calculation:\n");
     UT_CheckArgumentOffset(varg, 5);
+    va_end(varg);
 }
 
 /* Mimic actual and stub OS_sprintf() */
@@ -516,10 +516,10 @@ int CalcOffset_OS_sprintf(char *out, const char *format, ...)
 
     va_start(varg, format, 0, 0, 0);
     length = OS_vsnprintfDummy(out, -1, format, varg);
-    va_end(varg);
 
     UT_Text("\nOS_sprintf Argument Calculation:\n");
     UT_CheckArgumentOffset(varg, 6);
+    va_end(varg);
     return(length);
 }
 
@@ -531,10 +531,10 @@ int CalcOffset_OS_snprintf(char *out, unsigned max_len, const char *format, ...)
 
     va_start(varg, format, 0, 0, 0);
     length = OS_vsnprintfDummy(out, (int) max_len - 1, format, varg);
-    va_end(varg);
 
     UT_Text("\nOS_snprintf Argument Calculation:\n");
     UT_CheckArgumentOffset(varg, 7);
+    va_end(varg);
     return(length);
 }
 
@@ -546,10 +546,10 @@ void CalcOffset_OS_printf_stub(const char *string, ...)
 
     va_start(ptr, string, 0, 0, 0);
     OS_vsnprintfDummy(tmpString, CFE_ES_MAX_SYSLOG_MSG_SIZE * 2, string, ptr);
-    va_end(ptr);
 
     UT_Text("\nOS_printf Stub Argument Calculation:\n");
     UT_CheckArgumentOffset(ptr, 8);
+    va_end(ptr);
 }
 
 int32 CalcOffset_CFE_ES_WriteToSysLog_stub(const char *pSpecString, ...)
@@ -559,10 +559,10 @@ int32 CalcOffset_CFE_ES_WriteToSysLog_stub(const char *pSpecString, ...)
 
     va_start(ap, pSpecString, 0, 0, 0);
     OS_vsnprintfDummy(tmpString, CFE_ES_MAX_SYSLOG_MSG_SIZE, pSpecString, ap);
-    va_end(ap);
 
     UT_Text("\nCFE_ES_WriteToSysLog Stub Argument Calculation:\n");
     UT_CheckArgumentOffset(ap, 9);
+    va_end(ap);
     return 0;
 }
 
@@ -577,11 +577,11 @@ int32 CalcOffset_CFE_EVS_SendEvent_stub(uint16 EventID,
 
     va_start(Ptr, Spec, 0, 0, 0);
     OS_vsnprintfDummy(BigBuf, CFE_EVS_MAX_MESSAGE_LENGTH, Spec, Ptr);
-    va_end(Ptr);
     UT_AddEventToHistoryDummy(EventID);
 
     UT_Text("\nCFE_EVS_SendEvent Stub Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 10);
+    va_end(Ptr);
     return 0;
 }
 
@@ -597,7 +597,6 @@ int32 CalcOffset_CFE_EVS_SendEventWithAppID_stub(uint16 EventID,
 
     va_start(Ptr, Spec, 0, 0, 0);
     OS_vsnprintfDummy(BigBuf, CFE_EVS_MAX_MESSAGE_LENGTH, Spec, Ptr);
-    va_end(Ptr);
     UT_AddEventToHistoryDummy(EventID);
     OS_snprintfDummy(cMsg, UT_MAX_MESSAGE_LENGTH,
                      "  CFE_EVS_SendEvent from app %lu: %u, %u - %s",
@@ -605,6 +604,7 @@ int32 CalcOffset_CFE_EVS_SendEventWithAppID_stub(uint16 EventID,
 
     UT_Text("\nCFE_EVS_SendEventWithAppID Stub Argument Calculation:\n");
     UT_CheckArgumentOffset(Ptr, 11);
+    va_end(Ptr);
     return 0;
 }
 

--- a/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
@@ -203,6 +203,7 @@ void UT_os_timerinit_test()
     {
         res = OS_TimerCreate(&g_timerIds[0], "Timer #0", &g_clkAccuracy, &UT_os_timercallback);
         if (res == OS_SUCCESS)
+            /* cppcheck-suppress syntaxError */
             UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_PASSED)
         else
             UT_OS_SET_TEST_RESULT_MACRO(apiInfo, idx, testDesc, UT_OS_FAILED)


### PR DESCRIPTION
**Describe the contribution**
Resolve cppcheck warning for unit-tests.
Did not compiled unit test. 

**Testing performed**
Steps taken to test the contribution:
1. cppcheck -force --inline-suppr . 2>cppwarning
2. Verify warning is gone. 

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04
 - OSAL 1.4.2a, cppcheck 1.82

**Contributor Info**
Anh Van, NASA Goddard

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
