### PR TITLE
Fix #287: cppcheck warnings

### DIFF
--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -38,7 +38,7 @@
  * Added SEM_VALUE_MAX Define
  */
 #ifndef SEM_VALUE_MAX
-#define SEM_VALUE_MAX       (1 << 31)
+#define SEM_VALUE_MAX       (UINT32_MAX/2)
 #endif
 
 /*

--- a/src/os/shared/osapi-time.c
+++ b/src/os/shared/osapi-time.c
@@ -313,7 +313,7 @@ int32 OS_TimerSet(uint32 timer_id, uint32 start_time, uint32 interval_time)
 
    dedicated_timebase_id = 0;
 
-   if (start_time >= INT_MAX || interval_time >= INT_MAX)
+   if (start_time >= (UINT32_MAX/2) || interval_time >= (UINT32_MAX/2))
    {
        return OS_TIMER_ERR_INVALID_ARGS;
    }

--- a/src/unit-test-coverage/shared/src/coveragetest-time.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-time.c
@@ -172,7 +172,7 @@ void Test_OS_TimerSet(void)
     memset(OS_timecb_table, 0, sizeof(OS_timecb_table));
 
     expected = OS_TIMER_ERR_INVALID_ARGS;
-    actual = OS_TimerSet(2, 1 << 31, 1 << 31);
+    actual = OS_TimerSet(2, UINT32_MAX, UINT32_MAX);
     UtAssert_True(actual == expected, "OS_TimerSet() (%ld) == OS_TIMER_ERR_INVALID_ARGS", (long)actual);
 
     UT_SetForceFail(UT_KEY(OS_TaskGetId_Impl), 1 | (OS_OBJECT_TYPE_OS_TIMEBASE << OS_OBJECT_TYPE_SHIFT));

--- a/src/unit-test-coverage/shared/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-timebase.c
@@ -108,7 +108,7 @@ void Test_OS_TimeBaseSet(void)
 
     /* test error paths: overflow on input */
     expected = OS_TIMER_ERR_INVALID_ARGS;
-    actual = OS_TimeBaseSet(1, 1 << 31, 1 << 31);
+    actual = OS_TimeBaseSet(1, UINT32_MAX, UINT32_MAX);
     UtAssert_True(actual == expected, "OS_TimeBaseSet() (%ld) == OS_TIMER_ERR_INVALID_ARGS", (long)actual);
 
     /* test error paths */

--- a/src/unit-test-coverage/ut-stubs/src/libc-stdio-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/libc-stdio-stubs.c
@@ -124,7 +124,7 @@ int OCS_rename (const char * old, const char * nw)
 int OCS_snprintf (char * s, size_t maxlen, const char * format, ...)
 {
     int32 Status;
-    int actual;
+    int actual = 0;
     va_list ap;
 
     Status = UT_DEFAULT_IMPL(OCS_snprintf);
@@ -148,7 +148,7 @@ int OCS_snprintf (char * s, size_t maxlen, const char * format, ...)
 int OCS_vsnprintf (char * s, size_t maxlen, const char * format, OCS_va_list arg)
 {
     int32 Status;
-    int actual;
+    int actual = 0;
 
     Status = UT_DEFAULT_IMPL(OCS_vsnprintf);
 


### PR DESCRIPTION
**Describe the contribution**
Replace use of `1<<31` and `INT_MAX` with `UINT32_MAX/2` which should
squelch the cppcheck warnings about the left shift as well as being
more correct (the values in question are uint32's, not int's).

Also address two false positives about a return value being unassigned,
by simply initializing the value to be 0.

Fixes issue #287

**Testing performed**
Build coverage test and ensure all tests passing and line coverage is unaffected
Build and run CFE and confirm no effect.

Ran cppcheck and confirmed that warnings are gone.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on:**
Ubuntu 18.04 LTS, 64 bit.

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
