### PR TITLE
Add alignment wrapper to OS_SockAddr_t

### DIFF
--- a/src/os/inc/osapi-os-net.h
+++ b/src/os/inc/osapi-os-net.h
@@ -65,6 +65,20 @@ typedef enum
    OS_SocketType_MAX
 } OS_SocketType_t;
 
+/**
+ * Storage buffer for generic network address
+ *
+ * This is a union type that helps to ensure a minimum
+ * alignment value for the data storage, such that it can
+ * be cast to the system-specific type without
+ * increasing alignment requirements.
+ */
+typedef union
+{
+    uint8  Buffer[OS_SOCKADDR_MAX_LEN]; /**< Ensures length of at least OS_SOCKADDR_MAX_LEN */
+    uint32 AlignU32;                    /**< Ensures uint32 alignment */
+    void*  AlignPtr;                    /**< Ensures pointer alignment */
+} OS_SockAddrData_t;
 
 /**
  * Encapsulates a generic network address
@@ -76,7 +90,7 @@ typedef enum
 typedef struct
 {
    uint32 ActualLength;                 /**< Length of the actual address data */
-   char AddrData[OS_SOCKADDR_MAX_LEN];  /**< Abstract Address data */
+   OS_SockAddrData_t AddrData;          /**< Abstract Address data */
 } OS_SockAddr_t;
 
 /**

--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -197,7 +197,7 @@ int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr)
    socklen_t addrlen;
    const struct sockaddr *sa;
 
-   sa = (const struct sockaddr *)Addr->AddrData;
+   sa = (const struct sockaddr *)&Addr->AddrData;
 
    switch(sa->sa_family)
    {
@@ -257,7 +257,7 @@ int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 tim
    uint32 operation;
    const struct sockaddr *sa;
 
-   sa = (const struct sockaddr *)Addr->AddrData;
+   sa = (const struct sockaddr *)&Addr->AddrData;
    switch(sa->sa_family)
    {
    case AF_INET:
@@ -352,7 +352,7 @@ int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Ad
       else
       {
          addrlen = Addr->ActualLength;
-         OS_impl_filehandle_table[connsock_id].fd = accept(OS_impl_filehandle_table[sock_id].fd, (struct sockaddr *)Addr->AddrData, &addrlen);
+         OS_impl_filehandle_table[connsock_id].fd = accept(OS_impl_filehandle_table[sock_id].fd, (struct sockaddr *)&Addr->AddrData, &addrlen);
          if (OS_impl_filehandle_table[connsock_id].fd < 0)
          {
             return_code = OS_ERROR;
@@ -405,7 +405,7 @@ int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_Soc
    else
    {
       addrlen = OS_SOCKADDR_MAX_LEN;
-      sa = (struct sockaddr *)RemoteAddr->AddrData;
+      sa = (struct sockaddr *)&RemoteAddr->AddrData;
    }
 
    operation = OS_STREAM_STATE_READABLE;
@@ -484,7 +484,7 @@ int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, uint32 buflen, co
    socklen_t addrlen;
    const struct sockaddr *sa;
 
-   sa = (const struct sockaddr *)RemoteAddr->AddrData;
+   sa = (const struct sockaddr *)&RemoteAddr->AddrData;
    switch(sa->sa_family)
    {
    case AF_INET:
@@ -546,7 +546,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
    OS_SockAddr_Accessor_t *Accessor;
 
    memset(Addr, 0, sizeof(OS_SockAddr_t));
-   Accessor = (OS_SockAddr_Accessor_t *)Addr->AddrData;
+   Accessor = (OS_SockAddr_Accessor_t *)&Addr->AddrData;
 
    switch(Domain)
    {
@@ -590,7 +590,7 @@ int32 OS_SocketAddrToString_Impl(char *buffer, uint32 buflen, const OS_SockAddr_
    const void *addrbuffer;
    const OS_SockAddr_Accessor_t *Accessor;
 
-   Accessor = (const OS_SockAddr_Accessor_t *)Addr->AddrData;
+   Accessor = (const OS_SockAddr_Accessor_t *)&Addr->AddrData;
 
    switch(Accessor->sockaddr.sa_family)
    {
@@ -629,7 +629,7 @@ int32 OS_SocketAddrFromString_Impl(OS_SockAddr_t *Addr, const char *string)
    void *addrbuffer;
    OS_SockAddr_Accessor_t *Accessor;
 
-   Accessor = (OS_SockAddr_Accessor_t *)Addr->AddrData;
+   Accessor = (OS_SockAddr_Accessor_t *)&Addr->AddrData;
 
    switch(Accessor->sockaddr.sa_family)
    {
@@ -668,7 +668,7 @@ int32 OS_SocketAddrGetPort_Impl(uint16 *PortNum, const OS_SockAddr_t *Addr)
    in_port_t sa_port;
    const OS_SockAddr_Accessor_t *Accessor;
 
-   Accessor = (const OS_SockAddr_Accessor_t *)Addr->AddrData;
+   Accessor = (const OS_SockAddr_Accessor_t *)&Addr->AddrData;
 
    switch(Accessor->sockaddr.sa_family)
    {
@@ -705,7 +705,7 @@ int32 OS_SocketAddrSetPort_Impl(OS_SockAddr_t *Addr, uint16 PortNum)
    OS_SockAddr_Accessor_t *Accessor;
 
    sa_port = htons(PortNum);
-   Accessor = (OS_SockAddr_Accessor_t *)Addr->AddrData;
+   Accessor = (OS_SockAddr_Accessor_t *)&Addr->AddrData;
 
    switch(Accessor->sockaddr.sa_family)
    {


### PR DESCRIPTION
**Describe the contribution**

Fix #295 

Add a union wrapper for the abstract data field such that it will be aligned for 32 bit integer values and/or pointers, whichever is greater.

This removes cast alignment warnings in this code with compiling on CPU architectures with strict alignment requirements.


**Testing performed**
Build code with full warnings (including -Wcast-align) on both native (x86-64) and MIPS32

Execute CFE on native (x86-64) (with CI_LAB/TO_LAB that use OSAL-provided socket abstraction), confirm no changes in behavior.

**Expected behavior changes**
No compiler warning.  No changes to runtime behavior.

**System(s) tested on:**
Linux MIPS 32 bit (build)
Ubuntu 18.04 LTS, 64 bit (build + run)

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
