### PR TITLE
Fix minor warnings in OSAL code

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -972,7 +972,7 @@ int32 OS_ExcDisable            (int32 ExceptionNumber);
  * @returns OS_SUCCESS on success, or appropriate error code
  * OS_ERR_NOT_IMPLEMENTED on platforms that do not support this function
  */
-int32 OS_FPUExcAttachHandler   (uint32 ExceptionNumber, void * ExceptionHandler ,
+int32 OS_FPUExcAttachHandler   (uint32 ExceptionNumber, osal_task_entry ExceptionHandler,
                                  int32 parameter);
 
 /*-------------------------------------------------------------------------------------*/

--- a/src/os/portable/os-impl-posix-dl.c
+++ b/src/os/portable/os-impl-posix-dl.c
@@ -150,7 +150,7 @@ int32 OS_SymbolLookup_Impl( cpuaddr *SymbolAddress, const char *SymbolName )
  *           See description in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl ( uint32 module_id, char *translated_path )
+int32 OS_ModuleLoad_Impl ( uint32 module_id, const char *translated_path )
 {
     int32 status = OS_ERROR;
 

--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -2327,7 +2327,7 @@ static int OS_PriorityRemap(uint32 InputPri)
  *           See prototype in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, void * ExceptionHandler,
+int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, osal_task_entry ExceptionHandler,
                                  int32 parameter)
 {
     /*

--- a/src/os/rtems/osapi.c
+++ b/src/os/rtems/osapi.c
@@ -1590,7 +1590,7 @@ int32 OS_IntGetMask_Impl ( uint32 * MaskSettingPtr )
  *           See prototype in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, void * ExceptionHandler,
+int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, osal_task_entry ExceptionHandler,
                                  int32 parameter)
 {
     /*

--- a/src/os/rtems/osloader.c
+++ b/src/os/rtems/osloader.c
@@ -205,7 +205,7 @@ static bool OS_rtems_rtl_check_unresolved (rtems_rtl_unresolv_rec_t* rec,
  *           See prototype in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl ( uint32 module_id, char *translated_path )
+int32 OS_ModuleLoad_Impl ( uint32 module_id, const char *translated_path )
 {
     int32 status = OS_ERROR;
     int unresolved;

--- a/src/os/shared/os-impl.h
+++ b/src/os/shared/os-impl.h
@@ -1227,7 +1227,7 @@ int32 OS_SetLocalTime_Impl(const OS_time_t *time_struct);
   
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl ( uint32 module_id, char *translated_path );
+int32 OS_ModuleLoad_Impl ( uint32 module_id, const char *translated_path );
 
 /*----------------------------------------------------------------
   
@@ -1874,7 +1874,7 @@ int32 OS_IntGetMask_Impl ( uint32 * MaskSettingPtr );
  * FPU API low-level handlers
  * These may also not be implementable on some platforms
  */
-int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, void * ExceptionHandler,
+int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, osal_task_entry ExceptionHandler,
                                  int32 parameter);
 int32 OS_FPUExcEnable_Impl(int32 ExceptionNumber);
 int32 OS_FPUExcDisable_Impl(int32 ExceptionNumber);

--- a/src/os/shared/osapi-fpu.c
+++ b/src/os/shared/osapi-fpu.c
@@ -40,7 +40,7 @@
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FPUExcAttachHandler   (uint32 ExceptionNumber, void * ExceptionHandler ,
+int32 OS_FPUExcAttachHandler   (uint32 ExceptionNumber, osal_task_entry ExceptionHandler ,
                                  int32 parameter)
 {
     if (ExceptionHandler == NULL)

--- a/src/os/vxworks/osapi.c
+++ b/src/os/vxworks/osapi.c
@@ -155,7 +155,7 @@ VX_MUTEX_SEMAPHORE(OS_console_mut_mem);
 
 typedef struct
 {
-    char * const mem;
+    void * const mem;
     SEM_ID vxid;
 } VxWorks_GlobalMutex_t;
 
@@ -1538,7 +1538,7 @@ int32 OS_IntGetMask_Impl ( uint32 * MaskSettingPtr )
  *           See prototype in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, void * ExceptionHandler,
+int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, osal_task_entry ExceptionHandler,
                                  int32 parameter)
 {
     /*

--- a/src/os/vxworks/osloader.c
+++ b/src/os/vxworks/osloader.c
@@ -297,7 +297,7 @@ int32 OS_SymbolTableDump_Impl ( const char *local_filename, uint32 SizeLimit )
  *           See prototype in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl ( uint32 local_id, char *translated_path )
+int32 OS_ModuleLoad_Impl ( uint32 local_id, const char *translated_path )
 {
    int32       return_code;
    int         fd;

--- a/src/os/vxworks/ostimer.c
+++ b/src/os/vxworks/ostimer.c
@@ -469,7 +469,7 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
                 OSAL_TIMEBASE_TASK_PRIORITY,    /* priority */
                 OSAL_TIMEBASE_TASK_OPTION_WORD, /* task option word */
                 OSAL_TIMEBASE_TASK_STACK_SIZE,  /* size (bytes) of stack needed */
-                OS_VxWorks_TimeBaseTask,
+                (FUNCPTR)OS_VxWorks_TimeBaseTask,
                 global->active_id, /* 1st arg is ID */
                 0,0,0,0,0,0,0,0,0);
 

--- a/src/unit-test-coverage/shared/src/coveragetest-dir.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-dir.c
@@ -161,7 +161,7 @@ void Test_OS_readdir(void)
     os_dirp_t dirp = OS_opendir("Dir");
     os_dirent_t *dirent = OS_readdir(dirp);
 
-    UtAssert_True(dirent != NULL, "OS_readdir() (%p) != NULL", dirent);
+    UtAssert_True(dirent != NULL, "OS_readdir() (%p) != NULL", (void*)dirent);
 }
 
 

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -70,13 +70,15 @@ void Test_OS_mkfs(void)
     int32 expected = OS_SUCCESS;
     int32 actual = ~OS_SUCCESS;
 
-    actual = OS_mkfs("adr","/ramdev0","vol",0,0);
+    char TestBuffer[128];
+
+    actual = OS_mkfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_SUCCESS", (long)actual);
 
     /*
      * Test an entry NOT found in the OS_VolumeTable
      */
-    actual = OS_mkfs("adr","/rd1","vol1",0,0);
+    actual = OS_mkfs(TestBuffer,"/rd1","vol1",0,0);
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_SUCCESS", (long)actual);
 
 
@@ -86,25 +88,25 @@ void Test_OS_mkfs(void)
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
-    actual = OS_mkfs("adr","/ramdev0","vol",0,0);
+    actual = OS_mkfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strlen));
 
     /* set up for failure due to empty strings */
     expected = OS_FS_ERR_PATH_INVALID;
-    actual = OS_mkfs("adr","","",0,0);
+    actual = OS_mkfs(TestBuffer,"","",0,0);
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
 
     /* set up for failure due to formatting */
     UT_SetForceFail(UT_KEY(OS_FileSysFormatVolume_Impl), OS_FS_ERR_DRIVE_NOT_CREATED);
     expected = OS_FS_ERR_DRIVE_NOT_CREATED;
-    actual = OS_mkfs("adr","/ramdev0","vol",0,0);
+    actual = OS_mkfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_DRIVE_NOT_CREATED (format failure)", (long)actual);
 
     /* set up for failure due to no free slots */
     UT_SetForceFail(UT_KEY(OS_ObjectIdAllocateNew), OS_ERR_NO_FREE_IDS);
     expected = OS_FS_ERR_DEVICE_NOT_FREE;
-    actual = OS_mkfs("adr","/ramdev0","vol",0,0);
+    actual = OS_mkfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_DEVICE_NOT_FREE", (long)actual);
 }
 
@@ -148,7 +150,9 @@ void Test_OS_initfs(void)
     int32 expected = OS_SUCCESS;
     int32 actual = ~OS_SUCCESS;
 
-    actual = OS_initfs("adr","/ramdev0","vol",0,0);
+    char TestBuffer[128];
+
+    actual = OS_initfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_SUCCESS", (long)actual);
 
     actual = OS_initfs(NULL,"/hda2","vol2",0,0);
@@ -160,14 +164,14 @@ void Test_OS_initfs(void)
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
-    actual = OS_initfs("adr","/ramdev0","vol",0,0);
+    actual = OS_initfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strlen));
 
     /* set up for failure */
     UT_SetForceFail(UT_KEY(OS_ObjectIdAllocateNew), OS_ERR_NO_FREE_IDS);
     expected = OS_FS_ERR_DEVICE_NOT_FREE;
-    actual = OS_initfs("adr","/ramdev0","vol",0,0);
+    actual = OS_initfs(TestBuffer,"/ramdev0","vol",0,0);
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_FS_ERR_DEVICE_NOT_FREE", (long)actual);
 }
 

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -368,7 +368,7 @@ void Test_OS_ObjectIdGetById(void)
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_ObjectIdGetById() (%ld) == OS_SUCCESS", (long)actual);
     UtAssert_True(local_idx == 1, "local_idx (%lu) == 1", (unsigned long)local_idx);
-    UtAssert_True(rptr != NULL, "rptr (%p) != NULL", rptr);
+    UtAssert_True(rptr != NULL, "rptr (%p) != NULL", (void*)rptr);
     UtAssert_True(rptr->refcount == 1, "refcount (%u) == 1",
             (unsigned int)rptr->refcount);
 
@@ -517,7 +517,7 @@ void Test_OS_ObjectIdFindNext(void)
         }
         if (rec1 == rec2)
         {
-            UtAssert_Failed("OS_ObjectIdFindNext() duplicate slot (%p)", rec1);
+            UtAssert_Failed("OS_ObjectIdFindNext() duplicate slot (%p)", (void*)rec1);
             break;
         }
 
@@ -556,7 +556,7 @@ void Test_OS_ObjectIdAllocateNew(void)
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_SUCCESS", (long)actual);
-    UtAssert_True(rptr != NULL, "rptr (%p) != NULL", rptr);
+    UtAssert_True(rptr != NULL, "rptr (%p) != NULL", (void*)rptr);
 
     /* Passing a NULL name also should work here (used for internal objects) */
     actual = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, NULL, &objid, &rptr);

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -280,8 +280,9 @@ void Test_OS_TaskInstallDeleteHandler(void)
     UT_SetForceFail(UT_KEY(OS_TaskGetId_Impl), 1);
     actual = OS_TaskInstallDeleteHandler(UT_TestHook);
     UtAssert_True(actual == expected, "OS_TaskInstallDeleteHandler() (%ld) == OS_SUCCESS", (long)actual);
-    UtAssert_True(OS_task_table[1].delete_hook_pointer == UT_TestHook, "OS_task_table[1].delete_hook_pointer (%p) == %p",
-            OS_task_table[1].delete_hook_pointer, UT_TestHook);
+    UtAssert_True(OS_task_table[1].delete_hook_pointer == UT_TestHook, "OS_task_table[1].delete_hook_pointer (%lx) == %lx",
+            (unsigned long)OS_task_table[1].delete_hook_pointer,
+            (unsigned long)UT_TestHook);
 
     OS_task_table[1].delete_hook_pointer = NULL;
 }

--- a/src/unit-test-coverage/shared/src/coveragetest-time.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-time.c
@@ -113,9 +113,9 @@ void Test_OS_TimerCreate(void)
     OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TIMECB, objid, &local_id);
 
     UtAssert_True(OS_timecb_table[local_id].callback_ptr != NULL,
-            "OS_timecb_table[%lu].callback_ptr (%p) != NULL",
+            "OS_timecb_table[%lu].callback_ptr (%lx) != NULL",
             (unsigned long)local_id,
-            OS_timecb_table[local_id].callback_ptr);
+            (unsigned long)OS_timecb_table[local_id].callback_ptr);
 
     UT_TimerCount = 0;
     OS_timecb_table[local_id].callback_ptr(objid, OS_timecb_table[local_id].callback_arg);

--- a/src/unit-test-coverage/ut-stubs/src/osapi-base-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-base-impl-stubs.c
@@ -163,7 +163,7 @@ UT_DEFAULT_STUB(OS_HeapGetInfo_Impl,(OS_heap_prop_t *heap_prop))
 /*
  * FPU API low-level handlers
  */
-UT_DEFAULT_STUB(OS_FPUExcAttachHandler_Impl,(uint32 ExceptionNumber, void * ExceptionHandler,int32 parameter))
+UT_DEFAULT_STUB(OS_FPUExcAttachHandler_Impl,(uint32 ExceptionNumber, osal_task_entry ExceptionHandler,int32 parameter))
 UT_DEFAULT_STUB(OS_FPUExcEnable_Impl,(int32 ExceptionNumber))
 UT_DEFAULT_STUB(OS_FPUExcDisable_Impl,(int32 ExceptionNumber))
 UT_DEFAULT_STUB(OS_FPUExcSetMask_Impl,(uint32 mask))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-loader-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-loader-impl-stubs.c
@@ -17,7 +17,7 @@
 /*
  * Module Loader API
  */
-UT_DEFAULT_STUB(OS_ModuleLoad_Impl,( uint32 module_id, char *translated_path ))
+UT_DEFAULT_STUB(OS_ModuleLoad_Impl,( uint32 module_id, const char *translated_path ))
 UT_DEFAULT_STUB(OS_ModuleUnload_Impl,( uint32 module_id ))
 UT_DEFAULT_STUB(OS_ModuleGetInfo_Impl,( uint32 module_id, OS_module_prop_t *module_prop ))
 UT_DEFAULT_STUB(OS_SymbolLookup_Impl,( cpuaddr *SymbolAddress, const char *SymbolName ))

--- a/src/unit-test-coverage/vxworks/modules/inc/ut-osloader.h
+++ b/src/unit-test-coverage/vxworks/modules/inc/ut-osloader.h
@@ -24,7 +24,7 @@ int32 OS_VxWorks_ModuleAPI_Impl_Init(void);
  * Invokes OS_SymTableIterator_Impl() with the given arguments.
  * This is normally a static function but exposed via a non-static wrapper for UT purposes.
  */
-int32 Osapi_Internal_CallIteratorFunc(char *name, void* val, uint32 TestSize, uint32 SizeLimit);
+int32 Osapi_Internal_CallIteratorFunc(const char *name, void* val, uint32 TestSize, uint32 SizeLimit);
 
 #endif /* _OSAL_UT_OSLOADER_H_ */
 

--- a/src/unit-test-coverage/vxworks/modules/src/ut-osloader.c
+++ b/src/unit-test-coverage/vxworks/modules/src/ut-osloader.c
@@ -19,10 +19,15 @@ OS_SharedGlobalVars_t OS_SharedGlobalVars =
  * A UT-specific wrapper function to invoke the Symbol Table Iterator.
  * This is normally static so it needs this wrapper to call it.
  */
-int32 Osapi_Internal_CallIteratorFunc(char *name, void* val, uint32 TestSize, uint32 SizeLimit)
+int32 Osapi_Internal_CallIteratorFunc(const char *name, void* val, uint32 TestSize, uint32 SizeLimit)
 {
     OS_impl_module_global.sym_dump.Sizelimit = SizeLimit;
     OS_impl_module_global.sym_dump.CurrSize = TestSize;
-    return OS_SymTableIterator_Impl(name,val,0,0,0);
+    /*
+     * note the internal function is takes a name declared as "char*" to be
+     * consistent with the VxWorks API, however the implementation does not
+     * modify this argument.
+     */
+    return OS_SymTableIterator_Impl((char*)name,val,0,0,0);
 }
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-osfilesys.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-osfilesys.c
@@ -62,8 +62,6 @@ void Test_OS_FileSysStartVolume_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStartVolume_Impl(1), OS_FS_ERR_DRIVE_NOT_CREATED);
 }
 
-
-;
 void Test_OS_FileSysStopVolume_Impl(void)
 {
     /* Test Case For:

--- a/src/ut-stubs/osapi-utstub-fpu.c
+++ b/src/ut-stubs/osapi-utstub-fpu.c
@@ -30,14 +30,12 @@
  * Stub function for OS_FPUExcAttachHandler()
  *
  *****************************************************************************/
-int32 OS_FPUExcAttachHandler   (uint32 ExceptionNumber, void * ExceptionHandler ,
+int32 OS_FPUExcAttachHandler   (uint32 ExceptionNumber, osal_task_entry ExceptionHandler ,
                                  int32 parameter)
 {
     int32 status;
 
-    UT_Stub_RegisterContext(UT_KEY(OS_FPUExcAttachHandler), ExceptionHandler);
-
-    status = UT_DEFAULT_IMPL(OS_FPUExcAttachHandler);
+    status = UT_DEFAULT_IMPL_ARGS(OS_FPUExcAttachHandler, ExceptionNumber, ExceptionHandler, parameter);
 
     return status;
 }


### PR DESCRIPTION
**Describe the contribution**

Fix #298

Fix warnings that are triggered by compiling the OSAL coverage unit test with strict settings.

- The `OS_FPUExcAttachHandler()` function needs to be prototyped as accepting a function pointer (not `void*`)
- Const-Correctness on `OS_ModuleLoad_Impl()`
- Use `void*` instead of `char*` for buffer pointer as the specific type is not known
- Cast the function passed into `taskSpawn()` on VxWorks

**Testing performed**
Build code on all three supported OS's (POSIX, RTEMS, VxWorks) with full warnings and ENABLE_UNIT_TESTS=TRUE
Execute all unit tests and confirm passage
Execute cFE and confirm normal operation

**Expected behavior changes**
None.

**System(s) tested on:**
 - Ubuntu 18.04 LTS, 64-bit (native)
 - VxWorks 6.9 / MCP750 (GSFC build machine)
 - RTEMS 4.11 / i686 (running within QEMU)

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
