### PR TITLE
issue #305, Resolve cppcheck warning ut_stubs

### DIFF
--- a/src/ut-stubs/osapi-utstub-file.c
+++ b/src/ut-stubs/osapi-utstub-file.c
@@ -105,7 +105,7 @@ static int32 UT_GenericWriteStub(const char *fname, UT_EntryKey_t fkey, const vo
  *****************************************************************************/
 int32 OS_creat(const char *path, int32 access)
 {
-    int32 status = OS_SUCCESS;
+    int32 status;
 
     status = UT_DEFAULT_IMPL(OS_creat);
 
@@ -144,7 +144,7 @@ int32 OS_open(const char *path, int32 access, uint32 mode)
  *****************************************************************************/
 int32 OS_close(uint32 filedes)
 {
-    int32 status = OS_FS_SUCCESS;
+    int32 status;
 
     status = UT_DEFAULT_IMPL(OS_close);
 

--- a/src/ut-stubs/osapi-utstub-mutex.c
+++ b/src/ut-stubs/osapi-utstub-mutex.c
@@ -124,7 +124,7 @@ int32 OS_MutSemDelete(uint32 sem_id)
 ******************************************************************************/
 int32 OS_MutSemGive(uint32 sem_id)
 {
-    int32 status = OS_SUCCESS;
+    int32 status;
 
     status = UT_DEFAULT_IMPL(OS_MutSemGive);
 
@@ -153,7 +153,7 @@ int32 OS_MutSemGive(uint32 sem_id)
 ******************************************************************************/
 int32 OS_MutSemTake(uint32 sem_id)
 {
-    int32 status = OS_SUCCESS;
+    int32 status;
 
     status = UT_DEFAULT_IMPL(OS_MutSemTake);
 

--- a/src/ut-stubs/osapi-utstub-queue.c
+++ b/src/ut-stubs/osapi-utstub-queue.c
@@ -58,7 +58,7 @@ int32 OS_QueueCreate(uint32 *queue_id,
                      uint32 data_size,
                      uint32 flags)
 {
-    int32   status = OS_SUCCESS;
+    int32   status;
 
     status = UT_DEFAULT_IMPL(OS_QueueCreate);
 
@@ -99,7 +99,7 @@ int32 OS_QueueCreate(uint32 *queue_id,
 ******************************************************************************/
 int32 OS_QueueDelete(uint32 queue_id)
 {
-    int32   status = OS_SUCCESS;
+    int32   status;
 
     status = UT_DEFAULT_IMPL(OS_QueueDelete);
 
@@ -142,7 +142,7 @@ int32 OS_QueueGet(uint32 queue_id,
                   uint32 *size_copied,
                   int32 timeout)
 {
-    int32   status = OS_SUCCESS;
+    int32   status;
 
     status = UT_DEFAULT_IMPL(OS_QueueGet);
 
@@ -183,7 +183,7 @@ int32 OS_QueueGet(uint32 queue_id,
 ******************************************************************************/
 int32 OS_QueuePut(uint32 queue_id, const void *data, uint32 size, uint32 flags)
 {
-    int32   status = OS_SUCCESS;
+    int32   status;
 
     status = UT_DEFAULT_IMPL(OS_QueuePut);
 

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -49,7 +49,7 @@ int32 OS_TaskCreate(uint32 *task_id, const char *task_name,
                     uint32 stack_size, uint32 priority,
                     uint32 flags)
 {
-    int32 status = OS_SUCCESS;
+    int32 status;
 
     UT_Stub_RegisterContext(UT_KEY(OS_TaskCreate), &function_pointer);
     UT_Stub_RegisterContext(UT_KEY(OS_TaskCreate), stack_pointer);
@@ -154,7 +154,7 @@ int32 OS_TaskDelay(uint32 millisecond)
  *****************************************************************************/
 int32 OS_TaskSetPriority (uint32 task_id, uint32 new_priority)
 {
-    int32 status = OS_SUCCESS;
+    int32 status;
 
     status = UT_DEFAULT_IMPL(OS_TaskSetPriority);
 
@@ -179,7 +179,7 @@ int32 OS_TaskSetPriority (uint32 task_id, uint32 new_priority)
 ******************************************************************************/
 int32 OS_TaskRegister(void)
 {
-    int32 status = OS_SUCCESS;
+    int32 status;
 
     status = UT_DEFAULT_IMPL(OS_TaskRegister);
 

--- a/src/ut-stubs/utstub-helpers.c
+++ b/src/ut-stubs/utstub-helpers.c
@@ -182,7 +182,6 @@ void UT_CheckForOpenSockets(void)
     UT_ObjTypeState_t *StatePtr;
     uint32 i;
     uint32 id;
-    uint32 InUse = 0;
 
     StatePtr = &UT_ObjState[UT_OBJTYPE_QUEUE];
     for (i=0; i <= StatePtr->LastIssueNumber; ++i)
@@ -191,10 +190,11 @@ void UT_CheckForOpenSockets(void)
         {
             id = i;
             UT_FIXUP_ID(id, UT_OBJTYPE_QUEUE);
+
             UtAssert_Failed("UT_Queue %d left open. ID=%x\n", (int)i, (unsigned int)id);
-            ++InUse;
         }
     }
+
 }
 
 


### PR DESCRIPTION
**Describe the contribution**
resolve cppcheck warning. 

**Testing performed**
Steps taken to test the contribution:
1. make ENABLE_UNIT_TESTS=TRUE SIMULATION=native prep
2. make
3. make install
4. make test
5. Verify passing unit-test
6. cppcheck --force --inline-suppr --std=c99 --language=c --error-exitcode=1 enable=warning,performance,portability,style --suppress=variableScope --inconclusive osal/src 2>osal.txt

**System(s) tested on:**
 - Hardware
 - OS: Ubuntu 18.04
 - osal 5.03

**Contributor Info**
Anh Van, NASA Goddard
