### PR TITLE
Exception/Interrupt API updates

### DIFF
--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -2382,7 +2382,7 @@ int32 OS_FPUExcSetMask_Impl(uint32 mask)
     /*
     ** Not implemented in linux.
     */
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_FPUExcSetMask_Impl */
 
                         
@@ -2400,7 +2400,7 @@ int32 OS_FPUExcGetMask_Impl(uint32 *mask)
     ** Not implemented in linux.
     */
     *mask = 0;
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_FPUExcGetMask_Impl */
 
 /********************************************************************/

--- a/src/os/rtems/osapi.c
+++ b/src/os/rtems/osapi.c
@@ -1469,7 +1469,8 @@ int32 OS_IntAttachHandler_Impl  (uint32 InterruptNumber, osal_task_entry Interru
  *-----------------------------------------------------------------*/
 int32 OS_IntUnlock_Impl (int32 IntLevel)
 {
-    rtems_interrupt_enable ( (rtems_interrupt_level) IntLevel);
+    rtems_interrupt_level rtems_int_level = IntLevel;
+    rtems_interrupt_local_enable ( rtems_int_level );
     return (OS_SUCCESS);
 
 } /* end OS_IntUnlock_Impl */
@@ -1487,7 +1488,21 @@ int32 OS_IntLock_Impl (void)
 {
    rtems_interrupt_level rtems_int_level;
 
-   rtems_interrupt_disable(rtems_int_level) ;
+   /*
+    * NOTE: rtems_interrupt_local_disable() is a macro
+    * that sets the rtems_int_level value.
+    *
+    * This code assumes that the value is also storable
+    * in an int32.
+    *
+    * This uses the "local" version which operates on
+    * the current CPU in case of a multi-processor environment.
+    *
+    * This should be identical to rtems_interrupt_disable in
+    * a single-processor config, but that call is not
+    * implemented in multi-processor configs.
+    */
+   rtems_interrupt_local_disable(rtems_int_level) ;
    return ( (int32) rtems_int_level) ;
 
 } /* end OS_IntLock_Impl */
@@ -1504,8 +1519,7 @@ int32 OS_IntLock_Impl (void)
  *-----------------------------------------------------------------*/
 int32 OS_IntEnable_Impl (int32 Level)
 {
-    rtems_interrupt_enable ( (rtems_interrupt_level) Level);
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_IntEnable_Impl */
 
                         
@@ -1519,10 +1533,7 @@ int32 OS_IntEnable_Impl (int32 Level)
  *-----------------------------------------------------------------*/
 int32 OS_IntDisable_Impl (int32 Level)
 {
-   rtems_interrupt_level rtems_int_level;
-
-   rtems_interrupt_disable(rtems_int_level) ;
-   return ( (int32) rtems_int_level) ;
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_IntDisable_Impl */
 
                         
@@ -1612,7 +1623,7 @@ int32 OS_FPUExcEnable_Impl(int32 ExceptionNumber)
     /*
     ** Not implemented in RTEMS.
     */
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_FPUExcEnable_Impl */
                         
 /*----------------------------------------------------------------
@@ -1628,7 +1639,7 @@ int32 OS_FPUExcDisable_Impl(int32 ExceptionNumber)
     /*
     ** Not implemented in RTEMS.
     */
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_FPUExcDisable_Impl */
 
                         
@@ -1645,7 +1656,7 @@ int32 OS_FPUExcSetMask_Impl(uint32 mask)
     /*
     ** Not implemented in RTEMS.
     */
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_FPUExcSetMask_Impl */
 
                         
@@ -1662,7 +1673,7 @@ int32 OS_FPUExcGetMask_Impl(uint32 *mask)
     /*
     ** Not implemented in RTEMS.
     */
-    return(OS_SUCCESS);
+    return(OS_ERR_NOT_IMPLEMENTED);
 } /* end OS_FPUExcGetMask_Impl */
 
 /********************************************************************/

--- a/src/os/shared/osapi-fpu.c
+++ b/src/os/shared/osapi-fpu.c
@@ -76,6 +76,11 @@ int32 OS_FPUExcSetMask(uint32 mask)
  *-----------------------------------------------------------------*/
 int32 OS_FPUExcGetMask(uint32 *mask)
 {
+    if (mask == NULL)
+    {
+        return OS_INVALID_POINTER;
+    }
+
     return OS_FPUExcGetMask_Impl(mask);
 } /* end OS_FPUExcGetMask */
                         


### PR DESCRIPTION
**Describe the contribution**
Fix #316

- Ensure the FPU functions that are actually not implemented in RTEMS/POSIX all return OS_ERR_NOT_IMPLEMENTED, not OS_SUCCESS.
- The RTEMS IntEnable/Disable API should not be a duplicate of the IntLock/Unlock API, as the semantics are slightly different.
  The Enable/Disable API should return OS_ERR_NOT_IMPLEMENTED.
- The OS_FPUExcGetMask API should confirm that the output buffer is not NULL.

**Testing performed**
Sanity check on basic CFE operation on native/simulation build - no changes to FSW behavior.

Modified APIs are exercised in the OSAL unit tests.  Unit tests executed on RTEMS, POSIX (native), and VxWorks in conjunction with changeset for #313.

**Expected behavior changes**
No change to FSW.
Unit tests related to these particular API calls now all PASS or are skipped appropriately for the ones that are actually not implemented.

**System(s) tested on:**
- Ubuntu 18.04 LTS 64-bit (native/posix)
- RTEMS 4.11 on i686/pc (QEMU-emulated target)
- VxWorks 6.9 on PPC/MCP750

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
