### PR TITLE
Update OS_VxWorks_SigWait test case

### DIFF
--- a/src/unit-test-coverage/ut-stubs/src/posix-time-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/posix-time-stubs.c
@@ -71,6 +71,10 @@ int OCS_timer_settime (OCS_timer_t timerid, int flags, const struct OCS_itimersp
     int32 Status;
 
     Status = UT_DEFAULT_IMPL(OCS_timer_settime);
+    if (Status == 0)
+    {
+        UT_Stub_CopyFromLocal(UT_KEY(OCS_timer_settime), value, sizeof(*value));
+    }
 
     return Status;
 }

--- a/src/unit-test-coverage/vxworks/src/coveragetest-ostimer.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-ostimer.c
@@ -150,18 +150,24 @@ void Test_OS_VxWorks_SigWait(void)
      * (invocation of static function through a wrapper)
      */
     int signo = OCS_SIGRTMIN;
+    struct OCS_itimerspec config_value;
 
     OS_global_timebase_table[0].active_id = 0x12345;
     OS_timebase_table[0].nominal_start_time = 8888;
     OS_timebase_table[0].nominal_interval_time = 5555;
 
+    memset(&config_value, 0, sizeof(config_value));
+    UT_SetDataBuffer(UT_KEY(OCS_timer_settime),&config_value,sizeof(config_value),false);
+    UT_SetDataBuffer(UT_KEY(OCS_timer_gettime),&config_value,sizeof(config_value),false);
     Osapi_Internal_Setup(0, signo, true);
+    OS_TimeBaseSet_Impl(0, 1111111, 2222222);
+
     UT_SetDataBuffer(UT_KEY(OCS_sigwait),&signo,sizeof(signo),false);
-    OSAPI_TEST_FUNCTION_RC(Osapi_Internal_CallSigWaitFunc(0), 8888);
+    OSAPI_TEST_FUNCTION_RC(Osapi_Internal_CallSigWaitFunc(0), 1111111);
     UT_SetDataBuffer(UT_KEY(OCS_sigwait),&signo,sizeof(signo),false);
-    OSAPI_TEST_FUNCTION_RC(Osapi_Internal_CallSigWaitFunc(0), 5555);
+    OSAPI_TEST_FUNCTION_RC(Osapi_Internal_CallSigWaitFunc(0), 2222222);
     UT_SetDataBuffer(UT_KEY(OCS_sigwait),&signo,sizeof(signo),false);
-    OSAPI_TEST_FUNCTION_RC(Osapi_Internal_CallSigWaitFunc(0), 5555);
+    OSAPI_TEST_FUNCTION_RC(Osapi_Internal_CallSigWaitFunc(0), 2222222);
 
     Osapi_Internal_Setup(0, 0, false);
     OS_global_timebase_table[0].active_id = 0;


### PR DESCRIPTION
**Describe the contribution**

Fix #321

This is related to the change for #271, where the return value of this function depends on the configured timer interval.  The coverage test case for this was not updated in the original change.

**Testing performed**
Build and execute OSAL coverage tests

**Expected behavior changes**
Test case now passes, as:
```
[BEGIN] 03 OS_VxWorks_SigWait
[ PASS] 03.001 coveragetest-ostimer.c:166 - Osapi_Internal_CallSigWaitFunc(0) (1111111) == 1111111 (1111111)
[ PASS] 03.002 coveragetest-ostimer.c:168 - Osapi_Internal_CallSigWaitFunc(0) (2222222) == 2222222 (2222222)
[ PASS] 03.003 coveragetest-ostimer.c:170 - Osapi_Internal_CallSigWaitFunc(0) (2222222) == 2222222 (2222222)
[  END] 03 OS_VxWorks_SigWait   TOTAL::3     PASS::3     FAIL::0      MIR::0      TSF::0      N/A::0   
```

FSW code is not changed.

**System(s) tested on:**
Ubuntu 18.04 LTS, 64 bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
