### PR TITLE
Fix #329, resolve osfileapi.c lgtm issue

### DIFF
--- a/src/os/posix/osfileapi.c
+++ b/src/os/posix/osfileapi.c
@@ -156,11 +156,6 @@ int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char* Cmd)
    int wstat;
    const char *shell = getenv("SHELL");
 
-   if (shell == NULL)
-   {
-       shell = "/bin/sh";
-   }
-
    cpid = fork();
    if (cpid < 0)
    {
@@ -183,7 +178,11 @@ int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char* Cmd)
            }
        }
 
-       execl(shell, "sh", "-c", Cmd, NULL); /* does not return if successful */
+       if (shell == NULL || strstr(shell, "sh") != NULL )
+       {
+           execl("/bin/sh", "sh", "-c", Cmd, NULL); /* does not return if successful */
+       }
+
        exit(EXIT_FAILURE);
    }
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #329
Resolve osfileapi.c lgtm issue. 

**Testing performed**
Steps taken to test the contribution:
1. Build dummy repository against lgtm 
2. Verify it fixes. 

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
- execl() will only execute for /bin/sh. 

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04
- CFE 6.6


**Contributor Info**
Anh Van, NASA Goddard

