### PR TITLE
Fix #337, fix memory corruption produced by misplaced memset()

### DIFF
--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -1465,6 +1465,8 @@ int32 OS_BinSemCreate_Impl (uint32 sem_id, uint32 initial_value, uint32 options)
     mutex_created = 0;
     cond_created = 0;
     sem = &OS_impl_bin_sem_table[sem_id];
+    memset(sem, 0, sizeof (*sem));
+
     do
     {
         /*
@@ -1522,7 +1524,6 @@ int32 OS_BinSemCreate_Impl (uint32 sem_id, uint32 initial_value, uint32 options)
          ** fill out the proper OSAL table fields
          */
 
-        memset(sem, 0, sizeof (*sem));
         sem->current_value = initial_value;
 
         return_code = OS_SUCCESS;


### PR DESCRIPTION
**Describe the contribution**

This PR fixes #337. The exact change has been recommended by @jphickey.

**Testing performed**

Currently, I cannot test this on Linux only on macOS. As reported in the issue, I confirm that that the issue gets fixed with this change applied. Also, the bug has been confirmed by @jphickey and the changeset is created from his recommendation.

**Expected behavior changes**

See related issue: #337.

**System(s) tested on**

    Running osal-core-test tests (BSEM tests)
    OS: macOS Mojave 10.14.6 (18G87)
    Versions: master branch as of 155e9ebcd6d1930890231a44237e6883d229d22c.

**Contributor Info - All information REQUIRED for consideration of pull request**

Stanislav Pankevich, personal

The signed individual CLA has been sent to the email specified in the CLA document.


