### PR TITLE
Fix #357: Make parameter const

### DIFF
--- a/src/os/rtems/osloader.c
+++ b/src/os/rtems/osloader.c
@@ -317,7 +317,7 @@ int32 OS_ModuleUnload_Impl ( uint32 module_id )
  *           See prototype in os-impl.h for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl ( uint32 module_id, char *translated_path )
+int32 OS_ModuleLoad_Impl ( uint32 module_id, const char *translated_path )
 {
     return OS_SUCCESS;
 } /* end OS_ModuleLoad_Impl */


### PR DESCRIPTION
**Describe the contribution**
When OS_INCLUDE_MODULE_LOADER is not defined, the function header does not
match the definition. This issue was introduced in PR #21 .

Longer term: is there a continuous integration strategy to avoid this sort of situation happening in the future? 

**Testing performed**
Build with module loader disabled with cFS master distribution.

**Expected behavior changes**
None

**System(s) tested on**
 - PC, Ubuntu 19.04

**Contributor Info**
Andrei-Costin Zisu of Planetary Transportation Systems GmbH (Berlin, Germany). Company-wide CLA is in the process of being signed and should be available soon.
