### PR TITLE
Fix #359: src/os/shared/osapi-module.c: handle return value of OS_ModuleLoad_Impl

### DIFF
--- a/src/os/shared/osapi-module.c
+++ b/src/os/shared/osapi-module.c
@@ -242,6 +242,10 @@ int32 OS_ModuleLoad ( uint32 *module_id, const char *module_name, const char *fi
 
         /* Now call the OS-specific implementation.  This reads info from the module table. */
         return_code = OS_ModuleLoad_Impl(local_id, translated_path);
+        if (return_code != OS_SUCCESS)
+        {
+            return return_code;
+        }
 #endif
 
         /* Check result, finalize record, and unlock global table. */


### PR DESCRIPTION
**Describe the contribution**

This changeset fixes #359.

**Testing performed**

The change is not detectable by the current test suite in the current master branch (as of 64ad0f551c01ab846bc79b23411e72cddf987dde) but I can confirm that building OSAL and running its tests on Ubuntu Linux and macOS works fine.

**Expected behavior changes**

This changeset only adds a handling of the `OS_ModuleLoad_Impl` function's return value. In all nominal cases there should be no changes in the existing behavior.

**System(s) tested on**
 - Hardware: Linux laptop, macOS laptop
 - OS: Ubuntu 19.04, macOS 10.14.6
 - Versions: OSAL as of 64ad0f551c01ab846bc79b23411e72cddf987dde

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Stanislav Pankevich, personal

The signed individual CLA has been sent today to the email specified in the CLA document.

