### PR TITLE
Fix #349, OS_SocketAccept() fix

### DIFF
--- a/src/os/shared/osapi-sockets.c
+++ b/src/os/shared/osapi-sockets.c
@@ -237,7 +237,7 @@ int32 OS_SocketAccept(uint32 sock_id, uint32 *connsock_id, OS_SockAddr_t *Addr, 
          /* Socket must be of the STREAM variety */
          return_code = OS_ERR_INCORRECT_OBJ_TYPE;
       }
-      else if (record->refcount != 0 || (OS_stream_table[local_id].stream_state & (OS_STREAM_STATE_BOUND | OS_STREAM_STATE_CONNECTED)) != OS_STREAM_STATE_BOUND)
+      else if ((OS_stream_table[local_id].stream_state & (OS_STREAM_STATE_BOUND | OS_STREAM_STATE_CONNECTED)) != OS_STREAM_STATE_BOUND)
       {
          /* Socket must be bound but not connected */
          return_code = OS_ERR_INCORRECT_OBJ_STATE;


### PR DESCRIPTION
**Describe the contribution**
Fixes #349, note that this does *not* include unit tests. There don't seem to be any unit tests for the OSAL networking code. We should discuss at the CCB.

**Testing performed**
Tested with the TCP version of SBN, without the fix it fails on the Accept() call, with the fix, SBN nodes connect and traffic flows as expected.

**Expected behavior changes**
OS_SocketAccept() should work to accept new incoming TCP connections.

**System(s) tested on**
64-bit Debian 9 VM.

**Additional context**
Add any other context about the contribution here.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov