### PR TITLE
Fixes #259, updated osapi-filesys.c + ut_osfilesys_diskio_tes.ct to use…

### DIFF
--- a/src/os/shared/osapi-filesys.c
+++ b/src/os/shared/osapi-filesys.c
@@ -575,13 +575,7 @@ int32 OS_rmfs (const char *devname)
     }
     else
     {
-        /*
-         * Although OS_ERR_NAME_NOT_FOUND is more descriptive and a
-         * better indicator of the real failure, this preserves
-         * backward compatibility with unit tests that
-         * are checking specifically for the "OS_FS_ERROR" code.
-         */
-        return_code = OS_FS_ERROR;
+        return_code = OS_ERR_NAME_NOT_FOUND;
     }
 
     return return_code;
@@ -692,13 +686,7 @@ int32 OS_mount (const char *devname, const char* mountpoint)
 
     if (return_code != OS_SUCCESS)
     {
-        /*
-         * Although OS_ERR_NAME_NOT_FOUND is more descriptive and a
-         * better indicator of the real failure, this preserves
-         * backward compatibility with unit tests that
-         * are checking specifically for the "OS_FS_ERROR" code.
-         */
-        return_code = OS_FS_ERROR;
+        return_code = OS_ERR_NAME_NOT_FOUND;
     }
 
     return return_code;
@@ -777,13 +765,7 @@ int32 OS_unmount (const char *mountpoint)
 
     if (return_code != OS_SUCCESS)
     {
-        /*
-         * Although OS_ERR_NAME_NOT_FOUND is more descriptive and a
-         * better indicator of the real failure, this preserves
-         * backward compatibility with unit tests that
-         * are checking specifically for the "OS_FS_ERROR" code.
-         */
-        return_code = OS_FS_ERROR;
+        return_code = OS_ERR_NAME_NOT_FOUND;
     }
 
     return return_code;
@@ -991,8 +973,7 @@ int32 OS_FS_GetPhysDriveName(char * PhysDriveName, const char * MountPoint)
     }
     else
     {
-        /* preserves historical (vague) error code */
-        return_code = OS_FS_ERROR;
+        return_code = OS_ERR_NAME_NOT_FOUND;
     }
 
 

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
@@ -407,7 +407,7 @@ UT_os_makefs_test_exit_tag:
 ** Purpose: Removes or un-maps the target file system
 ** Parameters: *devname - a pointer to the name of the "generic" drive
 ** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
-**          OS_FS_ERROR if the given device is not found in the Volume table
+**          OS_ERR_NAME_NOT_FOUND if the given device is not found in the Volume table
 **          OS_FS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
@@ -426,7 +426,7 @@ UT_os_makefs_test_exit_tag:
 **   1) Make sure no file system has been created previously
 **   2) Call this routine with some device name as argument
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERR_NAME_NOT_FOUND
 ** -----------------------------------------------------
 ** Test #3: Nominal condition
 **   1) Call OS_mkfs to create a file system
@@ -465,7 +465,7 @@ void UT_os_removefs_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-device-arg";
 
-    if (OS_rmfs(g_devNames[2]) == OS_FS_ERROR)
+    if (OS_rmfs(g_devNames[2]) == OS_ERR_NAME_NOT_FOUND)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -500,7 +500,7 @@ UT_os_removefs_test_exit_tag:
 ** Parameters: *devname - a pointer to the name of the drive to mount
 **             *mountpoint - a pointer to the name to call this disk from now on
 ** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
-**          OS_FS_ERROR if the given device is not found in the Volume table
+**          OS_ERR_NAME_NOT_FOUND if the given device is not found in the Volume table
 **          OS_FS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
@@ -520,7 +520,7 @@ UT_os_removefs_test_exit_tag:
 **   1) Make sure no file system has been created previously
 **   2) Call this routine with some device name as argument
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERR_NAME_NOT_FOUND
 ** -----------------------------------------------------
 ** Test #3: Nominal condition
 **   1) Call OS_mkfs to create a file system
@@ -531,7 +531,7 @@ UT_os_removefs_test_exit_tag:
 **        (a) OS_FS_SUCCESS
 **   5) Call this routine again exactly as in #3
 **   6) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERR_NAME_NOT_FOUND
 **   7) Call OS_unmount with the mount-point used in #3 as argument
 **   8) Expect the returned value to be
 **        (a) OS_FS_SUCCESS
@@ -563,7 +563,7 @@ void UT_os_mount_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-device-arg";
 
-    if (OS_mount("ramdev0", g_mntNames[2]) == OS_FS_ERROR)
+    if (OS_mount("ramdev0", g_mntNames[2]) == OS_ERR_NAME_NOT_FOUND)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -579,7 +579,7 @@ void UT_os_mount_test()
     }
 
     if ((OS_mount(g_devNames[3], g_mntNames[3]) == OS_FS_SUCCESS) &&
-        (OS_mount(g_devNames[3], g_mntNames[3]) == OS_FS_ERROR))
+        (OS_mount(g_devNames[3], g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -599,7 +599,7 @@ UT_os_mount_test_exit_tag:
 ** Parameters: *mountpoint - a pointer to the name of the drive to unmount
 ** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the absolute path passed in is too long
-**          OS_FS_ERROR if the mount-point passed in is not found in the Volume table
+**          OS_ERR_NAME_NOT_FOUND if the mount-point passed in is not found in the Volume table
 **          OS_FS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
@@ -625,7 +625,7 @@ UT_os_mount_test_exit_tag:
 **   1) Make sure no file system has been created previously
 **   2) Call this routine with some mount-point name as argument
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERR_NAME_NOT_FOUND
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_mkfs to create a file system
@@ -639,7 +639,7 @@ UT_os_mount_test_exit_tag:
 **        (a) OS_FS_SUCCESS
 **   7) Call this routine again exactly as in #5
 **   8) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERR_NAME_NOT_FOUND
 **--------------------------------------------------------------------------------*/
 void UT_os_unmount_test()
 {
@@ -675,7 +675,7 @@ void UT_os_unmount_test()
     /*-----------------------------------------------------*/
     testDesc = "#3 Invalid-mount-point-arg";
 
-    if (OS_unmount(g_mntNames[3]) == OS_FS_ERROR)
+    if (OS_unmount(g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -692,7 +692,7 @@ void UT_os_unmount_test()
 
     if ((OS_mount(g_devNames[4], g_mntNames[4]) == OS_FS_SUCCESS) &&
         (OS_unmount(g_mntNames[4]) == OS_FS_SUCCESS) &&
-        (OS_unmount(g_mntNames[4]) == OS_FS_ERROR))
+        (OS_unmount(g_mntNames[4]) == OS_ERR_NAME_NOT_FOUND))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -712,7 +712,7 @@ UT_os_unmount_test_exit_tag:
 **             *MountPoint - a pointer to the name of the mount-point
 ** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the mount-point passed in is too long
-**          OS_FS_ERROR if the mount-point passed in is not found in the Volume table
+**          OS_ERR_NAME_NOT_FOUND if the mount-point passed in is not found in the Volume table
 **          OS_FS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
@@ -740,7 +740,7 @@ UT_os_unmount_test_exit_tag:
 **        (a) OS_FS_SUCCESS
 **   3) Call this routine
 **   4) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERR_NAME_NOT_FOUND
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_mkfs
@@ -789,7 +789,7 @@ void UT_os_getphysdrivename_test()
     /*-----------------------------------------------------*/
     testDesc = "#3 Invalid-mount-point-arg";
 
-    if (OS_FS_GetPhysDriveName(physDevName, g_mntNames[3]) == OS_FS_ERROR)
+    if (OS_FS_GetPhysDriveName(physDevName, g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);


### PR DESCRIPTION
**Describe the contribution**
Fixes #259, Updatese osapi-filesys.c + ut_osfilesys_diskio_test.c to use desired return values.

**Testing performed**
1. Ran unit tests

**Expected behavior changes**
The more descriptive return value (OS_ERR_NAME_NOT_FOUND) will now be returned from the following functions (instead of OS_FS_ERROR):
OS_rmfs
OS_mount
OS_unmount
OS_FS_GetPhysDriveName


**System(s) tested on**
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.10.0, OSAL 5.0.8.0, PSP 1.4.7.0,

Contributor Info 
Dan Knutsen
NASA/Goddard
