### PR TITLE
Fix #392, Make OS_STREAM_STATE available with APIs

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -139,6 +139,21 @@ typedef struct
 } OS_FdSet;
 
 /**
+ * @brief For the OS_SelectSingle() function's in/out StateFlags parameter,
+ * the state(s) of the stream and the result of the select is a combination
+ * of one or more of these states.
+ *
+ * @sa OS_SelectSingle()
+ */
+typedef enum
+{
+    OS_STREAM_STATE_BOUND      = 0x01, /**< @brief whether the stream is bound     */
+    OS_STREAM_STATE_CONNECTED  = 0x02, /**< @brief whether the stream is connected */
+    OS_STREAM_STATE_READABLE   = 0x04, /**< @brief whether the stream is readable  */
+    OS_STREAM_STATE_WRITABLE   = 0x08, /**< @brief whether the stream is writable  */
+} OS_StreamState_t;
+
+/**
  * @brief For the @ref OS_GetErrorName() function, to ensure
  * everyone is making an array of the same length.
  *
@@ -1409,9 +1424,9 @@ int32 OS_SelectMultiple(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs);
  *
  * This function can be used to wait for a single OSAL stream ID
  * to become readable or writable.   On entry, the "StateFlags"
- * parameter should be set to the desired state (readble or writable)
- * and upon return the flags will be set to the state actually
- * detected.
+ * parameter should be set to the desired state (OS_STREAM_STATE_READABLE
+ * and/or OS_STREAM_STATE_WRITABLE) and upon return the flags
+ * will be set to the state actually detected.
  *
  * As this operates on a single ID, the filehandle is protected
  * during this call, such that another thread accessing the same

--- a/src/os/shared/os-impl.h
+++ b/src/os/shared/os-impl.h
@@ -105,14 +105,6 @@ typedef struct
    uint16     flags;
 }OS_common_record_t;
 
-typedef enum
-{
-   OS_STREAM_STATE_BOUND      = 0x01,
-   OS_STREAM_STATE_CONNECTED  = 0x02,
-   OS_STREAM_STATE_READABLE   = 0x04,
-   OS_STREAM_STATE_WRITABLE   = 0x08,
-} OS_StreamState_t;
-
 /*tasks */
 typedef struct
 {


### PR DESCRIPTION
…it's needed by OS_SelectSingle()

**Describe the contribution**
moves OS_STREAM_STATE defines to os/inc/osapi-os-core.h as they're needed by OS_SelectSingle()

**Testing performed**
Can build unit tests (being developed) for OS_SelectSingle()

Note that this is a prerequisite for #377 and is related to #391 all three should be pulled at the same time, or #392, #391 then #377  

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov