### PR TITLE
Fix #389, Resolve CI config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
+os: linux
 dist: bionic
-sudo: required
-language:
-  - c
+language: c
 compiler:
   - gcc
 addons:


### PR DESCRIPTION
**Describe the contribution**
Fix #389 
Resolve CI config warnings

**Testing performed**
1. CI (CI config change only)

**Expected behavior changes**
No more config warnings reported by Travis-CI

**System(s) tested on**
 - Hardware: CI
 - OS: Ubuntu 18.04
 - Versions: master w/ this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC