### PR TITLE
adds unit tests for OS_Select... API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This distribution contains:
 Version Notes:
 ==============
 
-- 5.0.5: DEVELOPMENT
+- 5.0.6: DEVELOPMENT
   - Minor updates (see https://github.com/nasa/osal/pull/355)
 - 5.0.5: DEVELOPMENT
   - Fixed osal_timer_UT test failure case

--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -110,6 +110,15 @@ typedef struct
 }OS_heap_prop_t;
 
 
+typedef enum
+{
+    OS_STREAM_STATE_BOUND      = 0x01,
+    OS_STREAM_STATE_CONNECTED  = 0x02,
+    OS_STREAM_STATE_READABLE   = 0x04,
+    OS_STREAM_STATE_WRITABLE   = 0x08,
+} OS_StreamState_t;
+
+
 /* This typedef is for the OS_GetErrorName function, to ensure
  * everyone is making an array of the same length.
  *
@@ -1231,9 +1240,9 @@ int32 OS_SelectMultiple(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs);
  *
  * This function can be used to wait for a single OSAL stream ID
  * to become readable or writable.   On entry, the "StateFlags"
- * parameter should be set to the desired state (readble or writable)
- * and upon return the flags will be set to the state actually
- * detected.
+ * parameter should be set to the desired state (OS_STREAM_STATE_READABLE
+ * and/or OS_STREAM_STATE_WRITABLE) and upon return the flags
+ * will be set to the state actually detected.
  *
  * As this operates on a single ID, the filehandle is protected
  * during this call, such that another thread accessing the same

--- a/src/os/shared/os-impl.h
+++ b/src/os/shared/os-impl.h
@@ -105,14 +105,6 @@ typedef struct
    uint16     flags;
 }OS_common_record_t;
 
-typedef enum
-{
-   OS_STREAM_STATE_BOUND      = 0x01,
-   OS_STREAM_STATE_CONNECTED  = 0x02,
-   OS_STREAM_STATE_READABLE   = 0x04,
-   OS_STREAM_STATE_WRITABLE   = 0x08,
-} OS_StreamState_t;
-
 /*tasks */
 typedef struct
 {

--- a/src/unit-tests/oscore-test/CMakeLists.txt
+++ b/src/unit-tests/oscore-test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_MODULE_FILES
   ut_oscore_binsem_test.c    
   ut_oscore_misc_test.c   
   ut_oscore_queue_test.c  
+  ut_oscore_select_test.c  
   ut_oscore_countsem_test.c  
   ut_oscore_mutex_test.c  
   ut_oscore_task_test.c   

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.c
@@ -1,0 +1,164 @@
+/*================================================================================*
+** File:  ut_oscore_select_test.c
+** Owner: Chris Knight
+** Date:  March 2020
+**================================================================================*/
+
+/*--------------------------------------------------------------------------------*
+** Includes
+**--------------------------------------------------------------------------------*/
+
+#include "ut_oscore_select_test.h"
+
+/*--------------------------------------------------------------------------------*
+** Macros
+**--------------------------------------------------------------------------------*/
+
+#define UT_SELECT_FN "/cf/select_test.tmp"
+
+/*--------------------------------------------------------------------------------*
+** Data types
+**--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*
+** External global variables
+**--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*
+** Global variables
+**--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*
+** External function prototypes
+**--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*
+** Local function prototypes
+**--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*
+** Local function definitions
+**--------------------------------------------------------------------------------*/
+
+char *fsAddrPtr = NULL;
+static int32 setup_file(void)
+{
+    OS_mkfs(fsAddrPtr, "/ramdev3", " ", 512, 20);
+    OS_mount("/ramdev3", "/drive3");
+    return OS_creat("/drive3/select_test.txt", OS_READ_WRITE);
+}
+
+static void teardown_file(int32 fd)
+{
+    OS_close(fd);
+    OS_remove("/drive3/select_test.txt");
+    OS_unmount("/drive3");
+    OS_rmfs("/ramdev3");
+}
+
+/*--------------------------------------------------------------------------------*
+** Syntax: OS_SelectFdZero, OS_SelectFdAdd, OS_SelectFdClear, OS_SelectFdIsSet
+** Purpose: Configure file descriptor set for select
+** Parameters: To-be-filled-in
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_SUCCESS if succeeded
+**--------------------------------------------------------------------------------*/
+void UT_os_select_fd_test(void)
+{
+    OS_FdSet FdSet;
+    int32 fd = setup_file();
+
+    if(OS_SelectFdZero(&FdSet) == OS_ERR_NOT_IMPLEMENTED
+        || OS_SelectFdAdd(&FdSet, fd) == OS_ERR_NOT_IMPLEMENTED
+        || OS_SelectFdClear(&FdSet, fd) == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectFd...() not implemented");
+        goto UT_os_select_fd_test_exit_tag;
+    }
+
+    UtAssert_Simple(OS_SelectFdZero(NULL) == OS_INVALID_POINTER);
+    UtAssert_Simple(OS_SelectFdAdd(NULL, 0) == OS_INVALID_POINTER);
+    UtAssert_Simple(OS_SelectFdClear(NULL, 0) == OS_INVALID_POINTER);
+    UtAssert_Simple(OS_SelectFdIsSet(NULL, 0) == false);
+
+    OS_SelectFdZero(&FdSet);
+    OS_SelectFdAdd(&FdSet, fd);
+    UtAssert_Simple(OS_SelectFdIsSet(&FdSet, fd));
+
+    OS_SelectFdZero(&FdSet);
+    OS_SelectFdAdd(&FdSet, fd);
+    OS_SelectFdClear(&FdSet, fd);
+    UtAssert_Simple(!OS_SelectFdIsSet(&FdSet, fd));
+
+UT_os_select_fd_test_exit_tag:
+    teardown_file(fd);
+}
+
+/*--------------------------------------------------------------------------------*
+** Syntax: int32 OS_SelectSingle(uint32 objid, uint32 *StateFlags, int32 msecs);
+** Purpose: Select on a single file descriptor
+** Parameters: To-be-filled-in
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_SUCCESS if succeeded
+**--------------------------------------------------------------------------------*/
+void UT_os_select_single_test(void)
+{
+    uint32 StateFlags;
+    int32 fd = setup_file();
+
+    if(OS_SelectSingle(fd, &StateFlags, 0) == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectSingle() not implemented");
+        goto UT_os_select_single_test_exit_tag;
+    }
+
+    UtAssert_Simple(OS_SelectSingle(fd, NULL, 0) != OS_SUCCESS);
+
+    StateFlags = OS_STREAM_STATE_WRITABLE;
+    UtAssert_Simple(OS_SelectSingle(fd, &StateFlags, 0) == OS_SUCCESS && StateFlags & OS_STREAM_STATE_WRITABLE);
+
+    StateFlags = OS_STREAM_STATE_READABLE;
+    UtAssert_Simple(OS_SelectSingle(fd, &StateFlags, 1) == OS_SUCCESS);
+
+UT_os_select_single_test_exit_tag:
+    teardown_file(fd);
+}
+
+/*--------------------------------------------------------------------------------*
+** Syntax: int32 OS_SelectMultiple(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs)
+** Purpose: Select on a multiple file descriptors
+** Parameters: To-be-filled-in
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_SUCCESS if succeeded
+**--------------------------------------------------------------------------------*/
+void UT_os_select_multi_test(void)
+{
+    OS_FdSet ReadSet, WriteSet;
+    int32 fd = setup_file();
+
+    if(OS_SelectMultiple(&ReadSet, &WriteSet, 1) == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectMultiple() not implemented");
+        goto UT_select_multi_test_exit_tag;
+    }
+
+    OS_SelectFdZero(&WriteSet);
+    OS_SelectFdAdd(&WriteSet, fd);
+    UtAssert_Simple(OS_SelectMultiple(NULL, &WriteSet, 1) == OS_SUCCESS);
+
+    OS_SelectFdZero(&ReadSet);
+    OS_SelectFdAdd(&ReadSet, fd);
+    UtAssert_Simple(OS_SelectMultiple(&ReadSet, NULL, 1) == OS_SUCCESS);
+
+    OS_SelectFdZero(&ReadSet);
+    OS_SelectFdAdd(&ReadSet, fd);
+    OS_SelectFdZero(&WriteSet);
+    UtAssert_Simple(OS_SelectMultiple(&ReadSet, &WriteSet, 0) == OS_SUCCESS);
+
+UT_select_multi_test_exit_tag:
+    teardown_file(fd);
+}
+
+/*================================================================================*
+** End of File: ut_oscore_queue_test.c
+**================================================================================*/

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.h
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.h
@@ -1,26 +1,17 @@
 /*================================================================================*
-** File:  ut_oscore_test.h
-** Owner: Tam Ngo/Alan Cudmore
-** Date:  May 2013
+** File:  ut_oscore_select_test.h
+** Owner: Chris Knight
+** Date:  March 2020
 **================================================================================*/
 
-#ifndef _UT_OSCORE_TEST_H_
-#define _UT_OSCORE_TEST_H_
+#ifndef _UT_OSCORE_SELECT_TEST_H_
+#define _UT_OSCORE_SELECT_TEST_H_
 
 /*--------------------------------------------------------------------------------*
 ** Includes
 **--------------------------------------------------------------------------------*/
 
 #include "ut_os_support.h"
-#include "ut_oscore_misc_test.h"
-#include "ut_oscore_binsem_test.h"
-#include "ut_oscore_countsem_test.h"
-#include "ut_oscore_mutex_test.h"
-#include "ut_oscore_queue_test.h"
-#include "ut_oscore_select_test.h"
-#include "ut_oscore_task_test.h"
-#include "ut_oscore_interrupt_test.h"
-#include "ut_oscore_exception_test.h"
 
 /*--------------------------------------------------------------------------------*
 ** Macros
@@ -42,10 +33,14 @@
 ** Function prototypes
 **--------------------------------------------------------------------------------*/
 
+void UT_os_select_fd_test(void);
+void UT_os_select_single_test(void);
+void UT_os_select_multi_test(void);
+
 /*--------------------------------------------------------------------------------*/
 
-#endif  /* _UT_OSCORE_TEST_H_ */
+#endif  /* _UT_OSCORE_SELECT_TEST_H_ */
 
 /*================================================================================*
-** End of File: ut_oscore_test_posix.h
+** End of File: ut_oscore_select_test.h
 **================================================================================*/

--- a/src/unit-tests/oscore-test/ut_oscore_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_test.c
@@ -205,6 +205,10 @@ void UtTest_Setup(void)
     UtTest_Add(UT_os_queue_get_id_by_name_test, NULL, NULL, "OS_QueueGetIdByName");
     UtTest_Add(UT_os_queue_get_info_test, NULL, NULL, "OS_QueueGetInfo");
 
+    UtTest_Add(UT_os_select_fd_test, NULL, NULL, "OS_SelectFd");
+    UtTest_Add(UT_os_select_single_test, NULL, NULL, "OS_SelectSingle");
+    UtTest_Add(UT_os_select_multi_test, NULL, NULL, "OS_SelectMultiple");
+
     UtTest_Add(
             NULL,
             UT_os_init_task_misc,


### PR DESCRIPTION
**Describe the contribution**
Fix for ticket #377 which adds unit tests for OSAL select API's. This relies on, and has merges from, #390 and #393 .

**Testing performed**
make; cd cpu1/osal/unit-tests/oscore-test; ./osal-core-UT # all passes

**Expected behavior changes**
Adds unit tests for select.

**System(s) tested on**
Debian 9 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov