### PR TITLE
Fix #88, Add test for name too long and update comments 

### DIFF
--- a/src/bsp/mcp750-vxworks/config/osconfig.h
+++ b/src/bsp/mcp750-vxworks/config/osconfig.h
@@ -24,7 +24,7 @@
 #define OS_MAX_MUTEXES              20
 
 /*
-** Maximum length for an absolute path name
+** Maximum length (including terminator) for an absolute path name
 */
 #define OS_MAX_PATH_LEN     64
 
@@ -37,7 +37,7 @@
 
 
 /* 
-** The maxium length allowed for a object (task,queue....) name 
+** The maxium length allowed for a object name (task, queue, etc.), including terminating null 
 */
 #define OS_MAX_API_NAME     20
 
@@ -47,7 +47,7 @@
 #define OS_MAX_FILE_NAME    20
 
 /* 
-** These defines are for OS_printf
+** Buffer for OS_printf, includes terminator.  Longer messages will be truncated
 */
 #define OS_BUFFER_SIZE 172
 #define OS_BUFFER_MSG_DEPTH 100

--- a/src/bsp/pc-linux/config/osconfig.h
+++ b/src/bsp/pc-linux/config/osconfig.h
@@ -24,7 +24,7 @@
 #define OS_MAX_MUTEXES              20
 
 /*
-** Maximum length for an absolute path name
+** Maximum length (including terminator) for an absolute path name
 */
 #define OS_MAX_PATH_LEN     64
 
@@ -36,7 +36,7 @@
 #define OS_MAX_LOCAL_PATH_LEN (OS_MAX_PATH_LEN + OS_FS_PHYS_NAME_LEN)
 
 /* 
-** The maxium length allowed for a object (task,queue....) name 
+** The maxium length allowed for a object name (task, queue, etc.), including terminating null 
 */
 #define OS_MAX_API_NAME     20
 

--- a/src/bsp/pc-rtems/config/osconfig.h
+++ b/src/bsp/pc-rtems/config/osconfig.h
@@ -24,7 +24,7 @@
 #define OS_MAX_MUTEXES              20
 
 /*
-** Maximum length for an absolute path name
+** Maximum length (including terminator) for an absolute path name
 */
 #define OS_MAX_PATH_LEN     64
 
@@ -36,7 +36,7 @@
 #define OS_MAX_LOCAL_PATH_LEN (OS_MAX_PATH_LEN + OS_FS_PHYS_NAME_LEN)
 
 /* 
-** The maxium length allowed for a object (task,queue....) name 
+** The maxium length allowed for a object name (task, queue, etc.), including terminating null 
 */
 #define OS_MAX_API_NAME     20
 

--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -327,7 +327,7 @@ void OS_ForEachObject           (uint32 creator_id, OS_ArgCallback_t callback_pt
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if any of the necessary pointers are NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the name of the task is too long to be copied
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_INVALID_PRIORITY if the priority is bad
  * @retval #OS_ERR_NO_FREE_IDS if there can be no more tasks created
  * @retval #OS_ERR_NAME_TAKEN if the name specified is already used by a task
@@ -442,7 +442,7 @@ uint32 OS_TaskGetId            (void);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if the pointers passed in are NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the name to found is too long to begin with
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name wasn't found in the table
  */
 int32 OS_TaskGetIdByName       (uint32 *task_id, const char *task_name);
@@ -489,7 +489,7 @@ int32 OS_TaskGetInfo           (uint32 task_id, OS_task_prop_t *task_prop);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if a pointer passed in is NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the name passed in is too long
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NO_FREE_IDS if there are already the max queues created
  * @retval #OS_ERR_NAME_TAKEN if the name is already being used on another queue
  * @retval #OS_ERROR if the OS create call fails
@@ -572,7 +572,7 @@ int32 OS_QueuePut              (uint32 queue_id, const void *data, uint32 size,
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if the name or id pointers are NULL
- * @retval #OS_ERR_NAME_TOO_LONG the name passed in is too long
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND the name was not found in the table
  */
 int32 OS_QueueGetIdByName      (uint32 *queue_id, const char *queue_name);
@@ -616,7 +616,7 @@ int32 OS_QueueGetInfo          (uint32 queue_id, OS_queue_prop_t *queue_prop);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if sen name or sem_id are NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is too long
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NO_FREE_IDS if all of the semaphore ids are taken
  * @retval #OS_ERR_NAME_TAKEN if this is already the name of a binary semaphore
  * @retval #OS_SEM_FAILURE if the OS call failed
@@ -729,7 +729,7 @@ int32 OS_BinSemDelete          (uint32 sem_id);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER is semid or sem_name are NULL pointers
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is to long to have been stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name was not found in the table
  */
 int32 OS_BinSemGetIdByName     (uint32 *sem_id, const char *sem_name);
@@ -768,7 +768,7 @@ int32 OS_BinSemGetInfo         (uint32 sem_id, OS_bin_sem_prop_t *bin_prop);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if sen name or sem_id are NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is too long
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NO_FREE_IDS if all of the semaphore ids are taken
  * @retval #OS_ERR_NAME_TAKEN if this is already the name of a counting semaphore
  * @retval #OS_SEM_FAILURE if the OS call failed
@@ -863,7 +863,7 @@ int32 OS_CountSemDelete          (uint32 sem_id);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER is semid or sem_name are NULL pointers
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is to long to have been stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name was not found in the table
  */
 int32 OS_CountSemGetIdByName     (uint32 *sem_id, const char *sem_name);
@@ -899,7 +899,7 @@ int32 OS_CountSemGetInfo         (uint32 sem_id, OS_count_sem_prop_t *count_prop
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if sem_id or sem_name are NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the sem_name is too long to be stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NO_FREE_IDS if there are no more free mutex Ids
  * @retval #OS_ERR_NAME_TAKEN if there is already a mutex with the same name
  * @retval #OS_SEM_FAILURE if the OS call failed
@@ -972,7 +972,7 @@ int32 OS_MutSemDelete           (uint32 sem_id);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER is semid or sem_name are NULL pointers
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is to long to have been stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name was not found in the table
  */
 int32 OS_MutSemGetIdByName      (uint32 *sem_id, const char *sem_name); 
@@ -1482,7 +1482,9 @@ bool OS_SelectFdIsSet(OS_FdSet *Set, uint32 objid);
  * Operates in a manner similar to the printf() call defined by the standard C
  * library and takes all the parameters and formatting options of printf.
  * This abstraction may implement additional buffering, if necessary,
- * to improve the real-time performance of the call.
+ * to improve the real-time performance of the call. 
+ * 
+ * Strings (including terminator) longer than #OS_BUFFER_SIZE will be truncated.
  *
  * The output of this routine also may be dynamically enabled or disabled by
  * the OS_printf_enable() and OS_printf_disable() calls, respectively.

--- a/src/os/inc/osapi-os-net.h
+++ b/src/os/inc/osapi-os-net.h
@@ -340,7 +340,7 @@ int32 OS_SocketSendTo(uint32 sock_id, const void *buffer, uint32 buflen, const O
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER is id or name are NULL pointers
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is to long to have been stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name was not found in the table
  */
 int32 OS_SocketGetIdByName (uint32 *sock_id, const char *sock_name);

--- a/src/os/inc/osapi-os-timer.h
+++ b/src/os/inc/osapi-os-timer.h
@@ -129,7 +129,7 @@ int32 OS_TimeBaseDelete         (uint32 timebase_id);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if timebase_id or timebase_name are NULL pointers
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is to long to have been stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name was not found in the table
  */
 int32 OS_TimeBaseGetIdByName    (uint32 *timebase_id, const char *timebase_name);
@@ -217,7 +217,7 @@ int32 OS_TimeBaseGetFreeRun     (uint32 timebase_id, uint32 *freerun_val);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if any parameters are NULL
- * @retval #OS_ERR_NAME_TOO_LONG if the name parameter is too long.
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_TAKEN if the name is already in use by another timer.
  * @retval #OS_ERR_NO_FREE_IDS if all of the timers are already allocated.
  * @retval #OS_TIMER_ERR_INVALID_ARGS if the callback pointer is zero.
@@ -316,7 +316,7 @@ int32 OS_TimerDelete            (uint32 timer_id);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if timer_id or timer_name are NULL pointers
- * @retval #OS_ERR_NAME_TOO_LONG if the name given is to long to have been stored
+ * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NAME_NOT_FOUND if the name was not found in the table
  */
 int32 OS_TimerGetIdByName       (uint32 *timer_id, const char *timer_name);

--- a/src/os/inc/osapi.h
+++ b/src/os/inc/osapi.h
@@ -58,7 +58,7 @@
 #define OS_QUEUE_TIMEOUT               (-10) /**< @brief Queue timeout */
 #define OS_QUEUE_INVALID_SIZE          (-11) /**< @brief Queue invalid size */
 #define OS_QUEUE_ID_ERROR              (-12) /**< @brief Queue ID error */
-#define OS_ERR_NAME_TOO_LONG           (-13) /**< @brief Name too long */
+#define OS_ERR_NAME_TOO_LONG           (-13) /**< @brief name length including null terminator greater than #OS_MAX_API_NAME */
 #define OS_ERR_NO_FREE_IDS             (-14) /**< @brief No free IDs */
 #define OS_ERR_NAME_TAKEN              (-15) /**< @brief Name taken */
 #define OS_ERR_INVALID_ID              (-16) /**< @brief Invalid ID */

--- a/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
@@ -241,7 +241,12 @@ void UT_os_timerinit_test()
 **   2) Expect the returned value to be
 **        (a) OS_ERR_NAME_TOO_LONG
 ** -----------------------------------------------------
-** Test #3: Name-taken-argument condition
+** Test #3: Name equal to OS_MAX_API_NAME characters test
+**   1) Call this routine with a timer name equal to OS_MAX_API_NAME + 1 as argument
+**   2) Expect the returned value to be
+**        (a) OS_ERR_NAME_TOO_LONG
+** -----------------------------------------------------
+** Test #4: Name-taken-argument condition
 **   1) Call this routine with a valid timer name as argument
 **   2) Expect the returned value to be
 **        (a) OS_SUCCESS
@@ -249,23 +254,23 @@ void UT_os_timerinit_test()
 **   4) Expect the returned value to be
 **        (a) OS_ERR_NAME_TAKEN
 ** -----------------------------------------------------
-** Test #4: No-free-ids condition
+** Test #5: No-free-ids condition
 **   1) Call this routine N number of times, where N = OS_MAX_TIMERS+1
 **   2) Expect the returned value of the last call to be
 **        (a) OS_ERR_NO_FREE_IDS
 ** -----------------------------------------------------
-** Test #5: Invalid-argument condition
+** Test #6: Invalid-argument condition
 **   1) Call this routine with a null pointer for callback as argument
 **   2) Expect the returned value to be
 **        (a) OS_TIMER_ERR_INVALID_ARGS
 ** -----------------------------------------------------
-** Test #6: Timer-unavailable condition
+** Test #7: Timer-unavailable condition
 **   1) Set up test to cause the OS call inside this routine to fail
 **   2) Call this routine with valid arguments
 **   3) Expect the returned value to be
 **        (a) OS_TIMER_ERR_UNAVAILABLE
 ** -----------------------------------------------------
-** Test #7: Nominal condition
+** Test #8: Nominal condition
 **   1) Call this routine
 **   2) Expect the returned value to be
 **        (a) OS_SUCCESS
@@ -281,7 +286,7 @@ void UT_os_timercreate_test()
 {
     const char* testDesc;
     int32 res=0, i=0, j=0;
-    char tmpStr[UT_OS_NAME_BUFF_SIZE];
+    char  tmpStr[UT_OS_NAME_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
@@ -319,7 +324,20 @@ void UT_os_timercreate_test()
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Name-taken";
+    testDesc = "#3 Name equal to OS_MAX_API_NAME characters test";
+
+    /* Test Load library returning an error on a too long library name */
+    memset(&tmpStr[0], 'a', OS_MAX_API_NAME);
+    tmpStr[OS_MAX_API_NAME] = '\0';
+
+    if (OS_TimerCreate(&g_timerIds[2], tmpStr, &g_clkAccuracy, &UT_os_timercallback) ==
+        OS_ERR_NAME_TOO_LONG)
+        UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
+    else
+        UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
+
+    /*-----------------------------------------------------*/
+    testDesc = "#4 Name-taken";
 
     if ((OS_TimerCreate(&g_timerIds[3], g_timerNames[3], &g_clkAccuracy, &UT_os_timercallback) ==
          OS_SUCCESS) &&
@@ -333,7 +351,7 @@ void UT_os_timercreate_test()
     OS_TimerDelete(g_timerIds[3]);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 No-free-IDs";
+    testDesc = "#5 No-free-IDs";
 
     for (i=0; i <= OS_MAX_TIMERS; i++)
     {
@@ -363,7 +381,7 @@ void UT_os_timercreate_test()
         OS_TimerDelete(g_timerIds[j]);
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 Invalid-arg";
+    testDesc = "#6 Invalid-arg";
 
     if (OS_TimerCreate(&g_timerIds[5], g_timerNames[5], &g_clkAccuracy, NULL) ==
         OS_TIMER_ERR_INVALID_ARGS)
@@ -372,12 +390,12 @@ void UT_os_timercreate_test()
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
 
     /*-----------------------------------------------------*/
-    testDesc = "#6 Timer-unavailable";
+    testDesc = "#7 Timer-unavailable";
 
     UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_INFO);
 
     /*-----------------------------------------------------*/
-    testDesc = "#7 Nominal";
+    testDesc = "#8 Nominal";
 
     res = OS_TimerCreate(&g_timerIds[7], g_timerNames[7], &g_clkAccuracy, &UT_os_timercallback);
     if (res == OS_SUCCESS)


### PR DESCRIPTION
Describe the contribution
Fixes #88, Add test for name too long and update comments.
Coverage test added to OS_TimerCreate for OS_ERR_NAME_TOO_LONG.
Updated comments related to sizing includes null terminator for:
OS_MAX_API_NAME, OS_MAX_PATH_LEN, OS_BUFFER_SIZE

Testing performed
Ran unit tests.

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.11.0, OSAL 5.0.9.0, PSP 1.4.7.0

Contributor Info
Dan Knutsen
NASA/Goddard
