### PR TITLE
Fix #232, pthread stack min typo

### DIFF
--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -31,7 +31,7 @@
  * Defines
  */
 #ifndef PTHREAD_STACK_MIN
-#define PTHREAD_STACK_MIN 8092
+#define PTHREAD_STACK_MIN 8*1024
 #endif
 
 /*

--- a/src/os/posix/osapi.c
+++ b/src/os/posix/osapi.c
@@ -31,7 +31,7 @@
  * Defines
  */
 #ifndef PTHREAD_STACK_MIN
-#define PTHREAD_STACK_MIN 8*1024
+#define PTHREAD_STACK_MIN (8*1024)
 #endif
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Fixes #232 PTHREAD_STACK_MIN typo. I could have changed the number to 8192 but I thought (8*1024) was more true to where the number comes from. Let me know if this is not inline with NASA code style preferences.

**Testing performed**
Steps taken to test the contribution:
1. Build steps: built with cmake:
`cmake -DOSAL_SYSTEM_OSTYPE=posix -DOSAL_SYSTEM_BSPTYPE=pc-linux -DENABLE_UNIT_TESTS=TRUE -DOSAL_INCLUDEDIR=/home/david/projects/config -DCFE_SYSTEM_PSPNAME=whyohwhy /home/david/projects/osal`
1. Ran all tests and unit tests.
Note that osloader module test nominal 7 failed (ut_osloader_module_test.c:242) but it failed no matter whether my changes were implemented or not. I assume it's a quirk of my system/environment.

**Expected behavior changes**
 - no impact to behavior

**System(s) tested on**
 - Hardware: ASUS ZenBook Laptop
 - OS: Debian GNU/Linux 10 VM on Hyper-V Manager
 - Versions: OSAL 5.0.9.0

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
David Archuleta Jr.
Personal