### PR TITLE
Fix #12, Comment update to correct for microseconds not always rounding up + a…

### DIFF
--- a/src/os/posix/ostimer.c
+++ b/src/os/posix/ostimer.c
@@ -285,9 +285,10 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
        }
 
        /*
-        * Calculate microseconds per tick - Rounding UP
-        *  - If the ratio is not an integer, this will choose the next higher value
-        *  - The result is guaranteed not to be zero.
+        * Calculate microseconds per tick 
+        *  - If the ratio is not an integer, this will round to the nearest integer value
+        *  - This is used internally for reporting accuracy,
+        *  - TicksPerSecond values over 2M will return zero
         */
        OS_SharedGlobalVars.MicroSecPerTick = (1000000 + (OS_SharedGlobalVars.TicksPerSecond / 2)) /
              OS_SharedGlobalVars.TicksPerSecond;

--- a/src/os/shared/osapi-common.c
+++ b/src/os/shared/osapi-common.c
@@ -64,6 +64,7 @@ int32 OS_API_Init(void)
 {
    int32  return_code = OS_SUCCESS;
    uint32 idtype;
+   uint32 microSecPerSec;
 
    if (OS_SharedGlobalVars.Initialized != false)
    {
@@ -159,6 +160,14 @@ int32 OS_API_Init(void)
    {
       OS_DEBUG("Implementation failed to initialize tick time globals\n");
       return_code = OS_ERROR;
+   }
+
+   microSecPerSec = OS_SharedGlobalVars.MicroSecPerTick * OS_SharedGlobalVars.TicksPerSecond;
+	
+   if ( microSecPerSec != 1000000 )
+   {   
+      OS_DEBUG("Warning: Microsecs per sec value of %lu does not equal 1000000 (MicroSecPerTick: %ld   TicksPerSecond: %ld)\n", 
+                (unsigned long) microSecPerSec, (long) OS_SharedGlobalVars.MicroSecPerTick, (long) OS_SharedGlobalVars.TicksPerSecond);
    }
 
    return(return_code);

--- a/src/unit-test-coverage/shared/src/coveragetest-common.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-common.c
@@ -97,6 +97,11 @@ void Test_OS_API_Init(void)
     OS_SharedGlobalVars.Initialized = false;
     OSAPI_TEST_FUNCTION_RC(OS_API_Init(), OS_SUCCESS);
 
+    Test_MicroSecPerTick = 1000;
+    Test_TicksPerSecond = 1001;
+    OS_SharedGlobalVars.Initialized = false;
+    OSAPI_TEST_FUNCTION_RC(OS_API_Init(), OS_SUCCESS);
+
     /* Second call should return ERROR */
     OSAPI_TEST_FUNCTION_RC(OS_API_Init(), OS_ERROR);
 


### PR DESCRIPTION
Describe the contribution
Fixes #12 , Microsecond round up code doesn't round up.
Updated comments in ostimer.c to reflect what the code is actually doing.
Added debug message if microsecs per sec value does not equal 1000000.

Testing performed
Ran unit tests.

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.11.0, OSAL 5.0.9.0, PSP 1.4.7.0

Contributor Info
Dan Knutsen
NASA/Goddard