### PR TITLE
Fix #407, Resolve doxygen warnings for main doc

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -591,7 +591,6 @@ int32 OS_QueueGetIdByName      (uint32 *queue_id, const char *queue_name);
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if queue_prop is NULL
  * @retval #OS_ERR_INVALID_ID if the ID given is not  a valid queue
- * @retval #OS_SUCCESS if the info was copied over correctly
  */
 int32 OS_QueueGetInfo          (uint32 queue_id, OS_queue_prop_t *queue_prop);
 /**@}*/


### PR DESCRIPTION
**Describe the contribution**
Fixes #407 by removing a duplicate reference the doxygen warned about

**Testing performed**
Steps taken to test the contribution:
1. Edited file in which error occurred
2. Rebuilt documentation using `make doc`
3. Observed no warning generated
4. Viewed relevant documentation page to verify correctness

**Contributor Info - All information REQUIRED for consideration of pull request**
Leor Bleier NASA-GSFC
