### PR TITLE
Fix #368, Deprecate os_fs_err_name_t

### DIFF
--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -89,7 +89,7 @@
 #define OS_FS_UNIMPLEMENTED            OS_ERR_NOT_IMPLEMENTED   /**< @brief Not implemented */
 /**@}*/
 
-
+#ifndef OSAL_OMIT_DEPRECATED
 /* This typedef is for OS_FS_GetErrorName(), to ensure
  * everyone is making an array of the same length
  *
@@ -103,7 +103,7 @@
  * os_err_name_t.
  */
 typedef os_err_name_t os_fs_err_name_t;
-
+#endif
 
 /**
  * @brief Internal structure of the OS volume table for 

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -21,7 +21,7 @@ void TestStat(void);
 void TestOpenFileAPI(void);
 void TestUnmountRemount(void);
 
-os_fs_err_name_t errname;
+os_err_name_t errname;
 
 /* *************************************** MAIN ************************************** */
 


### PR DESCRIPTION
**Describe the contribution**
Fix #368
Deprecates the define and updates the reference in unit test

**Testing performed**
CI - https://travis-ci.com/github/skliper/cFS/builds/159834459

**Expected behavior changes**
None

**System(s) tested on**
 - CI, master bundle w/ this branch

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC