### PR TITLE
Fix #262,  Deprecates OS_FS_* defines that aren't unique to FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This distribution contains:
   - Provide sufficient framework for combining the OSAL BSP, UT BSP, and the CFE PSP and eliminating the duplication/overlap between these items.
   - Minor updates (see https://github.com/nasa/osal/pull/417)
 - 5.0.11: DEVELOPMENT
-  - The more descriptive return value OS_ERR_NAME_NOT_FOUND (instead of OS_FS_ERROR) will now be returned from the following functions (): OS_rmfs, OS_mount, OS_unmount, OS_FS_GetPhysDriveName
+  - The more descriptive return value OS_ERR_NAME_NOT_FOUND (instead of OS_ERROR) will now be returned from the following functions (): OS_rmfs, OS_mount, OS_unmount, OS_FS_GetPhysDriveName
   - Wraps OS_ShMem* prototype and unit test wrapper additions in OSAL_OMIT_DEPRECATED
   - Minor updates (see https://github.com/nasa/osal/pull/408)
 - 5.0.10: DEVELOPMENT

--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -76,19 +76,20 @@
 #define OS_FS_ERR_DEVICE_NOT_FREE      (-107)  /**< @brief FS device not free */
 #define OS_FS_ERR_PATH_INVALID         (-108)  /**< @brief FS path invalid */
 
-
+#ifndef OSAL_OMIT_DEPRECATED
 /* 
  * Map some codes used by the file API back to the generic counterparts 
  * where there is overlap between them.  Do not duplicate error codes.
  */
-#define OS_FS_SUCCESS                  OS_SUCCESS               /**< @brief Successful execution */
-#define OS_FS_ERROR                    OS_ERROR                 /**< @brief Failed execution */
-#define OS_FS_ERR_INVALID_POINTER      OS_INVALID_POINTER       /**< @brief Invalid pointer */
-#define OS_FS_ERR_NO_FREE_FDS          OS_ERR_NO_FREE_IDS       /**< @brief No free IDs */
-#define OS_FS_ERR_INVALID_FD           OS_ERR_INVALID_ID        /**< @brief Invalid ID */
-#define OS_FS_UNIMPLEMENTED            OS_ERR_NOT_IMPLEMENTED   /**< @brief Not implemented */
-/**@}*/
+#define OS_FS_SUCCESS                  OS_SUCCESS               /**< @deprecated Successful execution */
+#define OS_FS_ERROR                    OS_ERROR                 /**< @deprecated Failed execution */
+#define OS_FS_ERR_INVALID_POINTER      OS_INVALID_POINTER       /**< @deprecated Invalid pointer */
+#define OS_FS_ERR_NO_FREE_FDS          OS_ERR_NO_FREE_IDS       /**< @deprecated No free IDs */
+#define OS_FS_ERR_INVALID_FD           OS_ERR_INVALID_ID        /**< @deprecated Invalid ID */
+#define OS_FS_UNIMPLEMENTED            OS_ERR_NOT_IMPLEMENTED   /**< @deprecated Not implemented */
+#endif
 
+/**@}*/
 
 /* This typedef is for OS_FS_GetErrorName(), to ensure
  * everyone is making an array of the same length
@@ -775,7 +776,7 @@ int32           OS_FileSysAddFixedMap(uint32 *filesys_id, const char *phys_path,
  * @retval #OS_INVALID_POINTER if devname is NULL
  * @retval #OS_FS_ERR_DRIVE_NOT_CREATED if the OS calls to create the the drive failed
  * @retval #OS_FS_ERR_DEVICE_NOT_FREE if the volume table is full
- * @retval #OS_FS_SUCCESS on creating the disk
+ * @retval #OS_SUCCESS on creating the disk
  */
 int32           OS_mkfs        (char *address, const char *devname, const char *volname,
                                 uint32 blocksize, uint32 numblocks);

--- a/src/os/portable/os-impl-posix-dirs.c
+++ b/src/os/portable/os-impl-posix-dirs.c
@@ -54,20 +54,20 @@ int32 OS_DirCreate_Impl(const char *local_path, uint32 access)
 
    if ( mkdir(local_path, S_IFDIR |S_IRWXU | S_IRWXG | S_IRWXO) < 0 )
    {
-      return_code = OS_FS_ERROR;
+      return_code = OS_ERROR;
 
       if (errno == EEXIST)
       {
          /* it exists, but not necessarily a directory */
          if ( stat(local_path, &st) == 0  && S_ISDIR(st.st_mode) )
          {
-            return_code = OS_FS_SUCCESS;
+            return_code = OS_SUCCESS;
          }
       }
    }
    else
    {
-      return_code = OS_FS_SUCCESS;
+      return_code = OS_SUCCESS;
    }
 
    return return_code;
@@ -86,9 +86,9 @@ int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
    OS_impl_dir_table[local_id] = opendir(local_path);
    if (OS_impl_dir_table[local_id] == NULL)
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirOpen_Impl */
                         
 /*----------------------------------------------------------------
@@ -103,7 +103,7 @@ int32 OS_DirClose_Impl(uint32 local_id)
 {
    closedir(OS_impl_dir_table[local_id]);
    OS_impl_dir_table[local_id] = NULL;
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirClose_Impl */
                         
 /*----------------------------------------------------------------
@@ -130,13 +130,13 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
    de = readdir(OS_impl_dir_table[local_id]);
    if (de == NULL)
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
 
    strncpy(dirent->FileName, de->d_name, OS_MAX_PATH_LEN - 1);
    dirent->FileName[OS_MAX_PATH_LEN - 1] = 0;
 
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirRead_Impl */
                         
 /*----------------------------------------------------------------
@@ -150,7 +150,7 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
 int32 OS_DirRewind_Impl(uint32 local_id)
 {
    rewinddir(OS_impl_dir_table[local_id]);
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirRewind_Impl */
                         
 /*----------------------------------------------------------------
@@ -165,8 +165,8 @@ int32 OS_DirRemove_Impl(const char *local_path)
 {
    if ( rmdir(local_path) < 0 )
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
 
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirRemove_Impl */

--- a/src/os/portable/os-impl-posix-files.c
+++ b/src/os/portable/os-impl-posix-files.c
@@ -67,7 +67,7 @@ int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int
           os_perm = O_RDWR;
            break;
        default:
-           return OS_FS_ERROR;
+           return OS_ERROR;
    }
 
    if (flags & OS_FILE_FLAG_CREATE)
@@ -88,7 +88,7 @@ int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int
    if (OS_impl_filehandle_table[local_id].fd < 0)
    {
        OS_DEBUG("open(%s): %s\n", local_path, strerror(errno));
-       return OS_FS_ERROR;
+       return OS_ERROR;
    }
 
    /*
@@ -98,7 +98,7 @@ int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int
    OS_impl_filehandle_table[local_id].selectable =
            ((os_perm & O_NONBLOCK) != 0);
 
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_FileOpen_Impl */
                         
 /*----------------------------------------------------------------
@@ -118,7 +118,7 @@ int32 OS_FileStat_Impl(const char *local_path, os_fstat_t *FileStats)
 
    if ( stat(local_path, &st) < 0 )
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
 
    FileStats->FileSize = st.st_size;
@@ -164,7 +164,7 @@ int32 OS_FileStat_Impl(const char *local_path, os_fstat_t *FileStats)
       FileStats->FileModeBits |= OS_FILESTAT_MODE_EXEC;
    }
 
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_FileStat_Impl */
 
                         
@@ -193,7 +193,7 @@ int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
      */
     if ( stat(local_path, &st) < 0 )
     {
-       return OS_FS_ERROR;
+       return OS_ERROR;
     }
 
     /* always check world bits */
@@ -239,7 +239,7 @@ int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
     /* finally, write the modified mode back to the file */
     if ( chmod(local_path, st.st_mode) < 0 )
     {
-        return OS_FS_ERROR;
+        return OS_ERROR;
     }
 
     return OS_SUCCESS;

--- a/src/os/portable/os-impl-posix-io.c
+++ b/src/os/portable/os-impl-posix-io.c
@@ -68,7 +68,7 @@ int32 OS_GenericClose_Impl(uint32 local_id)
        OS_DEBUG("close: %s\n",strerror(errno));
    }
    OS_impl_filehandle_table[local_id].fd = -1;
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_GenericClose_Impl */
                         
 /*----------------------------------------------------------------
@@ -96,7 +96,7 @@ int32 OS_GenericSeek_Impl (uint32 local_id, int32 offset, uint32 whence)
       where = SEEK_END;
       break;
    default:
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
 
    result = lseek(OS_impl_filehandle_table[local_id].fd, (off_t)offset, where);
@@ -111,7 +111,7 @@ int32 OS_GenericSeek_Impl (uint32 local_id, int32 offset, uint32 whence)
             * Use a different error code to differentiate from an
             * error involving a bad whence/offset
             */
-           result = OS_FS_UNIMPLEMENTED;
+           result = OS_ERR_NOT_IMPLEMENTED;
        }
        else
        {
@@ -119,7 +119,7 @@ int32 OS_GenericSeek_Impl (uint32 local_id, int32 offset, uint32 whence)
             * Most likely the "whence" and/or "offset" combo was not valid.
             */
            OS_DEBUG("lseek: %s\n",strerror(errno));
-           result = OS_FS_ERROR;
+           result = OS_ERROR;
        }
    }
 

--- a/src/os/posix/osfilesys.c
+++ b/src/os/posix/osfilesys.c
@@ -260,7 +260,7 @@ int32 OS_FileSysMountVolume_Impl (uint32 filesys_id)
     }
 
 
-    return OS_FS_SUCCESS;
+    return OS_SUCCESS;
 
 } /* end OS_FileSysMountVolume_Impl */
 
@@ -281,7 +281,7 @@ int32 OS_FileSysUnmountVolume_Impl (uint32 filesys_id)
      * This is a no-op.  The mount point that was created during
      * the mount process can stay for the next mount.
      */
-    return OS_FS_SUCCESS;
+    return OS_SUCCESS;
 
 } /* end OS_FileSysUnmountVolume_Impl */
 
@@ -307,7 +307,7 @@ int32 OS_FileSysStatVolume_Impl (uint32 filesys_id, OS_statvfs_t *result)
    result->blocks_free = stat_buf.f_bfree;
    result->total_blocks = stat_buf.f_blocks;
 
-   return(OS_FS_SUCCESS);
+   return(OS_SUCCESS);
 } /* end OS_FileSysStatVolume_Impl */
 
 

--- a/src/os/rtems/osfileapi.c
+++ b/src/os/rtems/osfileapi.c
@@ -176,7 +176,7 @@ int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char *Cmd)
 
    if (Result != 0)
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
    return OS_SUCCESS;
 } /* end OS_ShellOutputToFile_Impl */

--- a/src/os/rtems/osfilesys.c
+++ b/src/os/rtems/osfilesys.c
@@ -159,14 +159,14 @@ int32 OS_FileSysStartVolume_Impl (uint32 filesys_id)
            OS_DEBUG("OSAL: Error: RAM disk too large, %lu blocks requested, %lu available.\n",
                    (unsigned long)local->numblocks,
                    (unsigned long)rtems_ramdisk_configuration[os_idx].block_num);
-           return_code = OS_FS_ERROR;
+           return_code = OS_ERROR;
            break;
         }
         if ( local->blocksize != rtems_ramdisk_configuration[os_idx].block_size )
         {
            OS_DEBUG("OSAL: Error: RAM Disk needs a block size of %lu.\n",
                    (unsigned long)rtems_ramdisk_configuration[os_idx].block_size);
-           return_code = OS_FS_ERROR;
+           return_code = OS_ERROR;
            break;
         }
 
@@ -326,7 +326,7 @@ int32 OS_FileSysMountVolume_Impl (uint32 filesys_id)
     {
         OS_DEBUG("OSAL: Error: mount of %s to %s failed: %s\n",
                 impl->blockdev_name, local->system_mountpt, strerror(errno));
-        return OS_FS_ERROR;
+        return OS_ERROR;
     }
 
     return OS_SUCCESS;
@@ -352,7 +352,7 @@ int32 OS_FileSysUnmountVolume_Impl (uint32 filesys_id)
     if ( unmount(local->system_mountpt) < 0)
     {
        OS_DEBUG("OSAL: RTEMS unmount of %s failed :%s\n",local->system_mountpt, strerror(errno));
-       return OS_FS_ERROR;
+       return OS_ERROR;
     }
 
     return OS_SUCCESS;
@@ -375,14 +375,14 @@ int32 OS_FileSysStatVolume_Impl (uint32 filesys_id, OS_statvfs_t *result)
 
    if ( statvfs(local->system_mountpt, &stat_buf) != 0 )
    {
-       return OS_FS_ERROR;
+       return OS_ERROR;
    }
 
    result->block_size = stat_buf.f_bsize;
    result->blocks_free = stat_buf.f_bfree;
    result->total_blocks = stat_buf.f_blocks;
 
-   return(OS_FS_SUCCESS);
+   return(OS_SUCCESS);
 } /* end OS_FileSysStatVolume_Impl */
 
 

--- a/src/os/shared/osapi-dir.c
+++ b/src/os/shared/osapi-dir.c
@@ -105,7 +105,7 @@ int32 OS_mkdir (const char *path, uint32 access)
    char local_path[OS_MAX_LOCAL_PATH_LEN];
 
    return_code = OS_TranslatePath(path, local_path);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_DirCreate_Impl(local_path, access);
    }
@@ -136,7 +136,7 @@ int32 OS_DirectoryOpen(uint32 *dir_id, const char *path)
     }
 
     return_code = OS_TranslatePath(path, local_path);
-    if (return_code == OS_FS_SUCCESS)
+    if (return_code == OS_SUCCESS)
     {
        /* Note - the common ObjectIdAllocate routine will lock the object type and leave it locked. */
        return_code = OS_ObjectIdAllocateNew(LOCAL_OBJID_TYPE, NULL, &local_id, &record);
@@ -209,7 +209,7 @@ int32 OS_DirectoryRead(uint32 dir_id, os_dirent_t *dirent)
 
    if (dirent == NULL)
    {
-       return OS_FS_ERR_INVALID_POINTER;
+       return OS_INVALID_POINTER;
    }
 
    /* Make sure the file descriptor is legit before using it */
@@ -275,7 +275,7 @@ int32  OS_rmdir (const char *path)
    char local_path [OS_MAX_LOCAL_PATH_LEN];
 
    return_code = OS_TranslatePath(path, local_path);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       OS_DirRemove_Impl(local_path);
    }
@@ -320,7 +320,7 @@ int32 OS_closedir (os_dirp_t directory)
 
     if (directory == NULL)
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
     dirdescptr.dirp = directory;
 

--- a/src/os/shared/osapi-file.c
+++ b/src/os/shared/osapi-file.c
@@ -69,7 +69,7 @@ static int32 OS_check_name_length(const char *path)
     char* name_ptr;
 
     if (path == NULL)
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
 
     if (strlen(path) > OS_MAX_PATH_LEN)
         return OS_FS_ERR_PATH_TOO_LONG;
@@ -77,7 +77,7 @@ static int32 OS_check_name_length(const char *path)
     /* checks to see if there is a '/' somewhere in the path */
     name_ptr = strrchr(path, '/');
     if (name_ptr == NULL)
-        return OS_FS_ERROR;
+        return OS_ERROR;
 
     /* strrchr returns a pointer to the last '/' char, so we advance one char */
     name_ptr = name_ptr + 1;
@@ -85,7 +85,7 @@ static int32 OS_check_name_length(const char *path)
     if( strlen(name_ptr) > OS_MAX_FILE_NAME)
         return OS_FS_ERR_NAME_TOO_LONG;
 
-    return OS_FS_SUCCESS;
+    return OS_SUCCESS;
 
 } /* end OS_check_name_length */
 
@@ -129,7 +129,7 @@ static int32 OS_OpenCreate(uint32 *filedes, const char *path, int32 flags, int32
    ** check if the name of the file is too long
    */
    return_code = OS_check_name_length(path);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       /*
       ** Translate the path
@@ -137,7 +137,7 @@ static int32 OS_OpenCreate(uint32 *filedes, const char *path, int32 flags, int32
       return_code = OS_TranslatePath(path, (char *)local_path);
    }
 
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       /* Note - the common ObjectIdAllocate routine will lock the object type and leave it locked. */
       return_code = OS_ObjectIdAllocateNew(LOCAL_OBJID_TYPE, NULL, &local_id, &record);
@@ -184,12 +184,12 @@ int32 OS_creat  (const char *path, int32  access)
        case OS_READ_ONLY:
        default:
           /* Read only does not make sense for creat() */
-          return OS_FS_ERROR;
+          return OS_ERROR;
    }
 
 
    return_code = OS_OpenCreate(&filedes, path, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, access);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = (int32)filedes;
    }
@@ -221,12 +221,12 @@ int32 OS_open   (const char *path,  int32 access,  uint32  mode)
        case OS_READ_ONLY:
            break;
        default:
-          return OS_FS_ERROR;
+          return OS_ERROR;
    }
 
 
    return_code = OS_OpenCreate(&filedes, path, OS_FILE_FLAG_NONE, access);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = (int32)filedes;
    }
@@ -376,7 +376,7 @@ int32 OS_chmod  (const char *path, uint32 access)
     int32 return_code;
 
     return_code = OS_TranslatePath(path, local_path);
-    if (return_code == OS_FS_SUCCESS)
+    if (return_code == OS_SUCCESS)
     {
        return_code = OS_FileChmod_Impl(local_path, access);
     }
@@ -407,7 +407,7 @@ int32 OS_stat   (const char *path, os_fstat_t *filestats)
    memset(filestats, 0, sizeof(*filestats));
 
    return_code = OS_TranslatePath(path, local_path);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_FileStat_Impl(local_path, filestats);
    }
@@ -456,10 +456,10 @@ int32 OS_remove (const char *path)
    char local_path[OS_MAX_LOCAL_PATH_LEN];
 
    return_code = OS_check_name_length(path);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_TranslatePath(path, local_path);
-      if (return_code == OS_FS_SUCCESS)
+      if (return_code == OS_SUCCESS)
       {
          return_code = OS_FileRemove_Impl(local_path);
       }
@@ -486,25 +486,25 @@ int32 OS_rename (const char *old, const char *new)
    char new_path[OS_MAX_LOCAL_PATH_LEN];
 
    return_code = OS_check_name_length(old);
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_check_name_length(new);
    }
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_TranslatePath(old, old_path);
    }
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_TranslatePath(new, new_path);
    }
 
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       return_code = OS_FileRename_Impl(old_path, new_path);
    }
 
-   if (return_code == OS_FS_SUCCESS)
+   if (return_code == OS_SUCCESS)
    {
       OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
       for ( i =0; i < OS_MAX_NUM_OPEN_FILES; i++)
@@ -547,7 +547,7 @@ int32 OS_cp (const char *src, const char *dest)
         return OS_INVALID_POINTER;
     }
 
-    return_code = OS_FS_SUCCESS;
+    return_code = OS_SUCCESS;
     file2 = -1;
     file1 = OS_open(src, OS_READ_ONLY, 0);
     if (file1 < 0)
@@ -563,7 +563,7 @@ int32 OS_cp (const char *src, const char *dest)
        }
     }
 
-    while (return_code == OS_FS_SUCCESS)
+    while (return_code == OS_SUCCESS)
     {
        rd_size = OS_read((uint32)file1, copyblock, sizeof(copyblock));
        if (rd_size < 0)
@@ -616,10 +616,10 @@ int32 OS_mv (const char *src, const char *dest)
 
    /* First try rename - this only works if it is on the same filesystem */
    return_code = OS_rename(src, dest);
-   if (return_code != OS_FS_SUCCESS)
+   if (return_code != OS_SUCCESS)
    {
       return_code = OS_cp(src, dest);
-      if (return_code == OS_FS_SUCCESS)
+      if (return_code == OS_SUCCESS)
       {
          OS_remove(src);
       }
@@ -649,7 +649,7 @@ int32 OS_FDGetInfo (uint32 filedes, OS_file_prop_t *fd_prop)
    /* Check parameters */
    if (fd_prop == NULL)
    {
-       return(OS_FS_ERR_INVALID_POINTER);
+       return(OS_INVALID_POINTER);
    }
 
    memset(fd_prop,0,sizeof(OS_file_prop_t));
@@ -684,10 +684,10 @@ int32 OS_FileOpenCheck(const char *Filename)
 
    if (Filename == NULL)
    {
-      return(OS_FS_ERR_INVALID_POINTER);
+      return(OS_INVALID_POINTER);
    }
 
-   return_code = OS_FS_ERROR;
+   return_code = OS_ERROR;
 
    OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
 
@@ -697,7 +697,7 @@ int32 OS_FileOpenCheck(const char *Filename)
             OS_stream_table[i].socket_domain == OS_SocketDomain_INVALID &&
             (strcmp(OS_stream_table[i].stream_name, Filename) == 0))
       {
-         return_code = OS_FS_SUCCESS;
+         return_code = OS_SUCCESS;
          break;
       }
    }/* end for */
@@ -725,7 +725,7 @@ int32 OS_CloseFileByName(const char *Filename)
 
    if (Filename == NULL)
    {
-      return(OS_FS_ERR_INVALID_POINTER);
+      return(OS_INVALID_POINTER);
    }
 
    return_code = OS_FS_ERR_PATH_INVALID;
@@ -739,11 +739,11 @@ int32 OS_CloseFileByName(const char *Filename)
             (strcmp(OS_stream_table[i].stream_name, Filename) == 0))
       {
          close_code = OS_GenericClose_Impl(i);
-         if (close_code == OS_FS_SUCCESS)
+         if (close_code == OS_SUCCESS)
          {
              OS_global_stream_table[i].active_id = 0;
          }
-         if (return_code == OS_FS_ERR_PATH_INVALID || close_code != OS_FS_SUCCESS)
+         if (return_code == OS_FS_ERR_PATH_INVALID || close_code != OS_SUCCESS)
          {
             return_code = close_code;
          }
@@ -771,7 +771,7 @@ int32 OS_CloseAllFiles(void)
    int32 close_code;
    uint32  i;
 
-   return_code = OS_FS_SUCCESS;
+   return_code = OS_SUCCESS;
 
    OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
 
@@ -780,11 +780,11 @@ int32 OS_CloseAllFiles(void)
       if (OS_global_stream_table[i].active_id != 0)
       {
          close_code = OS_GenericClose_Impl(i);
-         if (close_code == OS_FS_SUCCESS)
+         if (close_code == OS_SUCCESS)
          {
              OS_global_stream_table[i].active_id = 0;
          }
-         if (close_code != OS_FS_SUCCESS)
+         if (close_code != OS_SUCCESS)
          {
             return_code = close_code;
          }
@@ -815,7 +815,7 @@ int32 OS_ShellOutputToFile(const char* Cmd, uint32 filedes)
    /* Check Parameters */
    if (Cmd == NULL)
    {
-       return OS_FS_ERR_INVALID_POINTER;
+       return OS_INVALID_POINTER;
    }
 
    return_code = OS_ObjectIdGetById(OS_LOCK_MODE_REFCOUNT, LOCAL_OBJID_TYPE, filedes, &local_id, &record);

--- a/src/os/shared/osapi-filesys.c
+++ b/src/os/shared/osapi-filesys.c
@@ -237,7 +237,7 @@ static int32 OS_FileSys_SetupInitialParamsForDevice(const char *devname, OS_file
  *           Implements Common code between the mkfs and initfs calls -
  *           mkfs passes the "should_format" as true and initfs passes as false.
  *
- *  Returns: OS_FS_SUCCESS on creating the disk, or appropriate error code.
+ *  Returns: OS_SUCCESS on creating the disk, or appropriate error code.
  *
  *-----------------------------------------------------------------*/
 static int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char * fsvolname, uint32 blocksize,
@@ -253,7 +253,7 @@ static int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const c
     */
     if ( fsdevname == NULL || fsvolname == NULL )
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     /* check names are not empty strings */
@@ -541,7 +541,7 @@ int32 OS_rmfs (const char *devname)
 
     if ( devname == NULL )
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     if ( strlen(devname) >= OS_MAX_API_NAME )
@@ -634,7 +634,7 @@ int32 OS_mount (const char *devname, const char* mountpoint)
     /* Check parameters */
     if ( devname == NULL || mountpoint == NULL )
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     if( strlen(devname) >= sizeof(local->device_name) ||
@@ -712,7 +712,7 @@ int32 OS_unmount (const char *mountpoint)
     /* Check parameters */
     if ( mountpoint == NULL )
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     if( strlen(mountpoint) >= sizeof(local->virtual_mountpt) )
@@ -789,7 +789,7 @@ int32 OS_fsBlocksFree (const char *name)
 
     if ( name == NULL )
     {
-        return(OS_FS_ERR_INVALID_POINTER);
+        return(OS_INVALID_POINTER);
     }
 
     if( strlen(name) >= OS_MAX_PATH_LEN )
@@ -841,7 +841,7 @@ int32 OS_fsBytesFree (const char *name, uint64 *bytes_free)
 
     if ( name == NULL || bytes_free == NULL )
     {
-        return(OS_FS_ERR_INVALID_POINTER);
+        return(OS_INVALID_POINTER);
     }
 
     if( strlen(name) >= OS_MAX_PATH_LEN )
@@ -896,7 +896,7 @@ int32 OS_chkfs (const char *name, bool repair)
     */
     if (name == NULL)
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     /*
@@ -942,7 +942,7 @@ int32 OS_FS_GetPhysDriveName(char * PhysDriveName, const char * MountPoint)
 
     if (MountPoint == NULL || PhysDriveName == NULL)
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     if( strlen(MountPoint) >= OS_MAX_PATH_LEN )
@@ -999,7 +999,7 @@ int32 OS_GetFsInfo(os_fsinfo_t  *filesys_info)
    */
    if (filesys_info == NULL)
    {
-       return OS_FS_ERR_INVALID_POINTER;
+       return OS_INVALID_POINTER;
    }
 
    memset(filesys_info, 0, sizeof(*filesys_info));
@@ -1031,7 +1031,7 @@ int32 OS_GetFsInfo(os_fsinfo_t  *filesys_info)
 
    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_FILESYS);
 
-   return(OS_FS_SUCCESS);
+   return(OS_SUCCESS);
 } /* end OS_GetFsInfo */
 
                         
@@ -1058,7 +1058,7 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
     */
     if (VirtualPath == NULL || LocalPath == NULL)
     {
-        return OS_FS_ERR_INVALID_POINTER;
+        return OS_INVALID_POINTER;
     }
 
     SysMountPointLen = 0;

--- a/src/os/vxworks/osfileapi.c
+++ b/src/os/vxworks/osfileapi.c
@@ -110,11 +110,11 @@ int32 OS_DirCreate_Impl(const char *local_path, uint32 access)
 
    if ( mkdir(local_path) != OK )
    {
-      return_code = OS_FS_ERROR;
+      return_code = OS_ERROR;
    }
    else
    {
-      return_code = OS_FS_SUCCESS;
+      return_code = OS_SUCCESS;
    }
 
    return return_code;
@@ -133,9 +133,9 @@ int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
    OS_impl_dir_table[local_id] = opendir(local_path);
    if (OS_impl_dir_table[local_id] == NULL)
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirOpen_Impl */
                         
 /*----------------------------------------------------------------
@@ -150,7 +150,7 @@ int32 OS_DirClose_Impl(uint32 local_id)
 {
    closedir(OS_impl_dir_table[local_id]);
    OS_impl_dir_table[local_id] = NULL;
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirClose_Impl */
                         
 /*----------------------------------------------------------------
@@ -177,13 +177,13 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
    de = readdir(OS_impl_dir_table[local_id]);
    if (de == NULL)
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
 
    strncpy(dirent->FileName, de->d_name, OS_MAX_PATH_LEN - 1);
    dirent->FileName[OS_MAX_PATH_LEN - 1] = 0;
 
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirRead_Impl */
                         
 /*----------------------------------------------------------------
@@ -197,7 +197,7 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
 int32 OS_DirRewind_Impl(uint32 local_id)
 {
    rewinddir(OS_impl_dir_table[local_id]);
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirRewind_Impl */
                         
 /*----------------------------------------------------------------
@@ -212,10 +212,10 @@ int32 OS_DirRemove_Impl(const char *local_path)
 {
    if ( rmdir(local_path) < 0 )
    {
-      return OS_FS_ERROR;
+      return OS_ERROR;
    }
 
-   return OS_FS_SUCCESS;
+   return OS_SUCCESS;
 } /* end OS_DirRemove_Impl */
 
 
@@ -280,7 +280,7 @@ int32 OS_VxWorks_DirAPI_Impl_Init(void)
  *-----------------------------------------------------------------*/
 int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char *Cmd)
 {
-    int32 ReturnCode = OS_FS_ERROR;
+    int32 ReturnCode = OS_ERROR;
     int32 Result = ERROR;
     int32 fdCmd;
     uint32 cmdidx;
@@ -289,9 +289,9 @@ int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char *Cmd)
     /* Create a file to write the command to (or write over the old one) */
     fdCmd = OS_creat(OS_SHELL_CMD_INPUT_FILE_NAME,OS_READ_WRITE);
 
-    if (fdCmd < OS_FS_SUCCESS)
+    if (fdCmd < OS_SUCCESS)
     {
-        return OS_FS_ERROR;
+        return OS_ERROR;
     }
 
     if (OS_ConvertToArrayIndex(fdCmd, &cmdidx) == OS_SUCCESS)

--- a/src/os/vxworks/osfilesys.c
+++ b/src/os/vxworks/osfilesys.c
@@ -252,7 +252,7 @@ int32 OS_FileSysMountVolume_Impl (uint32 filesys_id)
     fd = open ( local->system_mountpt, O_RDONLY, 0644 );
     if ( fd < 0 )
     {
-        status = OS_FS_ERROR;
+        status = OS_ERROR;
     }
     else
     {
@@ -285,13 +285,13 @@ int32 OS_FileSysUnmountVolume_Impl (uint32 filesys_id)
     fd = open ( local->system_mountpt, O_RDONLY, 0644 );
     if ( fd < 0 )
     {
-        status = OS_FS_ERROR;
+        status = OS_ERROR;
     }
     else
     {
         if ( ioctl( fd, FIOUNMOUNT,0) < 0 )
         {
-            status = OS_FS_ERROR;
+            status = OS_ERROR;
         }
         else
         {
@@ -322,7 +322,7 @@ int32 OS_FileSysStatVolume_Impl (uint32 filesys_id, OS_statvfs_t *result)
 
    if (statfs(local->system_mountpt, &stat_buf) != 0)
    {
-       return_code = OS_FS_ERROR;
+       return_code = OS_ERROR;
        memset(result, 0, sizeof(*result));
    }
    else
@@ -330,7 +330,7 @@ int32 OS_FileSysStatVolume_Impl (uint32 filesys_id, OS_statvfs_t *result)
        result->block_size = stat_buf.f_bsize;
        result->blocks_free = stat_buf.f_bfree;
        result->total_blocks = stat_buf.f_blocks;
-       return_code = OS_FS_SUCCESS;
+       return_code = OS_SUCCESS;
    }
 
    return return_code;
@@ -357,7 +357,7 @@ int32 OS_FileSysCheckVolume_Impl (uint32 filesys_id, bool repair)
     fd = open (local->system_mountpt, O_RDONLY, 0);
     if (fd < 0)
     {
-        return OS_FS_ERROR;
+        return OS_ERROR;
     }
 
     /* Fix the disk if there are errors */
@@ -378,10 +378,10 @@ int32 OS_FileSysCheckVolume_Impl (uint32 filesys_id, bool repair)
 
     if (chk_status != OK)
     {
-        return OS_FS_ERROR;
+        return OS_ERROR;
     }
 
-    return OS_FS_SUCCESS;
+    return OS_SUCCESS;
 
 } /* end OS_FileSysCheckVolume_Impl */
 

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -544,7 +544,7 @@ void TestOpenReadCloseDir(void)
     UtAssert_True(status == OS_SUCCESS, "DIRECTORY_ONE found");
 
     /* Advance to end of dir */
-    while (status == OS_FS_SUCCESS)
+    while (status == OS_SUCCESS)
     {
        status = OS_DirectoryRead(dirh, &dirent);
     }
@@ -756,7 +756,7 @@ void TestRename(void)
     size  = strlen(copybuffer1);
     status = OS_read(fd1,buffer1,size);
     UtAssert_True(status == size, "status after read 1 = %d size = %d",(int)status, (int)size);
-    if (status >= OS_FS_SUCCESS)
+    if (status >= OS_SUCCESS)
     {
         UtAssert_True(strncmp(buffer1,copybuffer1, size) == 0, "Read and Written Results are equal");
     }

--- a/src/unit-test-coverage/portable/coveragetest-posixfile.c
+++ b/src/unit-test-coverage/portable/coveragetest-posixfile.c
@@ -56,7 +56,7 @@ void Test_OS_FileOpen_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl(0,"local",OS_FILE_FLAG_TRUNCATE,OS_WRITE_ONLY), OS_SUCCESS);
     OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl(0,"local",0,OS_READ_ONLY), OS_SUCCESS);
     OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl(0,"local",OS_FILE_FLAG_CREATE,OS_READ_WRITE), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl(0,"local",0,-1234), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl(0,"local",0,-1234), OS_ERROR);
 
 
     /* failure mode */

--- a/src/unit-test-coverage/portable/coveragetest-posixio.c
+++ b/src/unit-test-coverage/portable/coveragetest-posixio.c
@@ -78,15 +78,15 @@ void Test_OS_GenericSeek_Impl (void)
     OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,OS_SEEK_END), 333);
 
     /* bad whence */
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,-1234), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,-1234), OS_ERROR);
 
     /* generic failure of lseek() */
     UT_SetForceFail(UT_KEY(OCS_lseek),-1);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,OS_SEEK_END), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,OS_SEEK_END), OS_ERROR);
 
     /* The seek implementation also checks for this specific pipe errno */
     OCS_errno = OCS_ESPIPE;
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,OS_SEEK_END), OS_FS_UNIMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl,(0,0,OS_SEEK_END), OS_ERR_NOT_IMPLEMENTED);
 }
 
 void Test_OS_GenericRead_Impl (void)

--- a/src/unit-test-coverage/shared/src/coveragetest-file.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-file.c
@@ -56,10 +56,10 @@ void Test_OS_creat(void)
     UtAssert_True(actual >= 0, "OS_creat() (%ld) >= 0", (long)actual);
 
     actual = OS_creat("/cf/file", OS_READ_ONLY);
-    UtAssert_True(actual == OS_FS_ERROR, "OS_creat() (%ld) == OS_FS_ERROR", (long)actual);
+    UtAssert_True(actual == OS_ERROR, "OS_creat() (%ld) == OS_ERROR", (long)actual);
 
     actual = OS_creat(NULL, OS_WRITE_ONLY);
-    UtAssert_True(actual == OS_FS_ERR_INVALID_POINTER, "OS_creat() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == OS_INVALID_POINTER, "OS_creat() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_PATH_LEN);
     actual = OS_creat("/file", OS_WRITE_ONLY);
@@ -68,7 +68,7 @@ void Test_OS_creat(void)
 
     UT_SetForceFail(UT_KEY(OCS_strrchr), -1);
     actual = OS_creat("/file", OS_WRITE_ONLY);
-    UtAssert_True(actual == OS_FS_ERROR, "OS_creat() (%ld) == OS_FS_ERROR", (long)actual);
+    UtAssert_True(actual == OS_ERROR, "OS_creat() (%ld) == OS_ERROR", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strrchr));
 
     UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 2, 2 + OS_MAX_FILE_NAME);
@@ -280,12 +280,12 @@ void Test_OS_cp(void)
      * Test Case For:
      * int32 OS_cp (const char *src, const char *dest)
      */
-    int32 expected = OS_FS_ERR_INVALID_POINTER;
+    int32 expected = OS_INVALID_POINTER;
     int32 actual = OS_cp(NULL,NULL);
     char ReadBuf[] = "cpcpcpcp";
     char WriteBuf[sizeof(ReadBuf)] = "";
 
-    UtAssert_True(actual == expected, "OS_cp() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_cp() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     /* setup to make internal copy loop execute at least once */
     expected = OS_SUCCESS;
@@ -308,7 +308,7 @@ void Test_OS_cp(void)
     UtAssert_True(actual == expected, "OS_cp() (%ld) == -555", (long)actual);
 
     UT_SetDeferredRetcode(UT_KEY(OCS_strrchr), 1, -1);
-    expected = OS_FS_ERROR;
+    expected = OS_ERROR;
     actual = OS_cp("/cf/file1", "/cf/file2");
     UtAssert_True(actual == expected, "OS_cp() (%ld) == OS_INVALID_POINTER", (long)actual);
     UT_SetDeferredRetcode(UT_KEY(OCS_strrchr), 2, -1);
@@ -362,9 +362,9 @@ void Test_OS_FDGetInfo(void)
     UtAssert_True(strcmp(file_prop.Path, "ABC") == 0, "file_prop.Path (%s) == ABC",
             file_prop.Path);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_FDGetInfo(1, NULL);
-    UtAssert_True(actual == expected, "OS_FDGetInfo() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_FDGetInfo() (%ld) == OS_INVALID_POINTER", (long)actual);
 
 }
 
@@ -374,10 +374,10 @@ void Test_OS_FileOpenCheck(void)
      * Test Case For:
      * int32 OS_FileOpenCheck(const char *Filename)
      */
-    int32 expected = OS_FS_ERROR;
+    int32 expected = OS_ERROR;
     int32 actual = OS_FileOpenCheck("/cf/file");
 
-    UtAssert_True(actual == expected, "OS_FileOpenCheck() (%ld) == OS_FS_ERROR", (long)actual);
+    UtAssert_True(actual == expected, "OS_FileOpenCheck() (%ld) == OS_ERROR", (long)actual);
 
     OS_global_stream_table[0].active_id = 1;
     UT_SetForceFail(UT_KEY(OCS_strcmp), 0);
@@ -386,9 +386,9 @@ void Test_OS_FileOpenCheck(void)
 
     UtAssert_True(actual == expected, "OS_FileOpenCheck() (%ld) == OS_SUCCESS", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_FileOpenCheck(NULL);
-    UtAssert_True(actual == expected, "OS_FDGetInfo() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_FDGetInfo() (%ld) == OS_INVALID_POINTER", (long)actual);
 
 }
 
@@ -411,9 +411,9 @@ void Test_OS_CloseFileByName(void)
     actual = OS_CloseFileByName("/cf/file");
     UtAssert_True(actual == expected, "OS_CloseFileByName() (%ld) == OS_SUCCESS", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_CloseFileByName(NULL);
-    UtAssert_True(actual == expected, "OS_CloseFileByName() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_CloseFileByName() (%ld) == OS_INVALID_POINTER", (long)actual);
 
 }
 
@@ -448,7 +448,7 @@ void Test_OS_ShellOutputToFile(void)
     UtAssert_True(actual == expected, "OS_ShellOutputToFile() (%ld) == OS_SUCCESS", (long)actual);
 
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_ShellOutputToFile(NULL, 1);
 
     UtAssert_True(actual == expected, "OS_ShellOutputToFile() (%ld) == OS_SUCCESS", (long)actual);

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -92,9 +92,9 @@ void Test_OS_mkfs(void)
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_SUCCESS", (long)actual);
 
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_mkfs(NULL,NULL,NULL,0,0);
-    UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -139,9 +139,9 @@ void Test_OS_rmfs(void)
     UtAssert_True(actual == expected, "OS_rmfs() (%ld) == OS_ERR_NAME_NOT_FOUND", (long)actual);
     UT_ClearForceFail(UT_KEY(OS_ObjectIdGetByName));
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_rmfs(NULL);
-    UtAssert_True(actual == expected, "OS_rmfs() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_rmfs() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -168,9 +168,9 @@ void Test_OS_initfs(void)
     actual = OS_initfs(NULL,"/hda2","vol2",0,0);
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_SUCCESS", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_initfs(NULL,NULL,NULL,0,0);
-    UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -213,9 +213,9 @@ void Test_OS_mount(void)
     actual = OS_mount("/ramdev5","/ram5");
     UtAssert_True(actual == expected, "OS_mount(nominal) (%ld) == OS_SUCCESS", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_mount(NULL,NULL);
-    UtAssert_True(actual == expected, "OS_mount() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_mount() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -256,9 +256,9 @@ void Test_OS_unmount(void)
     actual = OS_unmount("/ram0");
     UtAssert_True(actual == expected, "OS_unmount(nominal) (%ld) == OS_SUCCESS", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_unmount(NULL);
-    UtAssert_True(actual == expected, "OS_unmount() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_unmount() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_PATH_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -287,9 +287,9 @@ void Test_OS_fsBlocksFree(void)
     actual = OS_fsBlocksFree("/cf");
     UtAssert_True(actual == expected, "OS_fsBlocksFree() (%ld) == 1111", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_fsBlocksFree(NULL);
-    UtAssert_True(actual == expected, "OS_fsBlocksFree() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_fsBlocksFree() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_PATH_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -329,9 +329,9 @@ void Test_OS_fsBytesFree(void)
     UtAssert_True(bytes_free == (1024*1111), "bytes_free (%lu) == (1024*1111)",
             (unsigned long)bytes_free);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_fsBytesFree(NULL, NULL);
-    UtAssert_True(actual == expected, "OS_fsBytesFree() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_fsBytesFree() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_PATH_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -361,9 +361,9 @@ void Test_OS_chkfs(void)
     actual = OS_chkfs("/cf",true);
     UtAssert_True(actual == expected, "OS_chkfs() (%ld) == OS_SUCCESS", (long)actual);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_chkfs(NULL,false);
-    UtAssert_True(actual == expected, "OS_fsBytesFree() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_fsBytesFree() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_PATH_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -385,11 +385,11 @@ void Test_OS_FS_GetPhysDriveName(void)
      * Test Case For:
      * int32 OS_FS_GetPhysDriveName(char * PhysDriveName, const char * MountPoint)
      */
-    int32 expected = OS_FS_ERR_INVALID_POINTER;
+    int32 expected = OS_INVALID_POINTER;
     int32 actual = OS_FS_GetPhysDriveName(NULL, NULL);
     char NameBuf[OS_FS_PHYS_NAME_LEN];
 
-    UtAssert_True(actual == expected, "OS_FS_GetPhysDriveName() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_FS_GetPhysDriveName() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), OS_MAX_PATH_LEN + 10);
     expected = OS_FS_ERR_PATH_TOO_LONG;
@@ -444,9 +444,9 @@ void Test_OS_GetFsInfo(void)
             "filesys_info.FreeVolumes (%lu) == OS_MAX_FILE_SYSTEMS",
             (unsigned long)filesys_info.FreeVolumes);
 
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_GetFsInfo(NULL);
-    UtAssert_True(actual == expected, "OS_GetFsInfo() (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_GetFsInfo() (%ld) == OS_INVALID_POINTER", (long)actual);
 
 }
 
@@ -470,9 +470,9 @@ void Test_OS_TranslatePath(void)
     UtAssert_True(strcmp(LocalBuffer,"/mnt/cf/test") == 0, "OS_TranslatePath(/cf/test) (%s)  == /mnt/cf/test", LocalBuffer);
 
     /* Check various error paths */
-    expected = OS_FS_ERR_INVALID_POINTER;
+    expected = OS_INVALID_POINTER;
     actual = OS_TranslatePath(NULL, NULL);
-    UtAssert_True(actual == expected, "OS_TranslatePath(NULL,NULL) (%ld) == OS_FS_ERR_INVALID_POINTER", (long)actual);
+    UtAssert_True(actual == expected, "OS_TranslatePath(NULL,NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), OS_MAX_PATH_LEN + 10);
     expected = OS_FS_ERR_PATH_TOO_LONG;

--- a/src/unit-test-coverage/vxworks/src/coveragetest-osfilesys.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-osfilesys.c
@@ -107,7 +107,7 @@ void Test_OS_FileSysMountVolume_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysMountVolume_Impl(0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_open), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysMountVolume_Impl(0), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysMountVolume_Impl(0), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_open));
 }
 
@@ -121,11 +121,11 @@ void Test_OS_FileSysUnmountVolume_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_open), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(0), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(0), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_open));
 
     UT_SetForceFail(UT_KEY(OCS_ioctl), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(0), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(0), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_ioctl));
 }
 
@@ -139,7 +139,7 @@ void Test_OS_FileSysStatVolume_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStatVolume_Impl(0,&stat), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_statvfs), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysStatVolume_Impl(0,&stat), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysStatVolume_Impl(0,&stat), OS_ERROR);
 }
 
 void Test_OS_FileSysCheckVolume_Impl(void)
@@ -152,11 +152,11 @@ void Test_OS_FileSysCheckVolume_Impl(void)
 
 
     UT_SetForceFail(UT_KEY(OCS_open), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysCheckVolume_Impl(0,false), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysCheckVolume_Impl(0,false), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_open));
 
     UT_SetForceFail(UT_KEY(OCS_ioctl), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysCheckVolume_Impl(0,false), OS_FS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysCheckVolume_Impl(0,false), OS_ERROR);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -57,22 +57,22 @@ void UT_os_read_n_sort_dirs(uint32);
 ** Purpose: Creates a directory specified by path
 ** Parameters: *path - pointer to the absolute pathname of the directory to be created
 **             access - directory access mode (unused)
-** Returns: OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
-**          OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
+** Returns: OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
+**          OS_INVALID_POINTER if the pointer passed in is null
 **          OS_FS_ERR_PATH_TOO_LONG if the path is too long
 **          OS_FS_ERR_PATH_INVALID if the path is invalid
-**          OS_FS_ERROR if the OS call failed
+**          OS_ERROR if the OS call failed
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with a really long path as argument
@@ -88,12 +88,12 @@ void UT_os_read_n_sort_dirs(uint32);
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #5: Nominal condition
 **   1) Call this routine to create a directory under /cf mount point
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_creat to create and open a file inside the directory created in #1
 **   4) Expect the returned value to be
 **        (a) a file descriptor value greater than or equal to 0
@@ -106,7 +106,7 @@ void UT_os_makedir_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_mkdir(NULL, 755) == OS_FS_UNIMPLEMENTED)
+    if (OS_mkdir(NULL, 755) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_makedir_test_exit_tag;
@@ -115,7 +115,7 @@ void UT_os_makedir_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_mkdir(NULL, 755) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_mkdir(NULL, 755) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -146,7 +146,7 @@ void UT_os_makedir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/mkdir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -177,14 +177,14 @@ UT_os_makedir_test_exit_tag:
 ** Parameters: *dir_id - pointer to directory id (set by this function)
 **             *path - pointer to the absolute pathname of the directory to be opened
 ** Returns: OS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 **          OS_INVALID_POINTER if either pointer passed in is NULL
 **          OS_TranslatePath error response if failed
 **          OS_ObjectIdAllocateNew error response if failed
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
@@ -211,7 +211,7 @@ UT_os_makedir_test_exit_tag:
 ** Test #5: Nominal condition
 **   1) Call OS_mkdir to create a directory under /cf mount point
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call this routine with directory name used in #1 as argument
 **   4) Expect the returned value to be
 **        (a) a directory descriptor pointer that is __not__ NULL
@@ -224,7 +224,7 @@ void UT_os_opendir_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_DirectoryOpen(&dirh, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_DirectoryOpen(&dirh, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_opendir_test_exit_tag;
@@ -264,7 +264,7 @@ void UT_os_opendir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/opendir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - Dir-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -290,31 +290,31 @@ UT_os_opendir_test_exit_tag:
 ** Purpose: Closes the specified directory for reading
 ** Parameters: dir_id - directory id that was returned from OS_DirectoryOpen()
 ** Returns: OS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 **          OS_ObjectIdGetById return if failed
 **          OS_DirClose_Impl return if failed
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: OS-call-failure condition
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #2: Nominal condition
 **   1) Call OS_mkdir() to create a directory under /cf mount point
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_DirectoryOpen() with directory name used in #1 as argument
 **   4) Expect the returned value to be
 **        (a) a non-zero directory id
 **   5) Call this routine with the directory descriptor pointer returned in #3 as argument
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_DirectoryRead() with the directory descriptor pointer returned in #3 as argument
 **   8) Expect to not get OS_SUCCESS (closed directory)
 **--------------------------------------------------------------------------------*/
@@ -327,7 +327,7 @@ void UT_os_closedir_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_DirectoryClose(0) == OS_FS_UNIMPLEMENTED)
+    if (OS_DirectoryClose(0) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_closedir_test_exit_tag;
@@ -343,7 +343,7 @@ void UT_os_closedir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/closeDir3", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
     {
         testDesc = "#2 Nominal - Dir-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -382,14 +382,14 @@ UT_os_closedir_test_exit_tag:
 ** Parameters: dir_id - directory id from OS_DirectoryOpen
 **             *dirent - pointer to the directory entry (set by this function)
 ** Returns: OS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
-**          OS_FS_ERR_INVALID_POINTER if pointer passed in is NULL
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
+**          OS_INVALID_POINTER if pointer passed in is NULL
 **          OS_ObjectIdGetById error response if failed
 **          OS_Unlock_Global_Impl error response if failed
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
@@ -406,7 +406,7 @@ UT_os_closedir_test_exit_tag:
 ** Test #3: Nominal condition
 **   1) Call OS_mkdir() to create a directory
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_DirectoryOpen() with directory name used in #1 as argument
 **   4) Expect the returned value to be
 **        (a) OS_SUCCESS
@@ -430,7 +430,7 @@ void UT_os_readdir_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_DirectoryRead(0, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_DirectoryRead(0, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_readdir_test_exit_tag;
@@ -439,7 +439,7 @@ void UT_os_readdir_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_DirectoryRead(0, NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_DirectoryRead(0, NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -454,7 +454,7 @@ void UT_os_readdir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/readdir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Dir-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -463,7 +463,7 @@ void UT_os_readdir_test()
 
     memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
     UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
-    if (OS_mkdir(g_subdirNames[0], 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_subdirNames[0], 755) != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Dir-create(subdir1) failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -473,7 +473,7 @@ void UT_os_readdir_test()
 
     memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
     UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
-    if (OS_mkdir(g_subdirNames[1], 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_subdirNames[1], 755) != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Dir-create(subdir2) failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -513,12 +513,12 @@ UT_os_readdir_test_exit_tag:
 ** Purpose: Rewinds the directory to the beginning
 ** Parameters: dir_id - directory id from OS_DirectoryOpen
 ** Returns: OS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 **          OS_ObjectIdGetById error response if failed
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: OS-call-failure condition
@@ -530,7 +530,7 @@ UT_os_readdir_test_exit_tag:
 ** Test #2: Nominal condition
 **   1) Call OS_mkdir() to create a directory
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_opendir() with directory name used in #1 as argument
 **   4) Expect the returned value to be
 **        (a) a directory descriptor pointer
@@ -559,7 +559,7 @@ void UT_os_rewinddir_test()
     /*-----------------------------------------------------*/
     testDesc = "API Not implemented";
 
-    if (OS_DirectoryRewind(0) == OS_FS_UNIMPLEMENTED)
+    if (OS_DirectoryRewind(0) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_rewinddir_test_exit_tag;
@@ -575,7 +575,7 @@ void UT_os_rewinddir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/rewinddir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
     {
         testDesc = "#2 Nominal - Dir-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -585,7 +585,7 @@ void UT_os_rewinddir_test()
 
     memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
     UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
-    if (OS_mkdir(g_subdirNames[0], 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_subdirNames[0], 755) != OS_SUCCESS)
     {
         testDesc = "#2 Nominal - Dir-create(subdir1) failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -595,7 +595,7 @@ void UT_os_rewinddir_test()
 
     memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
     UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
-    if (OS_mkdir(g_subdirNames[1], 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_subdirNames[1], 755) != OS_SUCCESS)
     {
         testDesc = "#2 Nominal - Dir-create(subdir2) failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -647,22 +647,22 @@ UT_os_rewinddir_test_exit_tag:
 ** Syntax: int32 OS_rmdir(const char *path)
 ** Purpose: Removes the specified directory
 ** Parameters: *path - pointer to the absolute pathname of the directory to be removed
-** Returns: OS_FS_ERR_INVALID_POINTER if pointer passed in is NULL
+** Returns: OS_INVALID_POINTER if pointer passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if path is too long
 **          OS_FS_ERR_PATH_INVALID if path is invalid
-**          OS_FS_ERROR if OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERROR if OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with a really long path as argument
@@ -678,18 +678,18 @@ UT_os_rewinddir_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #5: Nominal condition
 **   1) Call OS_mkdir to create a directory under /cf mount point
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_creat() to create and open a file under the directory created in #1
 **   4) Expect the returned value to be
 **        (a) a file descriptor value greater than or equal to 0
 **   5) Call this routine with directory name used in #1
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_close() with the file descriptor returned in #3 as argument
 **   8) Call OS_remove() with the file name used in #3 as argument
 **   9) Call OS_creat() to create and open another file under the directory deleted in #5
@@ -704,7 +704,7 @@ void UT_os_removedir_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_rmdir(NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_rmdir(NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_removedir_test_exit_tag;
@@ -713,7 +713,7 @@ void UT_os_removedir_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_rmdir(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_rmdir(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -744,7 +744,7 @@ void UT_os_removedir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/rmdir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_FS_SUCCESS)
+    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - Dir-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -764,7 +764,7 @@ void UT_os_removedir_test()
     OS_close(fileDesc);
     OS_remove(g_fileName);
 
-    if (OS_rmdir(g_dirName) != OS_FS_SUCCESS)
+    if (OS_rmdir(g_dirName) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_removedir_test_exit_tag;

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -121,19 +121,19 @@ void UT_os_initfs_test()
 **          then opens it
 ** Parameters: *path - pointer to the absolute path name of the file to be created
 **             access - access modes with which to open a file
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
 **          OS_FS_ERR_PATH_INVALID is the path passed in is invalid
 **          OS_FS_ERR_PATH_TOO_LONG if the absolute path name passed in is too long
 **          OS_FS_ERR_NAME_TOO_LONG if the file name passed in is too long
-**          OS_FS_ERROR if the OS call failed or file access is invalid
+**          OS_ERROR if the OS call failed or file access is invalid
 **          OS_FS_ERR_NO_FREE_IDS if there are no more free file descriptors left in
 **                                the File Descriptor table
 **          A file descriptor value if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 **      NOTE: If OS_creat() is implemented, then OS_close() and OS_remove() should
 **            also be implemented.
@@ -141,7 +141,7 @@ void UT_os_initfs_test()
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -161,20 +161,20 @@ void UT_os_initfs_test()
 ** Test #5: Invalid-permission-arg condition
 **   1) Call this routine with a value of neither OS_WRITE_ONLY or OS_READ_WRITE
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #6: OS-call-failure condition
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #7: File-descriptors-full condition
 **   1) Call this routine OS_MAX_NUM_OPEN_FILES+1 times
 **   2) Expect the returned value, of all but the last call, to be
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Expect the returned value, of the last call, to be
-**        (b) OS_FS_ERR_NO_FREE_FDS
+**        (b) OS_ERR_NO_FREE_IDS
 ** -----------------------------------------------------
 ** Test #8: Nominal condition
 **   1) Call this routine twice with different file names and access modes
@@ -182,10 +182,10 @@ void UT_os_initfs_test()
 **        (a) A file descriptor value greater than or equal to 0
 **   3) Call OS_close() on both files opened in #1
 **   4) Expect both returned values to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_remove() on both files closed in #3
 **   6) Expect both returned values to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_createfile_test()
 {
@@ -195,7 +195,7 @@ void UT_os_createfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_creat(NULL, OS_READ_WRITE) == OS_FS_UNIMPLEMENTED)
+    if (OS_creat(NULL, OS_READ_WRITE) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_createfile_test_exit_tag;
@@ -204,7 +204,7 @@ void UT_os_createfile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_creat(NULL, OS_READ_WRITE) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_creat(NULL, OS_READ_WRITE) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -239,7 +239,7 @@ void UT_os_createfile_test()
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Create_InvPerm.txt", g_mntName);
     res = OS_creat(g_fNames[0], 123);
-    if (res == OS_FS_ERROR)
+    if (res == OS_ERROR)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -265,7 +265,7 @@ void UT_os_createfile_test()
             break;
     }
 
-    if ((i == OS_MAX_NUM_OPEN_FILES) && (g_fDescs[i] == OS_FS_ERR_NO_FREE_FDS))
+    if ((i == OS_MAX_NUM_OPEN_FILES) && (g_fDescs[i] == OS_ERR_NO_FREE_IDS))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -283,8 +283,8 @@ void UT_os_createfile_test()
     g_fDescs[5] = OS_creat(g_fNames[5], OS_WRITE_ONLY);
     g_fDescs[6] = OS_creat(g_fNames[6], OS_WRITE_ONLY);
 
-    if ((OS_close(g_fDescs[5])  != OS_FS_SUCCESS) || (OS_close(g_fDescs[6])  != OS_FS_SUCCESS) ||
-        (OS_remove(g_fNames[5]) != OS_FS_SUCCESS) || (OS_remove(g_fNames[6]) != OS_FS_SUCCESS))
+    if ((OS_close(g_fDescs[5])  != OS_SUCCESS) || (OS_close(g_fDescs[6])  != OS_SUCCESS) ||
+        (OS_remove(g_fNames[5]) != OS_SUCCESS) || (OS_remove(g_fNames[6]) != OS_SUCCESS))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
@@ -301,19 +301,19 @@ UT_os_createfile_test_exit_tag:
 ** Parameters: *path - pointer to the absolute path name of the file to be created
 **             access - access modes with which to open a file
 **             mode - file permission which is not currently used
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
 **          OS_FS_ERR_PATH_INVALID is the path passed in is invalid
 **          OS_FS_ERR_PATH_TOO_LONG if the absolute path name passed in is too long
 **          OS_FS_ERR_NAME_TOO_LONG if the file name passed in is too long
-**          OS_FS_ERROR if the OS call failed or file access is invalid
+**          OS_ERROR if the OS call failed or file access is invalid
 **          OS_FS_ERR_NO_FREE_IDS if there are no more free file descriptors left in
 **                                the File Descriptor table
 **          A file descriptor value if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 **      NOTE: If OS_creat() is implemented, then OS_close() and OS_remove() should
 **            also be implemented.
@@ -321,7 +321,7 @@ UT_os_createfile_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -341,20 +341,20 @@ UT_os_createfile_test_exit_tag:
 ** Test #5: Invalid-permission-arg condition
 **   1) Call this routine with a value of neither OS_WRITE_ONLY or OS_READ_WRITE
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #6: OS-call-failure condition
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #7: File-descriptors-full condition
 **   1) Call this routine OS_MAX_NUM_OPEN_FILES+1 times
 **   2) Expect the returned value, of all but the last call, to be
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Expect the returned value, of the last call, to be
-**        (b) OS_FS_ERR_NO_FREE_FDS
+**        (b) OS_ERR_NO_FREE_IDS
 ** -----------------------------------------------------
 ** Test #8: Nominal condition
 **   1) Call this routine twice with different file names and access modes
@@ -362,10 +362,10 @@ UT_os_createfile_test_exit_tag:
 **        (a) A file descriptor value greater than or equal to 0
 **   3) Call OS_close() on both files opened in #1
 **   4) Expect both returned values to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_remove() on both files closed in #3
 **   6) Expect both returned values to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_openfile_test()
 {
@@ -375,7 +375,7 @@ void UT_os_openfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_open(NULL, OS_READ_WRITE, 0644) == OS_FS_UNIMPLEMENTED)
+    if (OS_open(NULL, OS_READ_WRITE, 0644) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_openfile_test_exit_tag;
@@ -384,7 +384,7 @@ void UT_os_openfile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_open(NULL, OS_READ_WRITE, 0644) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_open(NULL, OS_READ_WRITE, 0644) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -419,7 +419,7 @@ void UT_os_openfile_test()
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Open_InvPerm.txt", g_mntName);
     res = OS_open(g_fNames[0], 123, 0644);
-    if (res == OS_FS_ERROR)
+    if (res == OS_ERROR)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -442,7 +442,7 @@ void UT_os_openfile_test()
         memset(g_fNames[i], '\0', sizeof(g_fNames[i]));
         UT_os_sprintf(g_fNames[i], "%s/tmpFile%d.txt", g_mntName, (int)i);
         g_fDescs[i] = OS_creat(g_fNames[i], OS_WRITE_ONLY);
-        if (g_fDescs[i] < OS_FS_SUCCESS)
+        if (g_fDescs[i] < OS_SUCCESS)
         {
             testDesc = "#7 File-descriptors-full - File-create failed";
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -450,7 +450,7 @@ void UT_os_openfile_test()
             break;
         }
 
-        if (continueFlg && (OS_close(g_fDescs[i]) != OS_FS_SUCCESS))
+        if (continueFlg && (OS_close(g_fDescs[i]) != OS_SUCCESS))
         {
             testDesc = "#7 File-descriptors-full - File-close failed";
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -468,7 +468,7 @@ void UT_os_openfile_test()
                 break;
         }
 
-        if ((i == OS_MAX_NUM_OPEN_FILES) && (g_fDescs[i] < OS_FS_SUCCESS))
+        if ((i == OS_MAX_NUM_OPEN_FILES) && (g_fDescs[i] < OS_SUCCESS))
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
         else
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -486,14 +486,14 @@ void UT_os_openfile_test()
 
     g_fDescs[5] = OS_creat(g_fNames[5], OS_READ_WRITE);
     g_fDescs[6] = OS_creat(g_fNames[6], OS_WRITE_ONLY);
-    if ((g_fDescs[5] < OS_FS_SUCCESS) || (g_fDescs[6] < OS_FS_SUCCESS))
+    if ((g_fDescs[5] < OS_SUCCESS) || (g_fDescs[6] < OS_SUCCESS))
     {
         testDesc = "#8 Nominal - File-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_openfile_test_exit_tag;
     }
 
-    if ((OS_close(g_fDescs[5]) != OS_FS_SUCCESS) || (OS_close(g_fDescs[6]) != OS_FS_SUCCESS))
+    if ((OS_close(g_fDescs[5]) != OS_SUCCESS) || (OS_close(g_fDescs[6]) != OS_SUCCESS))
     {
         testDesc = "#8 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -503,8 +503,8 @@ void UT_os_openfile_test()
     g_fDescs[5] = OS_open(g_fNames[5], OS_READ_WRITE, 0644);
     g_fDescs[6] = OS_open(g_fNames[6], OS_WRITE_ONLY, 0644);
 
-    if ((OS_close(g_fDescs[5])  != OS_FS_SUCCESS) || (OS_close(g_fDescs[6])  != OS_FS_SUCCESS) ||
-        (OS_remove(g_fNames[5]) != OS_FS_SUCCESS) || (OS_remove(g_fNames[6]) != OS_FS_SUCCESS))
+    if ((OS_close(g_fDescs[5])  != OS_SUCCESS) || (OS_close(g_fDescs[6])  != OS_SUCCESS) ||
+        (OS_remove(g_fNames[5]) != OS_SUCCESS) || (OS_remove(g_fNames[6]) != OS_SUCCESS))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
@@ -518,14 +518,14 @@ UT_os_openfile_test_exit_tag:
 ** Syntax: int32 OS_close(int32 filedes)
 ** Purpose: Closes a file of a given file descriptor
 ** Parameters: filedes - a file descriptor value
-** Returns: OS_FS_ERR_INVALID_FD if the file descriptor passed in invalid
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+** Returns: OS_ERR_INVALID_ID if the file descriptor passed in invalid
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 **      NOTE: If OS_close() is implemented, then OS_open() should also be implemented.
 ** -----------------------------------------------------
@@ -533,13 +533,13 @@ UT_os_openfile_test_exit_tag:
 **   1) Call this routine 3 times with a file descriptors of 0, -1, and (OS_MAX_NUM_OPEN_FILES+5)
 **      respectively as argument
 **   2) Expect all three returned values to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 ** -----------------------------------------------------
 ** Test #2: OS-call-failure condition
 **   1) Setup the test to fail OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #3: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -547,10 +547,10 @@ UT_os_openfile_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine with the file descriptor returned in #1
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_read() and OS_write() with the file descriptor returned in #1
 **   6) Expect both returned value to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 **--------------------------------------------------------------------------------*/
 void UT_os_closefile_test()
 {
@@ -560,7 +560,7 @@ void UT_os_closefile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_close(99999) == OS_FS_UNIMPLEMENTED)
+    if (OS_close(99999) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_closefile_test_exit_tag;
@@ -569,7 +569,7 @@ void UT_os_closefile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Invalid-file-desc-arg";
 
-    if (OS_close(99999) == OS_FS_ERR_INVALID_FD)
+    if (OS_close(99999) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -593,9 +593,9 @@ void UT_os_closefile_test()
         goto UT_os_closefile_test_exit_tag;
     }
 
-    if ((OS_close(g_fDescs[0]) != OS_FS_SUCCESS) ||
-        (OS_write(g_fDescs[0], tmpBuff, sizeof(tmpBuff)) != OS_FS_ERR_INVALID_FD) ||
-        (OS_read(g_fDescs[0],  tmpBuff, sizeof(tmpBuff)) != OS_FS_ERR_INVALID_FD))
+    if ((OS_close(g_fDescs[0]) != OS_SUCCESS) ||
+        (OS_write(g_fDescs[0], tmpBuff, sizeof(tmpBuff)) != OS_ERR_INVALID_ID) ||
+        (OS_read(g_fDescs[0],  tmpBuff, sizeof(tmpBuff)) != OS_ERR_INVALID_ID))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
@@ -615,33 +615,33 @@ UT_os_closefile_test_exit_tag:
 ** Parameters: filedes - a file descriptor
 **             *buffer - pointer that will hold the data read from file
 **             nbytes - the number of bytes to be read from file
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERR_INVALID_FD if the file descriptor passed in is invalid
-**          OS_FS_ERROR if the OS call failed
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_ERR_INVALID_ID if the file descriptor passed in is invalid
+**          OS_ERROR if the OS call failed
 **          The number of bytes read if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-file-desc-arg condition
 **   1) Call this routine 3 times with a file descriptors of 0, -1, and (OS_MAX_NUM_OPEN_FILES+5)
 **      respectively as argument
 **   2) Expect all three returned values to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 ** -----------------------------------------------------
 ** Test #3: OS-call-failure condition
 **   1) Setup the test to fail OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -652,7 +652,7 @@ UT_os_closefile_test_exit_tag:
 **        (a) number of bytes written that is equal to the number of bytes in the write buffer
 **   5) Call OS_close() to flush and close the file opened in #1
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_open() with file name used in #1 as argument
 **   8) Expect the returned value to be
 **        (a) a file descriptor value greater than or equal to 0
@@ -668,7 +668,7 @@ void UT_os_readfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_read(99999, NULL, 0) == OS_FS_UNIMPLEMENTED)
+    if (OS_read(99999, NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_readfile_test_exit_tag;
@@ -687,7 +687,7 @@ void UT_os_readfile_test()
     }
     else
     {
-        if (OS_read(g_fDescs[0], NULL, sizeof(g_readBuff)) == OS_FS_ERR_INVALID_POINTER)
+        if (OS_read(g_fDescs[0], NULL, sizeof(g_readBuff)) == OS_INVALID_POINTER)
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
         else
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -700,7 +700,7 @@ void UT_os_readfile_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-file-desc-arg";
 
-    if (OS_read(99999, g_readBuff, sizeof(g_readBuff)) == OS_FS_ERR_INVALID_FD)
+    if (OS_read(99999, g_readBuff, sizeof(g_readBuff)) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -738,7 +738,7 @@ void UT_os_readfile_test()
         goto UT_os_readfile_test_exit_tag;
     }
 
-    if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -786,33 +786,33 @@ UT_os_readfile_test_exit_tag:
 ** Parameters: filedes - a file descriptor
 **             *buffer - pointer that holds the data to be written to file
 **             nbytes - the maximum number of bytes to copy to file
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERR_INVALID_FD if the file descriptor passed in is invalid
-**          OS_FS_ERROR if the OS call failed
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_ERR_INVALID_ID if the file descriptor passed in is invalid
+**          OS_ERROR if the OS call failed
 **          The number of bytes written if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-file-desc-arg condition
 **   1) Call this routine 3 times with a file descriptors of 0, -1, and (OS_MAX_NUM_OPEN_FILES+5)
 **      respectively as argument
 **   2) Expect all three returned values to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 ** -----------------------------------------------------
 ** Test #3: OS-call-failure condition
 **   1) Setup the test to fail OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -823,7 +823,7 @@ UT_os_readfile_test_exit_tag:
 **        (a) number of bytes written that is equal to the number of bytes in the write buffer
 **   5) Call OS_close() to flush and close the file opened in #1
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_open() with file name used in #1 as argument
 **   8) Expect the returned value to be
 **        (a) a file descriptor value greater than or equal to 0
@@ -839,7 +839,7 @@ void UT_os_writefile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_write(99999, NULL, 0) == OS_FS_UNIMPLEMENTED)
+    if (OS_write(99999, NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_writefile_test_exit_tag;
@@ -858,7 +858,7 @@ void UT_os_writefile_test()
     }
     else
     {
-        if (OS_write(g_fDescs[0], NULL, sizeof(g_writeBuff)) == OS_FS_ERR_INVALID_POINTER)
+        if (OS_write(g_fDescs[0], NULL, sizeof(g_writeBuff)) == OS_INVALID_POINTER)
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
         else
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -871,7 +871,7 @@ void UT_os_writefile_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-file-desc-arg";
 
-    if (OS_write(99999, g_writeBuff, sizeof(g_writeBuff)) == OS_FS_ERR_INVALID_FD)
+    if (OS_write(99999, g_writeBuff, sizeof(g_writeBuff)) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -888,7 +888,7 @@ void UT_os_writefile_test()
     UT_os_sprintf(g_fNames[0], "%s/Write_Nominal.txt", g_mntName);
 
     g_fDescs[0] = OS_creat(g_fNames[0], OS_READ_WRITE);
-    if (g_fDescs[0] < OS_FS_SUCCESS)
+    if (g_fDescs[0] < OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -908,7 +908,7 @@ void UT_os_writefile_test()
         goto UT_os_writefile_test_exit_tag;
     }
 
-    if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -960,32 +960,32 @@ UT_os_writefile_test_exit_tag:
 **                         OS_SEEK_SET - starts at beginning of file
 **                         OS_SEEK_CUR - starts at the current read/write pointer
 **                         OS_SEEK_END - starts at the end of the file
-** Returns: OS_FS_ERR_INVALID_FD is the file descriptor passed in is invalid
-**          OS_FS_ERROR if the OS call failed or the whence value is invalid
+** Returns: OS_ERR_INVALID_ID is the file descriptor passed in is invalid
+**          OS_ERROR if the OS call failed or the whence value is invalid
 **          The new offset from the beginning of the given file
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Invalid-file-desc-arg condition
 **   1) Call this routine 3 times with a file descriptors of 0, -1, and (OS_MAX_NUM_OPEN_FILES+5)
 **      respectively as argument
 **   2) Expect all three returned values to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 ** -----------------------------------------------------
 ** Test #2: Invalid-whence-arg condition
 **   1) Call this routine with invalid "whence" value as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #3: OS-call-failure condition
 **   1) Setup the test to fail OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -1008,7 +1008,7 @@ void UT_os_lseekfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_lseek(99999, 0, OS_SEEK_CUR) == OS_FS_UNIMPLEMENTED)
+    if (OS_lseek(99999, 0, OS_SEEK_CUR) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_lseekfile_test_exit_tag;
@@ -1017,7 +1017,7 @@ void UT_os_lseekfile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Invalid-file-desc-arg";
 
-    if (OS_lseek(99999, 0, OS_SEEK_SET) == OS_FS_ERR_INVALID_FD)
+    if (OS_lseek(99999, 0, OS_SEEK_SET) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1035,7 +1035,7 @@ void UT_os_lseekfile_test()
     }
     else
     {
-        if (OS_lseek(g_fDescs[0], 0, 123456) == OS_FS_ERROR)
+        if (OS_lseek(g_fDescs[0], 0, 123456) == OS_ERROR)
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
         else
             UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1099,11 +1099,11 @@ UT_os_lseekfile_test_exit_tag:
 ** Purpose: Changes access mode of a given file name
 ** Parameters: *path - pointer to the path/name of the given file
 **             access - file access flags
-** Returns: OS_FS_UNIMPLEMENTED if not implemented
+** Returns: OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 **--------------------------------------------------------------------------------*/
 void UT_os_chmodfile_test()
@@ -1113,7 +1113,7 @@ void UT_os_chmodfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_chmod(NULL, 0644) == OS_FS_UNIMPLEMENTED)
+    if (OS_chmod(NULL, 0644) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_chmodfile_test_exit_tag;
@@ -1129,22 +1129,22 @@ UT_os_chmodfile_test_exit_tag:
 ** Purpose: Returns file information about a given file name
 ** Parameters: *path - pointer to the file/name of a given file
 **             *filestats - pointer that will hold file information
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is null
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is null
 **          OS_FS_ERR_PATH_INVALID if the path is invalid
 **          OS_FS_ERR_PATH_TOO_LONG if the path name is too long
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -1160,7 +1160,7 @@ UT_os_chmodfile_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #5: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -1168,16 +1168,16 @@ UT_os_chmodfile_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine with the file name used in #1
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_write() to cause a file modification to occur
 **   6) Expect the returned value to be
 **        (a) number of bytes written to be equal to the length of write buffer
 **   7) Call OS_close() to flush and close the file written to in #5
 **   8) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   9) Call this routine again with the file name used in #1
 **  10) Expect the returned value to be
-**        (a) OS_FS_SUCCESS __and__
+**        (a) OS_SUCCESS __and__
 **        (b) fstats1 returned in #3 and fstats2 returned in #9 to be not equal
 **--------------------------------------------------------------------------------*/
 void UT_os_statfile_test()
@@ -1188,7 +1188,7 @@ void UT_os_statfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_stat(NULL, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_stat(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_statfile_test_exit_tag;
@@ -1197,8 +1197,8 @@ void UT_os_statfile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_stat(NULL, &fstats1) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_stat(g_fNames[0], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_stat(NULL, &fstats1) == OS_INVALID_POINTER) &&
+        (OS_stat(g_fNames[0], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1238,7 +1238,7 @@ void UT_os_statfile_test()
         goto UT_os_statfile_test_exit_tag;
     }
 
-    if (OS_stat(g_fNames[0], &fstats1) != OS_FS_SUCCESS)
+    if (OS_stat(g_fNames[0], &fstats1) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_statfile_test_exit_tag;
@@ -1253,14 +1253,14 @@ void UT_os_statfile_test()
         goto UT_os_statfile_test_exit_tag;
     }
 
-    if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_statfile_test_exit_tag;
     }
 
-    if (OS_stat(g_fNames[0], &fstats2) != OS_FS_SUCCESS)
+    if (OS_stat(g_fNames[0], &fstats2) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_statfile_test_exit_tag;
@@ -1283,23 +1283,23 @@ UT_os_statfile_test_exit_tag:
 ** Syntax: int32 OS_remove(const char *path)
 ** Purpose: Removes the given file name
 ** Parameters: *path - pointer to the path/name of the file to be removed
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
 **          OS_FS_ERR_PATH_INVALID if the path is invalid
 **          OS_FS_ERR_PATH_TOO_LONG if the path name is too long
 **          OS_FS_ERR_NAME_TOO_LONG if the name is too long
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -1320,7 +1320,7 @@ UT_os_statfile_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #6: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -1328,10 +1328,10 @@ UT_os_statfile_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine with path/file name used in #1 as argument
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_stat() to get file status on the deleted file
 **   6) Expect the returned values to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 **--------------------------------------------------------------------------------*/
 void UT_os_removefile_test()
 {
@@ -1341,7 +1341,7 @@ void UT_os_removefile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_remove(NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_remove(NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_removefile_test_exit_tag;
@@ -1350,7 +1350,7 @@ void UT_os_removefile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_remove(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_remove(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1401,13 +1401,13 @@ void UT_os_removefile_test()
     /* TODO: Check to see if OS_remove() can delete an opened file. */
     OS_close(g_fDescs[0]);
 
-    if (OS_remove(g_fNames[0]) != OS_FS_SUCCESS)
+    if (OS_remove(g_fNames[0]) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_removefile_test_exit_tag;
     }
 
-    if (OS_stat(g_fNames[0], &fstats) == OS_FS_ERROR)
+    if (OS_stat(g_fNames[0], &fstats) == OS_ERROR)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1422,22 +1422,22 @@ UT_os_removefile_test_exit_tag:
 ** Purpose: Renames the given file name to the new file name
 ** Parameters: *old - pointer to the path/name of the file to be renamed
 **             *new - pointer to the new path/name of the file
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is null
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is null
 **          OS_FS_ERR_PATH_TOO_LONG if the path name is too long
 **          OS_FS_ERR_NAME_TOO_LONG if the name is too long
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -1458,7 +1458,7 @@ UT_os_removefile_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #6: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -1466,10 +1466,10 @@ UT_os_removefile_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine with path/file name used in #1 as argument for old name
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_stat() to get file status on the old name used in #3
 **   6) Expect the returned values to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 **--------------------------------------------------------------------------------*/
 void UT_os_renamefile_test()
 {
@@ -1479,7 +1479,7 @@ void UT_os_renamefile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_rename(NULL, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_rename(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_renamefile_test_exit_tag;
@@ -1493,8 +1493,8 @@ void UT_os_renamefile_test()
     UT_os_sprintf(g_fNames[0], "%s/oldName.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/newName.txt", g_mntName);
 
-    if ((OS_rename(NULL, g_fNames[1]) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_rename(g_fNames[0], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_rename(NULL, g_fNames[1]) == OS_INVALID_POINTER) &&
+        (OS_rename(g_fNames[0], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1544,13 +1544,13 @@ void UT_os_renamefile_test()
         goto UT_os_renamefile_test_exit_tag;
     }
 
-    if (OS_rename(g_fNames[0], g_fNames[1]) != OS_FS_SUCCESS)
+    if (OS_rename(g_fNames[0], g_fNames[1]) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_renamefile_test_exit_tag;
     }
 
-    if (OS_stat(g_fNames[0], &fstats) == OS_FS_ERROR)
+    if (OS_stat(g_fNames[0], &fstats) == OS_ERROR)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1569,22 +1569,22 @@ UT_os_renamefile_test_exit_tag:
 ** Purpose: Copies the given file to a new specified file
 ** Parameters: *src - pointer to the absolute path of the file to be copied
 **             *dest - pointer to the absolute path of the new file
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is null
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is null
 **          OS_FS_ERR_PATH_INVALID if the path is invalid
 **          OS_FS_ERR_PATH_TOO_LONG if the path name is too long
 **          OS_FS_ERR_NAME_TOO_LONG if the name is too long
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -1605,22 +1605,22 @@ UT_os_renamefile_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #6: Nominal condition
 **   1) Call OS_stat() with a non-existing file name as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 **   3) Call OS_creat() to create and open a file
 **   4) Expect the returned value to be
 **        (a) a file descriptor value greater than or equal to 0
 **   5) Call this routine with file name used in #3 as old file and file name used
 **      in #1 as new file
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_stat() again as in #1
 **   8) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_copyfile_test()
 {
@@ -1630,7 +1630,7 @@ void UT_os_copyfile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_cp(NULL, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_cp(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_copyfile_test_exit_tag;
@@ -1644,8 +1644,8 @@ void UT_os_copyfile_test()
     UT_os_sprintf(g_fNames[0], "%s/oldName.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/newName.txt", g_mntName);
 
-    if ((OS_cp(NULL, g_fNames[1]) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_cp(g_fNames[0], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_cp(NULL, g_fNames[1]) == OS_INVALID_POINTER) &&
+        (OS_cp(g_fNames[0], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1687,7 +1687,7 @@ void UT_os_copyfile_test()
     UT_os_sprintf(g_fNames[0], "%s/Cp_Nom_Old.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/Cp_Nom_New.txt", g_mntName);
 
-    if (OS_stat(g_fNames[1], &fstats) != OS_FS_ERROR)
+    if (OS_stat(g_fNames[1], &fstats) != OS_ERROR)
     {
         testDesc = "#6 Nominal - File-stat failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -1702,20 +1702,20 @@ void UT_os_copyfile_test()
         goto UT_os_copyfile_test_exit_tag;
     }
 
-    if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#6 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_copyfile_test_exit_tag;
     }
 
-    if (OS_cp(g_fNames[0], g_fNames[1]) != OS_FS_SUCCESS)
+    if (OS_cp(g_fNames[0], g_fNames[1]) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_copyfile_test_exit_tag;
     }
 
-    if (OS_stat(g_fNames[1], &fstats) == OS_FS_SUCCESS)
+    if (OS_stat(g_fNames[1], &fstats) == OS_SUCCESS)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1734,22 +1734,22 @@ UT_os_copyfile_test_exit_tag:
 ** Purpose: Moves the given file to a new specified file
 ** Parameters: *src - pointer to the absolute path of the file to be moved
 **             *dest - pointer to the aboslute path of the new file
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is null
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is null
 **          OS_FS_ERR_INVALID_PATH if path is invalid
 **          OS_FS_ERR_PATH_TOO_LONG if the path name is too long
 **          OS_FS_ERR_NAME_TOO_LONG if the name is too long
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -1770,25 +1770,25 @@ UT_os_copyfile_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #6: Nominal condition
 **   1) Call OS_stat() with a non-existing file name as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 **   3) Call OS_creat() to create and open a file
 **   4) Expect the returned value to be
 **        (a) a file descriptor value greater than or equal to 0
 **   5) Call this routine with file name used in #3 as old file and file name used
 **      in #1 as new file
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_stat() again as in #1
 **   8) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   9) Call OS_stat() on the file name used in #3
 **  10) Expect the returned value to be
-**        (a) not OS_FS_SUCCESS
+**        (a) not OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_movefile_test()
 {
@@ -1798,7 +1798,7 @@ void UT_os_movefile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_mv(NULL, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_mv(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_movefile_test_exit_tag;
@@ -1812,8 +1812,8 @@ void UT_os_movefile_test()
     UT_os_sprintf(g_fNames[0], "%s/oldName.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/newName.txt", g_mntName);
 
-    if ((OS_mv(NULL, g_fNames[1]) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_mv(g_fNames[0], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_mv(NULL, g_fNames[1]) == OS_INVALID_POINTER) &&
+        (OS_mv(g_fNames[0], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1855,7 +1855,7 @@ void UT_os_movefile_test()
     UT_os_sprintf(g_fNames[0], "%s/Mv_Nom_Old.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/Mv_Nom_New.txt", g_mntName);
 
-    if (OS_stat(g_fNames[1], &fstats) != OS_FS_ERROR)
+    if (OS_stat(g_fNames[1], &fstats) != OS_ERROR)
     {
         testDesc = "#6 Nominal - File-stat failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -1871,21 +1871,21 @@ void UT_os_movefile_test()
     }
 
     /* Close file before moving */
-    if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#6 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_movefile_test_exit_tag;
     }
 
-    if (OS_mv(g_fNames[0], g_fNames[1]) != OS_FS_SUCCESS)
+    if (OS_mv(g_fNames[0], g_fNames[1]) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_movefile_test_exit_tag;
     }
 
-    if ((OS_stat(g_fNames[1], &fstats) == OS_FS_SUCCESS) &&
-        (OS_stat(g_fNames[0], &fstats) != OS_FS_SUCCESS))
+    if ((OS_stat(g_fNames[1], &fstats) == OS_SUCCESS) &&
+        (OS_stat(g_fNames[0], &fstats) != OS_SUCCESS))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1904,33 +1904,33 @@ UT_os_movefile_test_exit_tag:
 **          to the given file descriptor
 ** Parameters: *Cmd - pointer to the command to pass to the OS
 **             OS_fd - file descriptor to which the command output is written to
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERR_INVALID_FD if the file descriptor passed in is invalid
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_ERR_INVALID_ID if the file descriptor passed in is invalid
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-file-desc-arg condition
 **   1) Call this routine 3 times with a file descriptors of 0, -1, and (OS_MAX_NUM_OPEN_FILES+5)
 **      respectively as argument
 **   2) Expect all three returned values to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 ** -----------------------------------------------------
 ** Test #3: OS-call-failure condition
 **   1) Setup the test to fail OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_creat() to create and open a file for writing
@@ -1939,11 +1939,11 @@ UT_os_movefile_test_exit_tag:
 **   3) Call this routine with file descriptor returned in #1 and
 **      command "echo $HOME" as arguments
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_lseek() with file descriptor returned in #1 to rewind to  the
 **      beginning of file to get ready for reading
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call OS_read() with file descriptor returned in #1 to read from beginning of file
 **   8) Expect the returned value to be
 **        (a) number of bytes greater than 0 __and__
@@ -1958,7 +1958,7 @@ void UT_os_outputtofile_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_ShellOutputToFile(NULL, 0) == OS_FS_UNIMPLEMENTED)
+    if (OS_ShellOutputToFile(NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_outputtofile_test_exit_tag;
@@ -1967,7 +1967,7 @@ void UT_os_outputtofile_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_ShellOutputToFile(NULL, 0) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_ShellOutputToFile(NULL, 0) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1975,7 +1975,7 @@ void UT_os_outputtofile_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-file-desc-arg";
 
-    if (OS_ShellOutputToFile("ls", 99999) == OS_FS_ERR_INVALID_FD)
+    if (OS_ShellOutputToFile("ls", 99999) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2012,7 +2012,7 @@ void UT_os_outputtofile_test()
         goto UT_os_outputtofile_test_exit_tag;
     }
 
-    if (OS_lseek(g_fDescs[0], 0, OS_SEEK_SET) != OS_FS_SUCCESS)
+    if (OS_lseek(g_fDescs[0], 0, OS_SEEK_SET) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-lseek failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2049,32 +2049,32 @@ UT_os_outputtofile_test_exit_tag:
 ** Purpose: Returns file descriptor information about a given file descriptor
 ** Parameters: filedesc - a file descriptor
 **             *fd_prop - pointer that will hold the file descriptor's data
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERR_INVALID_FD if the file descriptor passed in is invalid
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_ERR_INVALID_ID if the file descriptor passed in is invalid
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-file-desc-arg condition
 **   1) Call this routine 3 times with a file descriptors of 0, -1, and (OS_MAX_NUM_OPEN_FILES+5)
 **      respectively as argument
 **   2) Expect all three returned values to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 ** -----------------------------------------------------
 ** Test #3: OS-call-failure condition
 **   1) Setup the test to fail OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -2082,15 +2082,15 @@ UT_os_outputtofile_test_exit_tag:
 **        (a) a file descriptor greater than or equal to 0
 **   3) Call this routine with the file descriptor returned in #1 as argument
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS __and__
+**        (a) OS_SUCCESS __and__
 **        (b) file descriptor property shows IsValid is TRUE __and__
 **        (c) file path is the same as the file path used in #1
 **   5) Call OS_close() with file descriptor returned in #1 as argument
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call this routine with the file descriptor returned in #1 as argument
 **   8) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_FD
+**        (a) OS_ERR_INVALID_ID
 **--------------------------------------------------------------------------------*/
 void UT_os_getfdinfo_test()
 {
@@ -2101,7 +2101,7 @@ void UT_os_getfdinfo_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_FDGetInfo(0, NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_FDGetInfo(0, NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_getfdinfo_test_exit_tag;
@@ -2119,7 +2119,7 @@ void UT_os_getfdinfo_test()
         testDesc = "#1 Null-pointer-arg - File-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
     }
-    else if (OS_FDGetInfo(g_fDescs[0], NULL) != OS_FS_ERR_INVALID_POINTER)
+    else if (OS_FDGetInfo(g_fDescs[0], NULL) != OS_INVALID_POINTER)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
     }
@@ -2134,7 +2134,7 @@ void UT_os_getfdinfo_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-file-desc-arg";
 
-    if (OS_FDGetInfo(99999, &fdProps) == OS_FS_ERR_INVALID_FD)
+    if (OS_FDGetInfo(99999, &fdProps) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2158,14 +2158,14 @@ void UT_os_getfdinfo_test()
     }
 
     memset(&fdProps, 0x00, sizeof(fdProps));
-    if (OS_FDGetInfo(g_fDescs[0], &fdProps) != OS_FS_SUCCESS ||
+    if (OS_FDGetInfo(g_fDescs[0], &fdProps) != OS_SUCCESS ||
         strcmp(fdProps.Path, g_fNames[0]) != 0)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_getfdinfo_test_exit_tag;
     }
 
-    if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -2173,7 +2173,7 @@ void UT_os_getfdinfo_test()
     }
 
     memset(&fdProps, 0x00, sizeof(fdProps));
-    if (OS_FDGetInfo(g_fDescs[0], &fdProps) == OS_FS_ERR_INVALID_FD)
+    if (OS_FDGetInfo(g_fDescs[0], &fdProps) == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2190,25 +2190,25 @@ UT_os_getfdinfo_test_exit_tag:
 ** Syntax: int32 OS_FileOpenCheck(char *Filename)
 ** Purpose: Determines if a given file is opened
 ** Parameters: *Filename - pointer to the name of the file to check
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERROR if the file is not opened
-**          OS_FS_SUCCESS if the file is opened
-**          OS_FS_UNIMPLEMENTED if not implemented
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
+**          OS_ERROR if the file is not opened
+**          OS_SUCCESS if the file is opened
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: File-not-opened condition
 **   1) Call this routine with some non-existing filename as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #3: Nominal condition
 **   1) Call OS_creat() to create and open some file
@@ -2216,7 +2216,7 @@ UT_os_getfdinfo_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine with file name used in #1
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_checkfileopen_test()
 {
@@ -2225,7 +2225,7 @@ void UT_os_checkfileopen_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_FileOpenCheck(NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_FileOpenCheck(NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_checkfileopen_test_exit_tag;
@@ -2234,7 +2234,7 @@ void UT_os_checkfileopen_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_FileOpenCheck(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_FileOpenCheck(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2251,12 +2251,12 @@ void UT_os_checkfileopen_test()
         testDesc = "#2 File-not-opened - File-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
     }
-    else if (OS_close(g_fDescs[0]) != OS_FS_SUCCESS)
+    else if (OS_close(g_fDescs[0]) != OS_SUCCESS)
     {
         testDesc = "#2 File-not-opened - File-close failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
     }
-    else if (OS_FileOpenCheck(g_fNames[0]) != OS_FS_ERROR)
+    else if (OS_FileOpenCheck(g_fNames[0]) != OS_ERROR)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
     }
@@ -2282,7 +2282,7 @@ void UT_os_checkfileopen_test()
         goto UT_os_checkfileopen_test_exit_tag;
     }
 
-    if (OS_FileOpenCheck(g_fNames[0]) == OS_FS_SUCCESS)
+    if (OS_FileOpenCheck(g_fNames[0]) == OS_SUCCESS)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2300,20 +2300,20 @@ UT_os_checkfileopen_test_exit_tag:
 ** Syntax: int32 OS_CloseAllFiles(void)
 ** Purpose: Closes all opened files
 ** Parameters: None
-** Returns: OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+** Returns: OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: OS-call-failure condition
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #2: Nominal condition
 **   1) Call OS_creat() 3 times to create and open some files
@@ -2321,10 +2321,10 @@ UT_os_checkfileopen_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_FileOpenCheck() on the file descriptors returned in #1
 **   6) Expect all returned values to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 **--------------------------------------------------------------------------------*/
 void UT_os_closeallfiles_test()
 {
@@ -2333,7 +2333,7 @@ void UT_os_closeallfiles_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_CloseAllFiles() == OS_FS_UNIMPLEMENTED)
+    if (OS_CloseAllFiles() == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_closeallfiles_test_exit_tag;
@@ -2364,15 +2364,15 @@ void UT_os_closeallfiles_test()
         goto UT_os_closeallfiles_test_exit_tag;
     }
 
-    if (OS_CloseAllFiles() != OS_FS_SUCCESS)
+    if (OS_CloseAllFiles() != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_closeallfiles_test_exit_tag;
     }
 
-    if ((OS_FileOpenCheck(g_fNames[0]) == OS_FS_ERROR) &&
-        (OS_FileOpenCheck(g_fNames[1]) == OS_FS_ERROR) &&
-        (OS_FileOpenCheck(g_fNames[2]) == OS_FS_ERROR))
+    if ((OS_FileOpenCheck(g_fNames[0]) == OS_ERROR) &&
+        (OS_FileOpenCheck(g_fNames[1]) == OS_ERROR) &&
+        (OS_FileOpenCheck(g_fNames[2]) == OS_ERROR))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2391,21 +2391,21 @@ UT_os_closeallfiles_test_exit_tag:
 ** Syntax: int32 OS_CloseFileByName(char *Filename)
 ** Purpose: Closes a given file
 ** Parameters: *Filename - pointer to the name of the file to be closed
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is null
+** Returns: OS_INVALID_POINTER if the pointer passed in is null
 **          OS_FS_ERR_PATH_INVALID if the path is invalid
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
-**          OS_FS_UNIMPLEMENTED if not implemented
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
+**          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
-**   2) If the returned value is OS_FS_UNIMPLEMENTED, then exit test
+**   2) If the returned value is OS_ERR_NOT_IMPLEMENTED, then exit test
 **   3) Otherwise, continue
 ** -----------------------------------------------------
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-path-arg condition
 **   1) Call this routine with a non-existing path as argument
@@ -2416,7 +2416,7 @@ UT_os_closeallfiles_test_exit_tag:
 **   1) Setup the test to fail the OS call inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Call OS_creat() to create and open a file
@@ -2424,10 +2424,10 @@ UT_os_closeallfiles_test_exit_tag:
 **        (a) a file descriptor value greater than or equal to 0
 **   3) Call this routine with the file name used in #1
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_FileOpenCheck() with the file name used in #1
 **   6) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 **--------------------------------------------------------------------------------*/
 void UT_os_closefilebyname_test()
 {
@@ -2436,7 +2436,7 @@ void UT_os_closefilebyname_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_CloseFileByName(NULL) == OS_FS_UNIMPLEMENTED)
+    if (OS_CloseFileByName(NULL) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_closefilebyname_test_exit_tag;
@@ -2445,7 +2445,7 @@ void UT_os_closefilebyname_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_CloseFileByName(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_CloseFileByName(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -2476,13 +2476,13 @@ void UT_os_closefilebyname_test()
         goto UT_os_closefilebyname_test_exit_tag;
     }
 
-    if (OS_CloseFileByName(g_fNames[0]) != OS_FS_SUCCESS)
+    if (OS_CloseFileByName(g_fNames[0]) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_closefilebyname_test_exit_tag;
     }
 
-    if (OS_FileOpenCheck(g_fNames[0]) == OS_FS_ERROR)
+    if (OS_FileOpenCheck(g_fNames[0]) == OS_ERROR)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);

--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -57,14 +57,14 @@ int32 UT_os_setup_fs()
     int32 res;
 
     res = OS_mkfs(g_fsAddrPtr, g_devName, " ", 512, 20);
-    if (res != OS_FS_SUCCESS)
+    if (res != OS_SUCCESS)
     {
         UT_OS_LOG("OS_mkfs() returns %d\n", (int)res);;
         goto UT_os_setup_fs_exit_tag;
     }
 
     res = OS_mount(g_devName, g_mntName);
-    if (res != OS_FS_SUCCESS)
+    if (res != OS_SUCCESS)
     {
         UT_OS_LOG("OS_mount() returns %d\n", (int)res);;
         OS_rmfs(g_devName);
@@ -112,7 +112,7 @@ void UtTest_Setup(void)
 {
     UT_os_initfs_test();
 
-    if (UT_os_setup_fs() == OS_FS_SUCCESS)
+    if (UT_os_setup_fs() == OS_SUCCESS)
     {
         UT_os_init_file_misc();
 

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
@@ -59,11 +59,11 @@ extern char  g_mntNames[UT_OS_FILESYS_LIST_LEN][UT_OS_FILE_BUFF_SIZE];
 **             *volname - a pointer to the name of the volume (only used in vxWorks)
 **             blocksize - size of a single block on the drive
 **             numblocks - the number of blocks to be allocated for the drive
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the device name or volume name passed in is too long
 **          OS_FS_ERR_DEVICE_NOT_FREE if the Volume table is full
 **          OS_FS_ERR_DRIVE_NOT_CREATED if the volume is not FS-BASED
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -74,7 +74,7 @@ extern char  g_mntNames[UT_OS_FILESYS_LIST_LEN][UT_OS_FILE_BUFF_SIZE];
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as one of the arguments
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with some device name or volume name of length greater than
@@ -90,7 +90,7 @@ extern char  g_mntNames[UT_OS_FILESYS_LIST_LEN][UT_OS_FILE_BUFF_SIZE];
 ** Test #4: Disk-full condition
 **   1) Call this routine (NUM_TABLE_ENTRIES+1) of times
 **   2) Expect the returned value to be (except the last call)
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Expect the returned value of the last call to be
 **        (a) OS_FS_ERR_DEVICE_NOT_FREE
 ** -----------------------------------------------------
@@ -98,10 +98,10 @@ extern char  g_mntNames[UT_OS_FILESYS_LIST_LEN][UT_OS_FILE_BUFF_SIZE];
 **   1) Make sure no file system has been created previously
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   4) Call OS_rmfs with device name used in #1 as argument
 **   5) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_initfs_test()
 {
@@ -122,9 +122,9 @@ void UT_os_initfs_test()
     testDesc = "#1 Null-pointer-arg";
 
     if ((OS_initfs(g_fsAddrPtr, NULL, g_volNames[1], 0, 0) ==
-         OS_FS_ERR_INVALID_POINTER) &&
+         OS_INVALID_POINTER) &&
         (OS_initfs(g_fsAddrPtr, g_devNames[1], NULL, 0, 0) ==
-         OS_FS_ERR_INVALID_POINTER))
+         OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -155,7 +155,7 @@ void UT_os_initfs_test()
         memset(g_volNames[i], '\0', sizeof(g_volNames[i]));
         UT_os_sprintf(g_volNames[i], "RAM%d", (int)i);
         res = OS_initfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt);
-        if (res != OS_FS_SUCCESS)
+        if (res != OS_SUCCESS)
             break;
     }
 
@@ -172,13 +172,13 @@ void UT_os_initfs_test()
     /*-----------------------------------------------------*/
     testDesc = "#5 Nominal";
 
-    if (OS_initfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_initfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_initfs_test_exit_tag;
     }
 
-    if (OS_rmfs(g_devNames[5]) == OS_FS_SUCCESS)
+    if (OS_rmfs(g_devNames[5]) == OS_SUCCESS)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -196,11 +196,11 @@ UT_os_initfs_test_exit_tag:
 **             *volname - a pointer to the name of the volume (only used in vxWorks)
 **             blocksize - the size of a single block on the drive
 **             numblocks - the number of blocks to be allocated for the drive
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the name passed in is too long
 **          OS_FS_ERR_DRIVE_NOT_CREATED if the OS call failed
 **          OS_FS_ERR_DEVICE_NOT_FREE if the Volume table is full
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -212,7 +212,7 @@ UT_os_initfs_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as one of the arguments
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with some device name or volume name of length greater than
@@ -228,7 +228,7 @@ UT_os_initfs_test_exit_tag:
 ** Test #4: Disk-full condition
 **   1) Call this routine (NUM_TABLE_ENTRIES+1) of times
 **   2) Expect the returned value to be (except the last call)
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Expect the returned value of the last call to be
 **        (a) OS_FS_ERR_DEVICE_NOT_FREE
 ** -----------------------------------------------------
@@ -236,10 +236,10 @@ UT_os_initfs_test_exit_tag:
 **   1) Make sure no file system has been created previously
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   4) Call OS_rmfs with device name used in #1 as argument
 **   5) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_makefs_test()
 {
@@ -259,8 +259,8 @@ void UT_os_makefs_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_mkfs(g_fsAddrPtr, NULL, g_volNames[1], 0, 0) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_mkfs(g_fsAddrPtr, g_devNames[1], NULL, 0, 0) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_mkfs(g_fsAddrPtr, NULL, g_volNames[1], 0, 0) == OS_INVALID_POINTER) &&
+        (OS_mkfs(g_fsAddrPtr, g_devNames[1], NULL, 0, 0) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -291,7 +291,7 @@ void UT_os_makefs_test()
         memset(g_volNames[i], '\0', sizeof(g_volNames[i]));
         UT_os_sprintf(g_volNames[i], "RAM%d", (int)i);
         res = OS_mkfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt);
-        if (res != OS_FS_SUCCESS)
+        if (res != OS_SUCCESS)
             break;
     }
 
@@ -308,13 +308,13 @@ void UT_os_makefs_test()
     /*-----------------------------------------------------*/
     testDesc = "#5 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
         goto UT_os_makefs_test_exit_tag;
     }
 
-    if (OS_rmfs(g_devNames[5]) == OS_FS_SUCCESS)
+    if (OS_rmfs(g_devNames[5]) == OS_SUCCESS)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -328,9 +328,9 @@ UT_os_makefs_test_exit_tag:
 ** Syntax: int32 OS_rmfs(char *devname)
 ** Purpose: Removes or un-maps the target file system
 ** Parameters: *devname - a pointer to the name of the "generic" drive
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_ERR_NAME_NOT_FOUND if the given device is not found in the Volume table
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -342,7 +342,7 @@ UT_os_makefs_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-device-arg condition
 **   1) Make sure no file system has been created previously
@@ -353,13 +353,13 @@ UT_os_makefs_test_exit_tag:
 ** Test #3: Nominal condition
 **   1) Call OS_mkfs to create a file system
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call this routine with the device name used in #1 as argument
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call OS_mkfs to create a file system again exactly as in #1
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_removefs_test()
 {
@@ -379,7 +379,7 @@ void UT_os_removefs_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_rmfs(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_rmfs(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -395,15 +395,15 @@ void UT_os_removefs_test()
     /*-----------------------------------------------------*/
     testDesc = "#3 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_removefs_test_exit_tag;
     }
 
-    if ((OS_rmfs(g_devNames[3]) == OS_FS_SUCCESS) &&
-        (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) == OS_FS_SUCCESS))
+    if ((OS_rmfs(g_devNames[3]) == OS_SUCCESS) &&
+        (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) == OS_SUCCESS))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -421,9 +421,9 @@ UT_os_removefs_test_exit_tag:
 ** Purpose: Mounts a disk volume to the file system tree
 ** Parameters: *devname - a pointer to the name of the drive to mount
 **             *mountpoint - a pointer to the name to call this disk from now on
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_ERR_NAME_NOT_FOUND if the given device is not found in the Volume table
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -436,7 +436,7 @@ UT_os_removefs_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Invalid-device-arg condition
 **   1) Make sure no file system has been created previously
@@ -447,16 +447,16 @@ UT_os_removefs_test_exit_tag:
 ** Test #3: Nominal condition
 **   1) Call OS_mkfs to create a file system
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call this routine with the device name used in #1 as argument
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call this routine again exactly as in #3
 **   6) Expect the returned value to be
 **        (a) OS_ERR_NAME_NOT_FOUND
 **   7) Call OS_unmount with the mount-point used in #3 as argument
 **   8) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
 void UT_os_mount_test()
 {
@@ -476,8 +476,8 @@ void UT_os_mount_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_mount(NULL, g_mntNames[1]) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_mount(g_devNames[1], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_mount(NULL, g_mntNames[1]) == OS_INVALID_POINTER) &&
+        (OS_mount(g_devNames[1], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -493,14 +493,14 @@ void UT_os_mount_test()
     /*-----------------------------------------------------*/
     testDesc = "#3 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_mount_test_exit_tag;
     }
 
-    if ((OS_mount(g_devNames[3], g_mntNames[3]) == OS_FS_SUCCESS) &&
+    if ((OS_mount(g_devNames[3], g_mntNames[3]) == OS_SUCCESS) &&
         (OS_mount(g_devNames[3], g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -519,10 +519,10 @@ UT_os_mount_test_exit_tag:
 ** Purpose: Un-mounts a drive from the file system and makes all open file descriptors
 **          obsolete
 ** Parameters: *mountpoint - a pointer to the name of the drive to unmount
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the absolute path passed in is too long
 **          OS_ERR_NAME_NOT_FOUND if the mount-point passed in is not found in the Volume table
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -535,7 +535,7 @@ UT_os_mount_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with some mount-point name of length greater than
@@ -552,13 +552,13 @@ UT_os_mount_test_exit_tag:
 ** Test #4: Nominal condition
 **   1) Call OS_mkfs to create a file system
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_mount to mount the device to a mount-point
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call this routine with the mount-point used in #3 as argument
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   7) Call this routine again exactly as in #5
 **   8) Expect the returned value to be
 **        (a) OS_ERR_NAME_NOT_FOUND
@@ -581,7 +581,7 @@ void UT_os_unmount_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_unmount(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_unmount(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -605,15 +605,15 @@ void UT_os_unmount_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_unmount_test_exit_tag;
     }
 
-    if ((OS_mount(g_devNames[4], g_mntNames[4]) == OS_FS_SUCCESS) &&
-        (OS_unmount(g_mntNames[4]) == OS_FS_SUCCESS) &&
+    if ((OS_mount(g_devNames[4], g_mntNames[4]) == OS_SUCCESS) &&
+        (OS_unmount(g_mntNames[4]) == OS_SUCCESS) &&
         (OS_unmount(g_mntNames[4]) == OS_ERR_NAME_NOT_FOUND))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -632,10 +632,10 @@ UT_os_unmount_test_exit_tag:
 ** Purpose: Returns the name of the physical drive of a given mount-point
 ** Parameters: *PhysDriveName - a pointer that will hold the name of the physical drive
 **             *MountPoint - a pointer to the name of the mount-point
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the mount-point passed in is too long
 **          OS_ERR_NAME_NOT_FOUND if the mount-point passed in is not found in the Volume table
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -648,7 +648,7 @@ UT_os_unmount_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with some mount-point name of length greater than
@@ -659,7 +659,7 @@ UT_os_unmount_test_exit_tag:
 ** Test #3: Invalid-mount-point-arg condition
 **   1) Call OS_mkfs
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call this routine
 **   4) Expect the returned value to be
 **        (a) OS_ERR_NAME_NOT_FOUND
@@ -667,13 +667,13 @@ UT_os_unmount_test_exit_tag:
 ** Test #4: Nominal condition
 **   1) Call OS_mkfs
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   3) Call OS_mount with device name used in #1 as argument
 **   4) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   5) Call this routine with the device name used in #1 as argument
 **   6) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 ** --------------------------------------------------------------------------------*/
 void UT_os_getphysdrivename_test()
 {
@@ -694,8 +694,8 @@ void UT_os_getphysdrivename_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_FS_GetPhysDriveName(NULL, g_mntNames[1]) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_FS_GetPhysDriveName(physDevName, NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_FS_GetPhysDriveName(NULL, g_mntNames[1]) == OS_INVALID_POINTER) &&
+        (OS_FS_GetPhysDriveName(physDevName, NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -719,14 +719,14 @@ void UT_os_getphysdrivename_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_getphysicaldrivename_test_exit_tag;
     }
 
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_FS_SUCCESS)
+    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-mount failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -734,7 +734,7 @@ void UT_os_getphysdrivename_test()
     }
 
     memset(physDevName, '\0', sizeof(physDevName));
-    if ((OS_FS_GetPhysDriveName(physDevName, g_mntNames[4]) == OS_FS_SUCCESS) &&
+    if ((OS_FS_GetPhysDriveName(physDevName, g_mntNames[4]) == OS_SUCCESS) &&
         (strncmp(physDevName, g_physDriveName, strlen(g_physDriveName)) == 0))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -753,8 +753,8 @@ UT_os_getphysicaldrivename_test_exit_tag:
 ** Syntax: int32 OS_GetFsInfo(os_fsinfo_t* filesys_info)
 ** Purpose: Returns information about the file system
 ** Parameters: filesys_info - out pointer contains info. about the file system
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
-**          OS_FS_SUCCESS if succeeded
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -764,12 +764,12 @@ UT_os_getphysicaldrivename_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Nominal condition
 **   1) Call this routine with a valid argument
 **   2) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 ** --------------------------------------------------------------------------------*/
 void UT_os_getfsinfo_test(void)
 {
@@ -790,7 +790,7 @@ void UT_os_getfsinfo_test(void)
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_GetFsInfo(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_GetFsInfo(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -798,7 +798,7 @@ void UT_os_getfsinfo_test(void)
     /*-----------------------------------------------------*/
     testDesc = "#2 Nominal";
 
-    if (OS_GetFsInfo(&fsInfo) == OS_FS_SUCCESS)
+    if (OS_GetFsInfo(&fsInfo) == OS_SUCCESS)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -814,11 +814,11 @@ UT_os_getfsinfo_test_exit_tag:
 ** Parameters: *VirtualPath - pointer to the name of the virtual path or mount point
 **             *LocalPath - pointer that will hold the name of the local path or
 **                          physical device name
-** Returns: OS_FS_ERR_INVALID_POINTER if any of the pointers passed in is NULL
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the device name or volume name passed in is too long
 **          OS_FS_ERR_PATH_INVALID if the virtual path passed in is not in correct format, or
 **                                 virtual path name not found in the Volume table
-**          OS_FS_SUCCESS if succeeded
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -829,7 +829,7 @@ UT_os_getfsinfo_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as one of the arguments
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with some device name or volume name of length greater than
@@ -846,13 +846,13 @@ UT_os_getfsinfo_test_exit_tag:
 **   1) Make sure no file system has been created previously
 **   2) Call OS_mkfs
 **   3) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   4) Call OS_mount with device name used in #2 as argument
 **   5) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   6) Call this routine with the mount-point used in #4 as argument
 **   7) Expect the returned value to be
-**        (a) OS_FS_SUCCESS __and__
+**        (a) OS_SUCCESS __and__
 **        (b) the returned local path to be ?
 ** --------------------------------------------------------------------------------*/
 void UT_os_translatepath_test()
@@ -874,8 +874,8 @@ void UT_os_translatepath_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_TranslatePath(NULL, localPath) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_TranslatePath(g_mntNames[1], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_TranslatePath(NULL, localPath) == OS_INVALID_POINTER) &&
+        (OS_TranslatePath(g_mntNames[1], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -901,14 +901,14 @@ void UT_os_translatepath_test()
     testDesc = "#4 Nominal";
 
     if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) !=
-        OS_FS_SUCCESS)
+        OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_translatepath_test_exit_tag;
     }
 
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_FS_SUCCESS)
+    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-mount failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -919,7 +919,7 @@ void UT_os_translatepath_test()
         goto UT_os_translatepath_test_exit_tag;
     }
 
-    if ((OS_TranslatePath(g_mntNames[4], localPath) == OS_FS_SUCCESS) &&
+    if ((OS_TranslatePath(g_mntNames[4], localPath) == OS_SUCCESS) &&
         (strncmp(localPath, g_physDriveName, strlen(g_physDriveName)) == 0))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -940,9 +940,9 @@ UT_os_translatepath_test_exit_tag:
 **          depending on repair
 ** Parameters: *name - the name of the drive to check
 **             repair - bool flag to repair or not to repair
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is NULL
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
+** Returns: OS_INVALID_POINTER if the pointer passed in is NULL
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -953,7 +953,7 @@ UT_os_translatepath_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as one of the arguments
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with some drive name of length greater than
@@ -965,7 +965,7 @@ UT_os_translatepath_test_exit_tag:
 **   1) Setup the test to cause the OS call to fail inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test #4: Nominal condition
 **   1) Currently only applicable to vxworks platform
@@ -979,7 +979,7 @@ void UT_os_checkfs_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    if (OS_chkfs(NULL, 0) == OS_FS_UNIMPLEMENTED)
+    if (OS_chkfs(NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
         goto UT_os_checkfs_test_exit_tag;
@@ -988,7 +988,7 @@ void UT_os_checkfs_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_chkfs(NULL, 0) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_chkfs(NULL, 0) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1012,14 +1012,14 @@ void UT_os_checkfs_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_checkfs_test_exit_tag;
     }
 
-    if (OS_mount(g_devNames[5], g_mntNames[5]) != OS_FS_SUCCESS)
+    if (OS_mount(g_devNames[5], g_mntNames[5]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-mount failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -1032,7 +1032,7 @@ void UT_os_checkfs_test()
         testDesc = "#4 Nominal - Not implemented in API";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_NA);
     }
-    else if (res == OS_FS_SUCCESS)
+    else if (res == OS_SUCCESS)
     {
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     }
@@ -1054,9 +1054,9 @@ UT_os_checkfs_test_exit_tag:
 ** Syntax: int32 OS_fsBlocksFree(const char *name)
 ** Purpose: Returns the number of blocks free in a the file system
 ** Parameters: *name - a pointer to the name of the drive to check for free blocks
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is NULL
+** Returns: OS_INVALID_POINTER if the pointer passed in is NULL
 **          OS_FS_ERR_PATH_TOO_LONG if the path passed in is too long
-**          OS_FS_ERROR if the OS call failed
+**          OS_ERROR if the OS call failed
 **          Number of blocks free in a volume if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
@@ -1068,7 +1068,7 @@ UT_os_checkfs_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as one of the arguments
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with a path name of length greater than Volume table's
@@ -1080,16 +1080,16 @@ UT_os_checkfs_test_exit_tag:
 **   1) Setup the test to cause the OS call to fail inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test#4: Nominal condition
 **   1) Make sure no file system has been previously created
 **   2) Call OS_mkfs
 **   3) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   4) Call OS_mount with device name used in #2
 **   5) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   6) Call this routine with mount-point used in #4
 **   7) Expect the returned value to be
 **        (a) greater than or equal to 0
@@ -1110,7 +1110,7 @@ void UT_os_fsblocksfree_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if (OS_fsBlocksFree(NULL) == OS_FS_ERR_INVALID_POINTER)
+    if (OS_fsBlocksFree(NULL) == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1131,14 +1131,14 @@ void UT_os_fsblocksfree_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_fsblocksfree_test_exit_tag;
     }
 
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_FS_SUCCESS)
+    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-mount failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
@@ -1164,9 +1164,9 @@ UT_os_fsblocksfree_test_exit_tag:
 ** Purpose: Returns the number of bytes free in a the file system
 ** Parameters: *name - a pointer to the name of the drive to check for free bytes
 **             *bytes_free - a pointer that will hold the number of bytes free
-** Returns: OS_FS_ERR_INVALID_POINTER if the pointer passed in is NULL
-**          OS_FS_ERROR if the OS call failed
-**          OS_FS_SUCCESS if succeeded
+** Returns: OS_INVALID_POINTER if the pointer passed in is NULL
+**          OS_ERROR if the OS call failed
+**          OS_SUCCESS if succeeded
 **          OS_ERR_NOT_IMPLEMENTED if not implemented
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
@@ -1177,7 +1177,7 @@ UT_os_fsblocksfree_test_exit_tag:
 ** Test #1: Null-pointer-arg condition
 **   1) Call this routine with a null pointer as one of the arguments
 **   2) Expect the returned value to be
-**        (a) OS_FS_ERR_INVALID_POINTER
+**        (a) OS_INVALID_POINTER
 ** -----------------------------------------------------
 ** Test #2: Path-too-long-arg condition
 **   1) Call this routine with a path name of length greater than Volume table's
@@ -1189,16 +1189,16 @@ UT_os_fsblocksfree_test_exit_tag:
 **   1) Setup the test to cause the OS call to fail inside this routine
 **   2) Call this routine
 **   3) Expect the returned value to be
-**        (a) OS_FS_ERROR
+**        (a) OS_ERROR
 ** -----------------------------------------------------
 ** Test#4: Nominal condition
 **   1) Make sure no file system has been previously created
 **   2) Call OS_mkfs
 **   3) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   4) Call OS_mount with device name used in #2
 **   5) Expect the returned value to be
-**        (a) OS_FS_SUCCESS
+**        (a) OS_SUCCESS
 **   6) Call this routine with mount-point used in #4
 **   7) Expect the returned value to be
 **        (a) greater than or equal to 0
@@ -1220,8 +1220,8 @@ void UT_os_fsbytesfree_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_fsBytesFree(NULL, &retBytes) == OS_FS_ERR_INVALID_POINTER) &&
-        (OS_fsBytesFree(g_mntNames[1], NULL) == OS_FS_ERR_INVALID_POINTER))
+    if ((OS_fsBytesFree(NULL, &retBytes) == OS_INVALID_POINTER) &&
+        (OS_fsBytesFree(g_mntNames[1], NULL) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -1242,21 +1242,21 @@ void UT_os_fsbytesfree_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Nominal";
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_FS_SUCCESS)
+    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-create failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_fsbytesfree_test_exit_tag;
     }
 
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_FS_SUCCESS)
+    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - File-system-mount failed";
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_TSF);
         goto UT_os_fsbytesfree_test_exit_tag;
     }
 
-    if (OS_fsBytesFree(g_mntNames[4], &retBytes) == OS_FS_SUCCESS)
+    if (OS_fsBytesFree(g_mntNames[4], &retBytes) == OS_SUCCESS)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);


### PR DESCRIPTION
**Describe the contribution**
Fix #262 
 Deprecates the following OS_FS* defines from osapi-os-filesys.h:
OS_FS_SUCCESS, OS_FS_ERROR , OS_FS_ERR_INVALID_POINTER, OS_FS_ERR_NO_FREE_FDS , OS_FS_ERR_INVALID_FD, and OS_FS_UNIMPLEMENTED 

Used sed to perform a bulk find/replace on each one to swap with common definitions.

**Testing performed**
Steps taken to test the contribution:
1. Ran unit tests.

**Expected behavior changes**
None

**System(s) tested on**
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.12.0, OSAL 5.0.11.0, PSP 1.4.7.0

**Contributor Info **
Dan Knutsen
NASA/Goddard