### PR TITLE
Fix #413, Add reference to osal user's guide from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Getting Started:
 
 See the document *doc/OSAL-Configuration-Guide.doc* for complete details.
 
+See User's Guide: https://github.com/nasa/cFS/blob/gh-pages/OSAL_Users_Guide.pdf
+
 An easy way to get started is to use the Linux port and classic build:
 
 1. Set the *OSAL_SRC* environment variable to point to the OSAL source code.


### PR DESCRIPTION
Fix413: Added reference to osal user's guide from ReadMe

**Testing performed**
Steps taken to test the contribution:
1. Went to GitHub to verify that that link added worked properly

**Expected Behavior Changes**
None

**System(s) tested on**
 - GNOME VM
 - OS: Ubuntu 18.04
 - Versions: OSAL 5.0.11.0

**Contributor **
Yasir Khan
NASA GSFC