### PR TITLE
Fix #425, Correct Test_OS_ConvertToArrayIndex assertion typo

### DIFF
--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -607,7 +607,7 @@ void Test_OS_ConvertToArrayIndex(void)
     Osapi_Call_ObjectIdFindNext(OS_OBJECT_TYPE_OS_TASK, &local_idx1, &rptr);
     actual = OS_ConvertToArrayIndex(rptr->active_id, &local_idx2);
     UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == OS_SUCCESS", (long)actual);
-    UtAssert_True(local_idx1 == local_idx1, "local_idx1 (%lu) == local_idx2 (%lu)",
+    UtAssert_True(local_idx1 == local_idx2, "local_idx1 (%lu) == local_idx2 (%lu)",
             (unsigned long)local_idx1, (unsigned long)local_idx2);
 
     expected = OS_ERR_INCORRECT_OBJ_TYPE;


### PR DESCRIPTION
Fix #425 Test_OS_ConvertToArrayIndex: tautological assertion

**Describe the contribution**
Unit test Test_OS_ConvertToArrayIndex implements the following assertion:
osal/src/unit-test-coverage/shared/src/coveragetest-idmap.c

Lines 610 to 611 in 7d9c4c8

 UtAssert_True(local_idx1 == local_idx1, "local_idx1 (%lu) == local_idx2 (%lu)", 
         (unsigned long)local_idx1, (unsigned long)local_idx2); 

This is a tautological assertion as it compares local_idx1 with itself.  

Update:
local_idx1 is now compared with local_idx2:

UtAssert_True(local_idx1 == local_idx2, "local_idx1 (%lu) == local_idx2 (%lu)",
            (unsigned long)local_idx1, (unsigned long)local_idx2);

**Testing performed**
Steps taken to test the contribution:
1. Standard build and ran unit tests.

**Expected behavior changes**

**System(s) tested on**
cFS Dev Server
OS: Ubuntu 18.04
Versions: OSAL 5.0.11.0


**Contributor Info - All information REQUIRED for consideration of pull request**
Yasir Khan
NASA-GSFC