### PR TITLE
unit-tests/osloader-test: make modules always be built for the test

### DIFF
--- a/src/unit-tests/osloader-test/CMakeLists.txt
+++ b/src/unit-tests/osloader-test/CMakeLists.txt
@@ -4,7 +4,9 @@ set(TEST_MODULE_FILES
   ut_osloader_module_test.c
   ut_osloader_symtable_test.c    
   ut_osloader_test.c)
-  
+
+add_osal_ut_exe(osal_loader_UT ${TEST_MODULE_FILES})
+
 # build many copies of the test module
 # we need to have unique modules to load up to OS_MAX_MODULES
 # This will cover up to 32 -- extras are ignored.  If needed this can be increased.
@@ -16,7 +18,5 @@ while(MOD GREATER 0)
     COMPILE_DEFINITIONS "MODULE_NAME=module${MOD}" 
     PREFIX ""
     LIBRARY_OUTPUT_DIRECTORY eeprom1)
+  add_dependencies(osal_loader_UT MODULE${MOD})
 endwhile(MOD GREATER 0)
-  
-add_osal_ut_exe(osal_loader_UT ${TEST_MODULE_FILES})
-


### PR DESCRIPTION
**Describe the contribution**

Fixes #430.

**Testing performed**

Running `osal_loader_UT` on macOS as described in the linked issue.

**Expected behavior changes**

Without this patch, the MODULE* files are not generated in the build folder.

After this patch is applied, the module files are generated when the `osal_loader_UT` test is built and run:

```
$ find . | grep MODULE.*dy
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE31.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE5.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE28.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE7.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE3.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE6.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE30.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE29.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE4.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE0.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE2.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE23.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE21.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE8.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE25.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE27.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE20.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE22.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE26.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE24.dylib
./cmake-build-debug/unit-tests/osloader-test/eeprom1/MODULE9.dylib
```

**System(s) tested on**
 - Hardware: MacBook
 - OS: macOS Mojave 10.14.6 (18G1012)
 - Versions: OSAL as of a66eb2dc00136a77779414452835bb6364d5e1fb commit.

**Additional context**

None.

**Third party code**

None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Stanislav Pankevich, PTS GmbH

The hand signed CLA has been sent before.
