### PR TITLE
Fix #374, Add Object Utility API functional tests

### DIFF
--- a/src/tests/idmap-api-test/idmap-api-test.c
+++ b/src/tests/idmap-api-test/idmap-api-test.c
@@ -79,6 +79,8 @@ void TestIdMapApi(void)
     uint32 mutex_id3;
     uint32 time_base_id;
     uint32 TestArrayIndex; 
+    uint32 TestMutex1Index; 
+    uint32 TestMutex2Index; 
     Test_OS_ObjTypeCount_t Count;
 
     /*
@@ -162,35 +164,32 @@ void TestIdMapApi(void)
      */
     actual   = OS_ConvertToArrayIndex(task_id, &TestArrayIndex);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_TASKS , "0 < TestArrayIndex(%lu)  <= OS_MAX_TASKS", (long)TestArrayIndex);
 
     actual   = OS_ConvertToArrayIndex(queue_id, &TestArrayIndex);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+    UtAssert_True(TestArrayIndex >=0 && TestArrayIndex < OS_MAX_QUEUES , "0 < TestArrayIndex(%lu)  <= OS_MAX_QUEUES", (long)TestArrayIndex);
 
     actual   = OS_ConvertToArrayIndex(count_sem_id, &TestArrayIndex);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_COUNT_SEMAPHORES , "0 < TestArrayIndex(%lu)  <= OS_MAX_COUNT_SEMAPHORES", (long)TestArrayIndex);
 
     actual   = OS_ConvertToArrayIndex(bin_sem_id, &TestArrayIndex);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 2 , "TestArrayIndex(%lu) == 2", (long)TestArrayIndex);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_BIN_SEMAPHORES , "0 < TestArrayIndex(%lu)  <= OS_MAX_BIN_SEMAPHORES", (long)TestArrayIndex);
 
-    actual   = OS_ConvertToArrayIndex(mutex_id1, &TestArrayIndex);
+    actual   = OS_ConvertToArrayIndex(mutex_id1, &TestMutex1Index);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+    UtAssert_True(TestMutex1Index >= 0 && TestMutex1Index < OS_MAX_MUTEXES , "0 < TestMutex1Index(%lu)  <= OS_MAX_MUTEXES", (long)TestMutex1Index);
 
-    actual   = OS_ConvertToArrayIndex(mutex_id2, &TestArrayIndex);
+    actual   = OS_ConvertToArrayIndex(mutex_id2, &TestMutex2Index);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 2 , "TestArrayIndex(%lu) == 2", (long)TestArrayIndex);
-
-    actual   = OS_ConvertToArrayIndex(mutex_id3, &TestArrayIndex);
-    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 3 , "TestArrayIndex(%lu) == 3", (long)TestArrayIndex);
+    UtAssert_True(TestMutex2Index >= 0 && TestMutex2Index < OS_MAX_MUTEXES , "0 < TestMutex2Index(%lu)  <= OS_MAX_MUTEXES", (long)TestMutex2Index);
+    UtAssert_True(TestMutex1Index != TestMutex2Index , "TestMutex1Index(%lu) !=  TestMutex2Index(%lu)", (long)TestMutex1Index, (long)TestMutex2Index );
 
     actual   = OS_ConvertToArrayIndex(time_base_id, &TestArrayIndex);
     UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
-    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_TIMEBASES , "0 < TestArrayIndex(%lu)  <= OS_MAX_TIMEBASES", (long)TestArrayIndex);
 
     /*
      * Test with extreme cases using invalid inputs and checking

--- a/src/tests/idmap-api-test/idmap-api-test.c
+++ b/src/tests/idmap-api-test/idmap-api-test.c
@@ -1,0 +1,278 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "common_types.h"
+#include "osapi.h"
+#include "utassert.h"
+#include "uttest.h"
+#include "utbsp.h"
+
+
+/* *************************************** MAIN ************************************** */
+
+typedef struct
+{
+    uint32 TaskCount;
+    uint32 QueueCount;
+    uint32 CountSemCount;
+    uint32 BinSemCount;
+    uint32 MutexCount;
+    uint32 TimeBaseCount;
+    uint32 OtherCount;
+} Test_OS_ObjTypeCount_t;
+
+static void ObjTypeCounter(uint32 object_id, void *arg)
+{
+    Test_OS_ObjTypeCount_t *count = arg;
+
+    switch(OS_IdentifyObject(object_id))
+    {
+    case OS_OBJECT_TYPE_OS_TASK:
+        ++count->TaskCount;
+        break;
+    case OS_OBJECT_TYPE_OS_QUEUE:
+        ++count->QueueCount;
+        break;
+    case OS_OBJECT_TYPE_OS_COUNTSEM:
+        ++count->CountSemCount;
+        break;
+    case OS_OBJECT_TYPE_OS_BINSEM:
+        ++count->BinSemCount;
+        break;
+    case OS_OBJECT_TYPE_OS_MUTEX:
+        ++count->MutexCount;
+        break;
+    case OS_OBJECT_TYPE_OS_TIMEBASE:
+        ++count->TimeBaseCount;
+        break;
+    default:
+        ++count->OtherCount;
+        break;
+    }
+}
+
+/*
+* A void test function that creates an object for testing
+*/
+void Test_Void_Fn(void)
+{
+    uint32 bin_sem_id_my_task;
+    OS_BinSemCreate( &bin_sem_id_my_task, "BinSemTaskMyTask", 1, 0);
+    OS_TaskDelay(5);
+
+} /* end Test_Void_Fn */
+
+
+/* *************************************** MAIN ************************************** */
+
+void TestIdMapApi(void)
+{
+    int32 expected;
+    int32 actual;
+    uint32 task_id;
+    uint32 queue_id;
+    uint32 count_sem_id;
+    uint32 bin_sem_id;
+    uint32 mutex_id1;
+    uint32 mutex_id2;
+    uint32 mutex_id3;
+    uint32 time_base_id;
+    uint32 TestArrayIndex; 
+    Test_OS_ObjTypeCount_t Count;
+
+    /*
+     * Create all allowed objects
+     */
+    OS_TaskCreate( &task_id, "Task", Test_Void_Fn, 0, 0, 0, 0);
+    OS_QueueCreate( &queue_id, "Queue", 5, 5, 0);
+    OS_CountSemCreate( &count_sem_id, "CountSem", 1, 0);
+    OS_BinSemCreate( &bin_sem_id, "BinSem", 1, 0);
+    OS_MutSemCreate( &mutex_id1, "Mutex1", 0);
+    OS_MutSemCreate( &mutex_id2, "Mutex2", 0);
+    OS_MutSemCreate( &mutex_id3, "Mutex3", 0);
+    OS_TimeBaseCreate( &time_base_id, "TimeBase", 0);
+
+    /*
+     * NOTE: The following objects were not created and tested:
+     * OS_OBJECT_TYPE_OS_STREAM
+     * OS_OBJECT_TYPE_OS_DIR
+     * OS_OBJECT_TYPE_OS_TIMECB
+     * OS_OBJECT_TYPE_OS_FILESYS
+     * OS_OBJECT_TYPE_OS_CONSOLE
+     * OS_OBJECT_TYPE_USER
+     */
+
+    /*
+     * Test Case For:
+     * int32 OS_IdentifyObject(void)
+     */
+
+    /*
+     * Test with nominal values
+     */
+    expected = OS_OBJECT_TYPE_OS_TASK;
+    actual   = OS_IdentifyObject(task_id); 
+    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected); 
+
+    expected = OS_OBJECT_TYPE_OS_QUEUE;
+    actual   = OS_IdentifyObject(queue_id); 
+    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected); 
+
+    expected = OS_OBJECT_TYPE_OS_COUNTSEM;
+    actual   = OS_IdentifyObject(count_sem_id); 
+    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected); 
+
+    expected = OS_OBJECT_TYPE_OS_BINSEM;
+    actual   = OS_IdentifyObject(bin_sem_id); 
+    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected); 
+
+    expected = OS_OBJECT_TYPE_OS_MUTEX;
+    actual   = OS_IdentifyObject(mutex_id1); 
+    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);   
+
+    expected = OS_OBJECT_TYPE_OS_TIMEBASE;
+    actual   = OS_IdentifyObject(time_base_id); 
+    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);  
+
+    /*
+     * Test with extreme cases using min and max values
+     * Note: There are no asserts, checks or expected values 
+     * here.  The only check is that the function doesn't return
+     * an error when called
+     */
+    OS_IdentifyObject(0x00000); 
+    OS_IdentifyObject(0xFFFFFFFF); 
+
+    /*
+     * Test Case For:
+     * int32 OS_ConvertToArrayIndex(void)
+     */
+    expected = OS_SUCCESS;
+
+    /*
+     * Check different id types and verify array indices
+     * Each Object Type index is added to an array index of its own type
+     * Each object type is checked once, and MUTEX is checked twice to 
+     * verify multiple indices
+     */
+
+    /*
+     * Test with nominal values
+     */
+    actual   = OS_ConvertToArrayIndex(task_id, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(queue_id, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(count_sem_id, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(bin_sem_id, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 2 , "TestArrayIndex(%lu) == 2", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(mutex_id1, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(mutex_id2, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 2 , "TestArrayIndex(%lu) == 2", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(mutex_id3, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 3 , "TestArrayIndex(%lu) == 3", (long)TestArrayIndex);
+
+    actual   = OS_ConvertToArrayIndex(time_base_id, &TestArrayIndex);
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+    UtAssert_True(TestArrayIndex == 1 , "TestArrayIndex(%lu) == 1", (long)TestArrayIndex);
+
+    /*
+     * Test with extreme cases using invalid inputs and checking
+     * for an error return code 
+     */
+    actual   = OS_ConvertToArrayIndex(0x0000, &TestArrayIndex);
+    expected = OS_ERR_INCORRECT_OBJ_TYPE;
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+
+    actual   = OS_ConvertToArrayIndex(0xFFFFFFFF, &TestArrayIndex);
+    expected = OS_ERR_INCORRECT_OBJ_TYPE;
+    UtAssert_True(actual == expected , "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected );
+
+    /*
+     * Test Case For:
+     * void OS_ForEachObject (uint32 creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg);
+     */
+    memset(&Count, 0, sizeof(Count));
+
+    OS_ForEachObject (0, &ObjTypeCounter, &Count);
+
+    /* Verify Outputs */
+    UtAssert_True(Count.TaskCount == 1, "OS_ForEachObject() TaskCount (%lu) == 1", (unsigned long)Count.TaskCount);
+    UtAssert_True(Count.QueueCount == 1, "OS_ForEachObject() QueueCount (%lu) == 1", (unsigned long)Count.QueueCount);
+    UtAssert_True(Count.CountSemCount == 1, "OS_ForEachObject() CountSemCount (%lu) == 1", (unsigned long)Count.CountSemCount);
+    UtAssert_True(Count.BinSemCount == 2, "OS_ForEachObject() BinSemCount (%lu) == 2", (unsigned long)Count.BinSemCount);
+    UtAssert_True(Count.MutexCount == 3, "OS_ForEachObject() MutexCount (%lu) == 3", (unsigned long)Count.MutexCount);
+    UtAssert_True(Count.TimeBaseCount == 1, "OS_ForEachObject() TimeBaseCount (%lu) == 1", (unsigned long)Count.TimeBaseCount);
+
+    /*
+     * Use current task as an input
+     */
+    memset(&Count, 0, sizeof(Count));
+    OS_ForEachObject (task_id, &ObjTypeCounter, &Count);
+
+    /* Verify Output */
+    UtAssert_True(Count.BinSemCount == 1, "OS_ForEachObject() BinSemCount MyTask (%lu) == 1", (unsigned long)Count.BinSemCount);
+
+    /*
+     * Delete all created objects, and verify that the count is now zero
+     */
+    memset(&Count, 0, sizeof(Count));
+    OS_DeleteAllObjects();
+    OS_ForEachObject (0, &ObjTypeCounter, &Count);
+
+    /* Verify Outputs */
+    UtAssert_True(Count.TaskCount == 0, "OS_ForEachObject() TaskCount After Delete (%lu) == 0", (unsigned long)Count.TaskCount);
+    UtAssert_True(Count.QueueCount == 0, "OS_ForEachObject() QueueCount After Delete (%lu) == 0", (unsigned long)Count.QueueCount);
+    UtAssert_True(Count.CountSemCount == 0, "OS_ForEachObject() CountSemCount After Delete (%lu) == 0", (unsigned long)Count.CountSemCount);
+    UtAssert_True(Count.BinSemCount == 0, "OS_ForEachObject() BinSemCount After Delete (%lu) == 0", (unsigned long)Count.BinSemCount);
+    UtAssert_True(Count.MutexCount == 0, "OS_ForEachObject() MutexCount After Delete (%lu) == 0", (unsigned long)Count.MutexCount);
+    UtAssert_True(Count.TimeBaseCount == 0, "OS_ForEachObject() TimeBaseCount After Delete (%lu) == 0", (unsigned long)Count.TimeBaseCount);
+
+    /*
+     * Pass an invalid input, and verify that object counts are not increased
+     */
+    OS_ForEachObject (0xFFFFFFFF, &ObjTypeCounter, &Count); 
+
+    /* Verify Outputs */
+    UtAssert_True(Count.TaskCount == 0, "OS_ForEachObject() TaskCount Invalid Input (%lu) == 0", (unsigned long)Count.TaskCount);
+    UtAssert_True(Count.QueueCount == 0, "OS_ForEachObject() QueueCount Invalid Input (%lu) == 0", (unsigned long)Count.QueueCount);
+    UtAssert_True(Count.CountSemCount == 0, "OS_ForEachObject() CountSemCount Invalid Input (%lu) == 0", (unsigned long)Count.CountSemCount);
+    UtAssert_True(Count.BinSemCount == 0, "OS_ForEachObject() BinSemCount Invalid Input (%lu) == 0", (unsigned long)Count.BinSemCount);
+    UtAssert_True(Count.MutexCount == 0, "OS_ForEachObject() MutexCount Invalid Input (%lu) == 0", (unsigned long)Count.MutexCount);
+    UtAssert_True(Count.TimeBaseCount == 0, "OS_ForEachObject() TimeBaseCount Invalid Input (%lu) == 0", (unsigned long)Count.TimeBaseCount);
+
+
+
+
+} /* end TestIdMapApi */
+
+
+void UtTest_Setup(void)
+{
+    if (OS_API_Init() != OS_SUCCESS)
+    {
+        UtAssert_Abort("OS_API_Init() failed");
+    }
+
+    /*
+     * Register the test setup and check routines in UT assert
+     */
+    UtTest_Add(TestIdMapApi, NULL, NULL, "TestIdMapApi");
+}
+


### PR DESCRIPTION
Fix #374, Object Utility API's missing functional test

**Describe the contribution**
Created missing functional tests for the OS_IdentifyObject, OS_ConvertToArrayIndex and OS_ForEachObject functions.  

**Testing performed**
Steps taken to test the contribution:
1. Standard build and ran unit tests.

**Expected behavior changes**

**System(s) tested on**
cFS Dev Server
OS: Ubuntu 18.04
Versions: OSAL 5.0.11.0

**Contributor Info **
Yasir Khan
NASA GSFC