### PR TITLE
Fix #435, fix string manipulations to avoid warnings

### DIFF
--- a/src/os/shared/inc/os-shared-filesys.h
+++ b/src/os/shared/inc/os-shared-filesys.h
@@ -96,8 +96,8 @@ typedef struct
 typedef struct
 {
     char device_name[OS_MAX_API_NAME];      /**< The name of the underlying block device, if applicable */
-    char volume_name[OS_MAX_API_NAME];
-    char system_mountpt[OS_MAX_PATH_LEN];   /**< The name/prefix where the contents are accessible in the host operating system */
+    char volume_name[OS_FS_VOL_NAME_LEN];
+    char system_mountpt[OS_MAX_LOCAL_PATH_LEN]; /**< The name/prefix where the contents are accessible in the host operating system */
     char virtual_mountpt[OS_MAX_PATH_LEN];  /**< The name/prefix in the OSAL Virtual File system exposed to applications */
     char *address;
     uint32 blocksize;

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -116,18 +116,21 @@ int32 OS_FileSys_InitLocalFromVolTable(OS_filesys_internal_record_t *local, cons
             strcmp(Vol->DeviceName,"unused") != 0)
     {
         strncpy(local->volume_name, Vol->VolumeName, sizeof(local->volume_name)-1);
+        local->volume_name[sizeof(local->volume_name)-1] = 0;
     }
 
     if (isgraph((int)Vol->PhysDevName[0]) &&
             strcmp(Vol->PhysDevName,"unused") != 0)
     {
         strncpy(local->system_mountpt, Vol->PhysDevName, sizeof(local->system_mountpt)-1);
+        local->system_mountpt[sizeof(local->system_mountpt)-1] = 0;
     }
 
     if (isgraph((int)Vol->MountPoint[0]) &&
             strcmp(Vol->MountPoint,"unused") != 0)
     {
         strncpy(local->virtual_mountpt, Vol->MountPoint, sizeof(local->virtual_mountpt)-1);
+        local->virtual_mountpt[sizeof(local->virtual_mountpt)-1] = 0;
     }
 
     /*
@@ -471,10 +474,10 @@ int32 OS_FileSysAddFixedMap(uint32 *filesys_id, const char *phys_path, const cha
 
         memset(local, 0, sizeof(*local));
         global->name_entry = local->device_name;
-        strcpy(local->device_name, dev_name);
-        strcpy(local->volume_name, dev_name);
-        strcpy(local->system_mountpt, phys_path);
-        strcpy(local->virtual_mountpt, virt_path);
+        strncpy(local->device_name, dev_name, sizeof(local->device_name)-1);
+        strncpy(local->volume_name, dev_name, sizeof(local->volume_name)-1);
+        strncpy(local->system_mountpt, phys_path, sizeof(local->system_mountpt)-1);
+        strncpy(local->virtual_mountpt, virt_path, sizeof(local->virtual_mountpt)-1);
 
         /*
          * mark the entry that it is a fixed disk

--- a/src/unit-tests/inc/ut_os_support.h
+++ b/src/unit-tests/inc/ut_os_support.h
@@ -79,7 +79,7 @@ static inline bool UtOsalImplemented(int32 Fn, const char *File, uint32 Line)
 /*--------------------------------------------------------------------------------*/
 
 #define UT_os_sprintf(buf,...)  \
-    do { int x = snprintf(buf,sizeof(buf),__VA_ARGS__); if (x > 0) buf[x] = 0; } while (0)
+    do { int x = snprintf(buf,sizeof(buf),__VA_ARGS__); if (x > 0 && x < sizeof(buf)) buf[x] = 0; } while (0)
 
 /*--------------------------------------------------------------------------------*/
 

--- a/src/unit-tests/inc/ut_os_support.h
+++ b/src/unit-tests/inc/ut_os_support.h
@@ -79,7 +79,7 @@ static inline bool UtOsalImplemented(int32 Fn, const char *File, uint32 Line)
 /*--------------------------------------------------------------------------------*/
 
 #define UT_os_sprintf(buf,...)  \
-    snprintf(buf,sizeof(buf),__VA_ARGS__)
+    do { int x = snprintf(buf,sizeof(buf),__VA_ARGS__); if (x > 0) buf[x] = 0; } while (0)
 
 /*--------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
**Describe the contribution**
Resize buffers and add explicit termination to string copies.
Avoids warnings on GCC9 with strict settings and optimization enabled.

Fixes #435

**Testing performed**
Build with default config and gcc 9.3.0 and confirm warnings are gone

**Expected behavior changes**
Warnings fixed.

**System(s) tested on**
Ubuntu 20.04 LTS

**Additional context**
Currently a draft because it uses PR #427 as a baseline.  Will mark as non-draft once prerequisite is merged.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey Vantage Systems, Inc.