### PR TITLE
Fix #235, add check against OS_MAX_QUEUE_DEPTH

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -507,6 +507,7 @@ int32 OS_TaskGetInfo           (uint32 task_id, OS_task_prop_t *task_prop);
  * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
  * @retval #OS_ERR_NO_FREE_IDS if there are already the max queues created
  * @retval #OS_ERR_NAME_TAKEN if the name is already being used on another queue
+ * @retval #OS_QUEUE_INVALID_SIZE if the queue depth exceeds the limit
  * @retval #OS_ERROR if the OS create call fails
  */
 int32 OS_QueueCreate           (uint32 *queue_id, const char *queue_name,

--- a/src/os/shared/src/osapi-queue.c
+++ b/src/os/shared/src/osapi-queue.c
@@ -102,6 +102,11 @@ int32 OS_QueueCreate (uint32 *queue_id, const char *queue_name, uint32 queue_dep
       return OS_ERR_NAME_TOO_LONG;
    }
 
+   if ( queue_depth > OS_QUEUE_MAX_DEPTH )
+   {
+       return OS_QUEUE_INVALID_SIZE;
+   }
+
    /* Note - the common ObjectIdAllocate routine will lock the object type and leave it locked. */
    return_code = OS_ObjectIdAllocateNew(LOCAL_OBJID_TYPE, queue_name, &local_id, &record);
    if(return_code == OS_SUCCESS)

--- a/src/unit-test-coverage/shared/src/coveragetest-queue.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-queue.c
@@ -63,6 +63,10 @@ void Test_OS_QueueCreate(void)
     actual = OS_QueueCreate(&objid, "UT", 0, 0,0);
     UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strlen));
+
+    expected = OS_QUEUE_INVALID_SIZE;
+    actual = OS_QueueCreate(&objid, "UT", 1 + OS_QUEUE_MAX_DEPTH, 0,0);
+    UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_QUEUE_INVALID_SIZE", (long)actual);
 }
 
 void Test_OS_QueueDelete(void)


### PR DESCRIPTION
**Describe the contribution**
The `OS_QueueCreate()` function will now sanity check the depth parameter against the configured OS_MAX_QUEUE_DEPTH value.  If it is too large, an error will be returned.  This is a hard limit
and independent of the "permissive" mode.

The OS_MAX_QUEUE_DEPTH should be configured to the largest value that an application may reasonably request.

Fix #235 

**Testing performed**
Confirm CFE framework starts and operates normally (but see nasa/to_lab#36)
Confirm OSAL unit tests pass

**Expected behavior changes**
`OS_QueueCreate()` will return an error code if the depth parameter is larger than the configured `OS_MAX_QUEUE_DEPTH`.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.