### PR TITLE
Integration Candidate COMBINED 2020-04-29 and 2020-05-06

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 Travis-CI: [![Build Status](https://travis-ci.com/nasa/osal.svg)](https://travis-ci.com/nasa/osal)
 
-Operating System Abstraction Layer Project
-==========================================
+# Operating System Abstraction Layer Project
 
 ![OSAL Logo by Michael Cudmore](./doc/OSAL-Logo.png)
 
-
 The OS Abstraction Layer was originally devloped by the Flight Software Systems Branch at NASA Goddard Space Flight Center.
 
-OS Abstraction Layer information:
-=================================
+# OS Abstraction Layer information:
 
 This distribution contains:
 
@@ -19,156 +16,185 @@ This distribution contains:
 
 ## Version History
 
+### Development Build: 5.0.16
 
-#### Development Build:  5.0.15
+- Resized buffers and added explicit termination to string copies. No warnings on GCC9 with strict settings and optimization enabled.
 
-- Changes the build system. 
+- New API to reverse lookup an OS-provided thread/task identifier back to an OSAL ID. Any use of existing OStask_id field within the task property structure is now deprecated.
+
+- See <https://github.com/nasa/osal/pull/458>
+
+### Development Build: 5.0.15
+
+- Changes the build system.
 - No more user-maintained osconfig.h file, this is now replaced by a cmake configuration file.
 - Breaks up low-level implementation into small, separate subsystem units, with a separate header file for each one.
-- See https://github.com/nasa/osal/pull/444
+- See <https://github.com/nasa/osal/pull/444>
 
-#### Development Build:  5.0.14
-  - Adds library build, functional, and coverage test to CI
-  - Deprecates `OS_FS_SUCCESS, OS_FS_ERROR , OS_FS_ERR_INVALID_POINTER, OS_FS_ERR_NO_FREE_FDS , OS_FS_ERR_INVALID_FD, and OS_FS_UNIMPLEMENTED` from from `osapi-os-filesys.h`
-  - Individual directory names now limited to OS_MAX_FILE_NAME
-  - Fix tautology, local_idx1 is now compared with local_idx2
-  - Module files are generated when the `osal_loader_UT` test is built and run
-  - Consistent osal-core-test execution status
-  - See https://github.com/nasa/osal/pull/440 for more details
-  
-#### Development Build:  5.0.13
-  - Added coverage test to `OS_TimerCreate` for `OS_ERR_NAME_TOO_LONG`.
-  - Externalize enum for `SelectSingle`, ensures that pointers passed to `SelectFd...()` APIs are not null, ensures that pointer to `SelectSingle` is not null.
-  - Command to run in shell and output to fill will fail with default (not implemented) setting.
-  - Builds successfully using the inferred OS when only `OSAL_SYSTEM_BSPTYPE` is set. Generates a warning when `OSAL_SYSTEM_BSPTYPE` and `OSAL_SYSTEM_OSTYPE` are both set but are mismatched.
-  - See https://github.com/nasa/osal/pull/433 for more details
+### Development Build: 5.0.14
 
-#### Development Build:  5.0.12
-  - Use the target_include_directories and target_compile_definitions functions from CMake to manage the build flags per target.
-  - Build implementation components using a separate CMakeLists.txt file rather than aux_source_directory.
-  - Provide sufficient framework for combining the OSAL BSP, UT BSP, and the CFE PSP and eliminating the duplication/overlap between these items.
-  - Minor updates (see https://github.com/nasa/osal/pull/417)
+- Adds library build, functional, and coverage test to CI
+- Deprecates `OS_FS_SUCCESS, OS_FS_ERROR , OS_FS_ERR_INVALID_POINTER, OS_FS_ERR_NO_FREE_FDS , OS_FS_ERR_INVALID_FD, and OS_FS_UNIMPLEMENTED` from from `osapi-os-filesys.h`
+- Individual directory names now limited to OS_MAX_FILE_NAME
+- Fix tautology, local_idx1 is now compared with local_idx2
+- Module files are generated when the `osal_loader_UT` test is built and run
+- Consistent osal-core-test execution status
+- See <https://github.com/nasa/osal/pull/440> for more details
 
-#### Development Build:  5.0.11
-  - The more descriptive return value OS_ERR_NAME_NOT_FOUND (instead of OS_FS_ERROR) will now be returned from the following functions (): OS_rmfs, OS_mount, OS_unmount, OS_FS_GetPhysDriveName
-  - Wraps OS_ShMem* prototype and unit test wrapper additions in OSAL_OMIT_DEPRECATED
-  - Minor updates (see https://github.com/nasa/osal/pull/408)
+### Development Build: 5.0.13
 
-#### Development Build:  5.0.10
-  - Minor updates (see https://github.com/nasa/osal/pull/401)
-- 5.0.9: DEVELOPMENT
-  - Documentation updates (see https://github.com/nasa/osal/pull/375)
+- Added coverage test to `OS_TimerCreate` for `OS_ERR_NAME_TOO_LONG`.
+- Externalize enum for `SelectSingle`, ensures that pointers passed to `SelectFd...()` APIs are not null, ensures that pointer to `SelectSingle` is not null.
+- Command to run in shell and output to fill will fail with default (not implemented) setting.
+- Builds successfully using the inferred OS when only `OSAL_SYSTEM_BSPTYPE` is set. Generates a warning when `OSAL_SYSTEM_BSPTYPE` and `OSAL_SYSTEM_OSTYPE` are both set but are mismatched.
+- See <https://github.com/nasa/osal/pull/433> for more details
 
-#### Development Build:  5.0.8
-  - Minor updates (see https://github.com/nasa/osal/pull/369)
+### Development Build: 5.0.12
 
-#### Development Build:  5.0.7
-  - Fixes memset bug
-  - Minor updates (see https://github.com/nasa/osal/pull/361)
+- Use the target_include_directories and target_compile_definitions functions from CMake to manage the build flags per target.
+- Build implementation components using a separate CMakeLists.txt file rather than aux_source_directory.
+- Provide sufficient framework for combining the OSAL BSP, UT BSP, and the CFE PSP and eliminating the duplication/overlap between these items.
+- Minor updates (see <https://github.com/nasa/osal/pull/417>)
 
-#### Development Build:  5.0.6
-  - Minor updates (see https://github.com/nasa/osal/pull/355)
+### Development Build: 5.0.11
 
-#### Development Build:  5.0.5
-  - Fixed osal_timer_UT test failure case
-  - Minor updates (see https://github.com/nasa/osal/pull/350)
+- The more descriptive return value OS_ERR_NAME_NOT_FOUND (instead of OS_FS_ERROR) will now be returned from the following functions (): OS_rmfs, OS_mount, OS_unmount, OS_FS_GetPhysDriveName
+- Wraps OS_ShMem* prototype and unit test wrapper additions in OSAL_OMIT_DEPRECATED
+- Minor updates (see <https://github.com/nasa/osal/pull/408>)
 
-#### Development Build:  5.0.4
-  - Minor updates (see https://github.com/nasa/osal/pull/334)
+### Development Build: 5.0.10
 
-#### Development Build:  5.0.3
-  - Minor updates (see https://github.com/nasa/osal/pull/292)
+- Minor updates (see <https://github.com/nasa/osal/pull/401>)
 
-#### Development Build:  5.0.2
-  - Bug fixes and minor updates (see https://github.com/nasa/osal/pull/281)
+  - 5.0.9: DEVELOPMENT
 
-#### Development Build:  5.0.1
-  - Minor updates (see https://github.com/nasa/osal/pull/264)
+- Documentation updates (see <https://github.com/nasa/osal/pull/375>)
 
-#### ***Release Candidate: 5.0.0µ***
-  - In build verification testing to be considered for official release
-  - Release documentation in work
-  - This is a point release from an internal repository
+### Development Build: 5.0.8
 
-### ***OFFICIAL RELEASE: 4.2.1a***
-  - Released under the NOSA license, see [LICENSE](LICENSE)
-  - See [version description document](OSAL%204.2.1.0%20Version%20Description%20Document.pdf)
-  - This is a point release from an internal repository
+- Minor updates (see <https://github.com/nasa/osal/pull/369>)
 
-Getting Started:
-================
+### Development Build: 5.0.7
 
-See the document *doc/OSAL-Configuration-Guide.doc* for complete details.
+- Fixes memset bug
+- Minor updates (see <https://github.com/nasa/osal/pull/361>)
 
-See User's Guide: https://github.com/nasa/cFS/blob/gh-pages/OSAL_Users_Guide.pdf
+### Development Build: 5.0.6
+
+- Minor updates (see <https://github.com/nasa/osal/pull/355>)
+
+### Development Build: 5.0.5
+
+- Fixed osal_timer_UT test failure case
+- Minor updates (see <https://github.com/nasa/osal/pull/350>)
+
+### Development Build: 5.0.4
+
+- Minor updates (see <https://github.com/nasa/osal/pull/334>)
+
+### Development Build: 5.0.3
+
+- Minor updates (see <https://github.com/nasa/osal/pull/292>)
+
+### Development Build: 5.0.2
+
+- Bug fixes and minor updates (see <https://github.com/nasa/osal/pull/281>)
+
+### Development Build: 5.0.1
+
+- Minor updates (see <https://github.com/nasa/osal/pull/264>)
+
+### **_Release Candidate: 5.0.0µ_**
+
+- In build verification testing to be considered for official release
+- Release documentation in work
+- This is a point release from an internal repository
+
+### **_OFFICIAL RELEASE: 4.2.1a_**
+
+- Released under the NOSA license, see 
+
+  <license>
+  </license>
+
+- See [version description document](OSAL%204.2.1.0%20Version%20Description%20Document.pdf)
+- This is a point release from an internal repository
+
+# Getting Started:
+
+See the document _doc/OSAL-Configuration-Guide.doc_ for complete details.
+
+See User's Guide: <https://github.com/nasa/cFS/blob/gh-pages/OSAL_Users_Guide.pdf>
 
 An easy way to get started is to use the Linux port and classic build:
 
-1. Set the *OSAL_SRC* environment variable to point to the OSAL source code.
-     - Running setvars.sh will set the variable for you ($source ./setvars.sh)
-2. Edit the *build/osal-config.mak* file and set the following options:
-     - BSP - Set this to the board you are running on. For a PC running linux, use *pc-linux*
-     - OS - Set this to the OS you are running. For a PC running linux, use *posix*.
-     - OSAL_M32 - Uncomment/Add this build variable for building 32-bit images using "native"
-       GCC on a 64-bit X86 Linux platform
+1. Set the _OSAL_SRC_ environment variable to point to the OSAL source code.
+
+  - Running setvars.sh will set the variable for you ($source ./setvars.sh)
+
+2. Edit the _build/osal-config.mak_ file and set the following options:
+
+  - BSP - Set this to the board you are running on. For a PC running linux, use _pc-linux_
+  - OS - Set this to the OS you are running. For a PC running linux, use _posix_.
+  - OSAL_M32 - Uncomment/Add this build variable for building 32-bit images using "native" GCC on a 64-bit X86 Linux platform
 
 Buiding on a PC running linux:
 
-    export OSAL_SRC = /home/acudmore/osal/src
+```
+export OSAL_SRC = /home/acudmore/osal/src
+```
 
 In build/osal-config.mak:
 
-    OS=posix
-    BSP=pc-linux
+```
+OS=posix
+BSP=pc-linux
 
-    Optional: OSAL_M32 = -m32 (Note: Usage of this flag may require an optional 'multilib' (or similar)
-    package to be installed. Refer to your operating system and toolchain documentation for details, if
-    adding the appropriate flag causes your builds to fail due to (for example) missing 32-bit or
-    multilib related headers or libraries.)
+Optional: OSAL_M32 = -m32 (Note: Usage of this flag may require an optional 'multilib' (or similar)
+package to be installed. Refer to your operating system and toolchain documentation for details, if
+adding the appropriate flag causes your builds to fail due to (for example) missing 32-bit or
+multilib related headers or libraries.)
+```
 
-Optional:  Some Linux systems may require an additional linker option in
-    src/bsp/pc-linux/make/link-rules.mak:
+Optional: Some Linux systems may require an additional linker option in src/bsp/pc-linux/make/link-rules.mak:
 
-    LDFLAGS ?= $(OSAL_M32) -export-dynamic
+```
+LDFLAGS ?= $(OSAL_M32) -export-dynamic
 
-    If the symbol-api-test fails, then you need this option.
+If the symbol-api-test fails, then you need this option.
+```
 
-Now just type *make config; make* from the build directory and it should build the OSAL core files, tests, and sample
-applications for you. The binary for each application is in its own directory
-(i.e. build/examples/tasking-example/tasking-example.bin) You can switch to that directory and run it. You
-can also debug it using GDB.
+Now just type _make config; make_ from the build directory and it should build the OSAL core files, tests, and sample applications for you. The binary for each application is in its own directory (i.e. build/examples/tasking-example/tasking-example.bin) You can switch to that directory and run it. You can also debug it using GDB.
 
 NOTE: Running on linux may require root or adjusting the posix message queue maximum sizes.
 
-The Embedded targets take a little more work to run, because they must be cross compiled and booted on the board.
-By copying a target, you should be able to come up with a new target.
+The Embedded targets take a little more work to run, because they must be cross compiled and booted on the board. By copying a target, you should be able to come up with a new target.
 
-If you would like just the OSAL itself, just look in src/os/inc for the include files and src/os/<your os here>
-for the OSAL implementation.
+If you would like just the OSAL itself, just look in src/os/inc for the include files and src/os/
 
-The API documentation is in the *doc* directory.
+<your os="" here="">
+for the OSAL implementation.</your>
 
-There are two sets of tests: build/tests and build/unit-tests.  To build and the unit tests,
-perform the build steps above then *make unit-tests* in the build directory.
+The API documentation is in the _doc_ directory.
 
-Instructions on how to use the newely supported cmake build system are provided in the OSAL Configuration Guide
-located in the *doc* directory.
+There are two sets of tests: build/tests and build/unit-tests. To build and the unit tests, perform the build steps above then _make unit-tests_ in the build directory.
 
-Contact Information:
-====================
+Instructions on how to use the newely supported cmake build system are provided in the OSAL Configuration Guide located in the _doc_ directory.
 
-    Alan Cudmore
-    NASA Goddard Space Flight Center
-    Code 582.0
-    Greenbelt, MD 20771
-    Alan.P.Cudmore@nasa.gov
+# Contact Information:
 
-Copyright notice:
-=================
+```
+Alan Cudmore
+NASA Goddard Space Flight Center
+Code 582.0
+Greenbelt, MD 20771
+Alan.P.Cudmore@nasa.gov
+```
+
+# Copyright notice:
 
 Copyright United States Government as represented by the Administrator of the National Aeronautics and Space Administration
 
-License information:
-====================
+# License information:
 
 This software is licensed under NASAs Open Source Agreement. The release of the software is conditional upon the recipients acceptance of the Open Source Agreement. Please see the file: NASA_Open_Source_Agreement_1_3-OS_AbstractionLayer.txt

--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -73,7 +73,9 @@ typedef struct
     uint32 creator;
     uint32 stack_size;
     uint32 priority;
-    uint32 OStask_id;
+#ifndef OSAL_OMIT_DEPRECATED
+    uint32 OStask_id;   /**< @deprecated */
+#endif
 }OS_task_prop_t;
     
 /** @brief OSAL queue properties */
@@ -479,6 +481,29 @@ int32 OS_TaskGetIdByName       (uint32 *task_id, const char *task_name);
  * @retval #OS_INVALID_POINTER if the task_prop pointer is NULL
  */
 int32 OS_TaskGetInfo           (uint32 task_id, OS_task_prop_t *task_prop);          
+
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Reverse-lookup the OSAL task ID from an operating system ID
+ *
+ * This provides a method by which an external entity may find the OSAL task
+ * ID corresponding to a system-defined identifier (e.g. TASK_ID, pthread_t, rtems_id, etc).
+ *
+ * Normally OSAL does not expose the underlying OS-specific values to the application,
+ * but in some circumstances, such as exception handling, the OS may provide this information
+ * directly to handler outside of the normal OSAL API.
+ *
+ * @param[out]  task_id         The buffer where the task id output is stored
+ * @param[in]   sysdata         Pointer to the system-provided identification data
+ * @param[in]   sysdata_size    Size of the system-provided identification data
+ *
+ * @return Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
+ */
+int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sysdata_size);
+
+
 /**@}*/
 
 /** @defgroup OSAPIMsgQueue OSAL Message Queue APIs

--- a/src/os/inc/osapi-version.h
+++ b/src/os/inc/osapi-version.h
@@ -20,7 +20,7 @@
 
 #define OS_MAJOR_VERSION 5  /**< @brief Major version number */
 #define OS_MINOR_VERSION 0  /**< @brief Minor version number */
-#define OS_REVISION      15  /**< @brief Revision number */
+#define OS_REVISION      16  /**< @brief Revision number */
 #define OS_MISSION_REV   0  /**< @brief Mission revision */
 
 /**

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -761,7 +761,8 @@ uint32 OS_TaskGetId_Impl (void)
  *-----------------------------------------------------------------*/
 int32 OS_TaskGetInfo_Impl (uint32 task_id, OS_task_prop_t *task_prop)
 {
-   size_t copy_sz;
+#ifndef OSAL_OMIT_DEPRECATED
+    size_t copy_sz;
 
    /*
     * NOTE - this is not really valid, as you can't officially
@@ -783,7 +784,43 @@ int32 OS_TaskGetInfo_Impl (uint32 task_id, OS_task_prop_t *task_prop)
    }
 
    memcpy(&task_prop->OStask_id, &OS_impl_task_table[task_id].id, copy_sz);
+#endif
 
    return OS_SUCCESS;
 } /* end OS_TaskGetInfo_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskIdMatchSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+{
+    const pthread_t *target = (const pthread_t *)ref;
+
+    return (pthread_equal(*target, OS_impl_task_table[local_id].id) != 0);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskValidateSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+{
+    if (sysdata == NULL || sysdata_size != sizeof(pthread_t))
+    {
+        return OS_INVALID_POINTER;
+    }
+    return OS_SUCCESS;
+}
+
+
 

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -328,9 +328,42 @@ uint32 OS_TaskGetId_Impl (void)
  *-----------------------------------------------------------------*/
 int32 OS_TaskGetInfo_Impl (uint32 task_id, OS_task_prop_t *task_prop)
 {
+#ifndef OSAL_OMIT_DEPRECATED
     task_prop->OStask_id =  (uint32) OS_impl_task_table[task_id].id;
+#endif
     return OS_SUCCESS;
 
 } /* end OS_TaskGetInfo_Impl */
 
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskValidateSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+{
+    if (sysdata == NULL || sysdata_size != sizeof(rtems_id))
+    {
+        return OS_INVALID_POINTER;
+    }
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskIdMatchSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+{
+    const rtems_id *target = (const rtems_id *)ref;
+
+    return (*target == OS_impl_task_table[local_id].id);
+}
 

--- a/src/os/shared/inc/os-shared-filesys.h
+++ b/src/os/shared/inc/os-shared-filesys.h
@@ -96,8 +96,8 @@ typedef struct
 typedef struct
 {
     char device_name[OS_MAX_API_NAME];      /**< The name of the underlying block device, if applicable */
-    char volume_name[OS_MAX_API_NAME];
-    char system_mountpt[OS_MAX_PATH_LEN];   /**< The name/prefix where the contents are accessible in the host operating system */
+    char volume_name[OS_FS_VOL_NAME_LEN];
+    char system_mountpt[OS_MAX_LOCAL_PATH_LEN]; /**< The name/prefix where the contents are accessible in the host operating system */
     char virtual_mountpt[OS_MAX_PATH_LEN];  /**< The name/prefix in the OSAL Virtual File system exposed to applications */
     char *address;
     uint32 blocksize;

--- a/src/os/shared/inc/os-shared-task.h
+++ b/src/os/shared/inc/os-shared-task.h
@@ -158,5 +158,26 @@ int32  OS_TaskGetInfo_Impl           (uint32 task_id, OS_task_prop_t *task_prop)
 int32  OS_TaskRegister_Impl          (uint32 global_task_id);
 
 
+/*----------------------------------------------------------------
+
+   Function: OS_TaskIdMatchSystemData_Impl
+
+    Purpose: A helper "match" function to find an OSAL task ID based on system ID
+             Compatible with the "OS_ObjectIdFindBySearch" routine
+
+ ------------------------------------------------------------------*/
+bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj);
+
+/*----------------------------------------------------------------
+
+   Function: OS_TaskValidateSystemData_Impl
+
+    Purpose: Checks that the supplied sysdata pointer and sysdata_size are
+             compatible/reasonable for the underlying OS.
+
+ ------------------------------------------------------------------*/
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size);
+
+
 #endif  /* INCLUDE_OS_SHARED_TASK_H_ */
 

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -116,18 +116,21 @@ int32 OS_FileSys_InitLocalFromVolTable(OS_filesys_internal_record_t *local, cons
             strcmp(Vol->DeviceName,"unused") != 0)
     {
         strncpy(local->volume_name, Vol->VolumeName, sizeof(local->volume_name)-1);
+        local->volume_name[sizeof(local->volume_name)-1] = 0;
     }
 
     if (isgraph((int)Vol->PhysDevName[0]) &&
             strcmp(Vol->PhysDevName,"unused") != 0)
     {
         strncpy(local->system_mountpt, Vol->PhysDevName, sizeof(local->system_mountpt)-1);
+        local->system_mountpt[sizeof(local->system_mountpt)-1] = 0;
     }
 
     if (isgraph((int)Vol->MountPoint[0]) &&
             strcmp(Vol->MountPoint,"unused") != 0)
     {
         strncpy(local->virtual_mountpt, Vol->MountPoint, sizeof(local->virtual_mountpt)-1);
+        local->virtual_mountpt[sizeof(local->virtual_mountpt)-1] = 0;
     }
 
     /*
@@ -471,10 +474,10 @@ int32 OS_FileSysAddFixedMap(uint32 *filesys_id, const char *phys_path, const cha
 
         memset(local, 0, sizeof(*local));
         global->name_entry = local->device_name;
-        strcpy(local->device_name, dev_name);
-        strcpy(local->volume_name, dev_name);
-        strcpy(local->system_mountpt, phys_path);
-        strcpy(local->virtual_mountpt, virt_path);
+        strncpy(local->device_name, dev_name, sizeof(local->device_name)-1);
+        strncpy(local->volume_name, dev_name, sizeof(local->volume_name)-1);
+        strncpy(local->system_mountpt, phys_path, sizeof(local->system_mountpt)-1);
+        strncpy(local->virtual_mountpt, virt_path, sizeof(local->virtual_mountpt)-1);
 
         /*
          * mark the entry that it is a fixed disk

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -512,3 +512,41 @@ int32 OS_TaskInstallDeleteHandler(osal_task_entry function_pointer)
 
    return return_code;
 } /* end OS_TaskInstallDeleteHandler */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskFindIdBySystemData
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sysdata_size)
+{
+    int32 return_code;
+    OS_common_record_t *record;
+
+    /* Check parameters */
+    if (task_id == NULL)
+    {
+       return OS_INVALID_POINTER;
+    }
+
+    /* The "sysdata" and "sysdata_size" must be passed to the underlying impl for validation */
+    return_code = OS_TaskValidateSystemData_Impl(sysdata, sysdata_size);
+    if (return_code != OS_SUCCESS)
+    {
+        return return_code;
+    }
+
+    return_code = OS_ObjectIdGetBySearch(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, OS_TaskIdMatchSystemData_Impl, (void*)sysdata, &record);
+    if (return_code == OS_SUCCESS)
+    {
+        *task_id = record->active_id;
+        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+    }
+
+    return return_code;
+} /* end OS_TaskFindIdBySystemData */
+
+

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -420,6 +420,7 @@ uint32 OS_TaskGetId_Impl (void)
  *-----------------------------------------------------------------*/
 int32 OS_TaskGetInfo_Impl (uint32 task_id, OS_task_prop_t *task_prop)
 {
+#ifndef OSAL_OMIT_DEPRECATED
     union
     {
         TASK_ID vxid;
@@ -434,8 +435,43 @@ int32 OS_TaskGetInfo_Impl (uint32 task_id, OS_task_prop_t *task_prop)
      */
     u.vxid = OS_impl_task_table[task_id].vxid;
     task_prop->OStask_id = u.value;
+#endif
 
     return OS_SUCCESS;
 
 } /* end OS_TaskGetInfo_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskValidateSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+{
+    if (sysdata == NULL || sysdata_size != sizeof(TASK_ID))
+    {
+        return OS_INVALID_POINTER;
+    }
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskIdMatchSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+{
+    const TASK_ID *target = (const TASK_ID *)ref;
+
+    return (*target == OS_impl_task_table[local_id].vxid);
+}
+
+
 

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -292,6 +292,51 @@ void Test_OS_TaskInstallDeleteHandler(void)
     OS_task_table[1].delete_hook_pointer = NULL;
 }
 
+void Test_OS_TaskFindIdBySystemData(void)
+{
+    /*
+     * Test Case For:
+     * int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sysdata_size)
+     */
+
+    int32 expected;
+    int32 actual;
+    uint32 task_id;
+
+    /*
+     * Use a compound data struct for the system data.
+     * The intent is to intentionally make something bigger that will not fit into e.g. "uint32"
+     */
+    struct
+    {
+        unsigned long v;
+        void *p;
+    } test_sysdata;
+
+    memset(&test_sysdata, 'x', sizeof(test_sysdata));
+
+    expected = OS_SUCCESS;
+    actual = OS_TaskFindIdBySystemData(&task_id, &test_sysdata, sizeof(test_sysdata));
+    UtAssert_True(actual == expected, "OS_TaskFindIdBySystemData() (%ld) == OS_SUCCESS", (long)actual);
+
+    /* Test parameter validation branches */
+    expected = OS_INVALID_POINTER;
+    actual = OS_TaskFindIdBySystemData(NULL, &test_sysdata, sizeof(test_sysdata));
+    UtAssert_True(actual == expected, "OS_TaskFindIdBySystemData() (%ld) == OS_INVALID_POINTER", (long)actual);
+
+    UT_SetForceFail(UT_KEY(OS_TaskValidateSystemData_Impl), expected);
+    actual = OS_TaskFindIdBySystemData(&task_id, &test_sysdata, sizeof(test_sysdata));
+    UtAssert_True(actual == expected, "OS_TaskFindIdBySystemData() (%ld) == OS_INVALID_POINTER", (long)actual);
+    UT_ClearForceFail(UT_KEY(OS_TaskValidateSystemData_Impl));
+
+    /* Test search failure */
+    expected = OS_ERR_NAME_NOT_FOUND;
+    UT_SetForceFail(UT_KEY(OS_ObjectIdGetBySearch), expected);
+    actual = OS_TaskFindIdBySystemData(&task_id, &test_sysdata, sizeof(test_sysdata));
+    UtAssert_True(actual == expected, "OS_TaskFindIdBySystemData() (%ld) == OS_ERR_NAME_NOT_FOUND", (long)actual);
+    UT_ClearForceFail(UT_KEY(OS_ObjectIdGetBySearch));
+}
+
 
 /* Osapi_Test_Setup
  *
@@ -332,6 +377,7 @@ void UtTest_Setup(void)
     ADD_TEST(OS_TaskGetIdByName);
     ADD_TEST(OS_TaskGetInfo);
     ADD_TEST(OS_TaskInstallDeleteHandler);
+    ADD_TEST(OS_TaskFindIdBySystemData);
 }
 
 

--- a/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
@@ -48,3 +48,10 @@ uint32 OS_TaskGetId_Impl            (void)
 UT_DEFAULT_STUB(OS_TaskGetInfo_Impl,(uint32 task_id, OS_task_prop_t *task_prop))
 UT_DEFAULT_STUB(OS_TaskRegister_Impl,(uint32 global_task_id))
 
+bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+{
+    return UT_DEFAULT_IMPL(OS_TaskIdMatchSystemData_Impl);
+}
+
+UT_DEFAULT_STUB(OS_TaskValidateSystemData_Impl,(const void *sysdata, uint32 sysdata_size))
+

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -188,6 +188,38 @@ void Test_OS_TaskGetInfo_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_TaskGetInfo_Impl(0,&task_prop), OS_SUCCESS);
 }
 
+void Test_OS_TaskValidateSystemData_Impl(void)
+{
+    /*
+     * Test Case For:
+     * int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+     */
+    OCS_TASK_ID test_sys_id;
+
+    memset(&test_sys_id, 'x', sizeof(test_sys_id));
+
+    OSAPI_TEST_FUNCTION_RC(OS_TaskValidateSystemData_Impl(&test_sys_id, sizeof(test_sys_id)), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskValidateSystemData_Impl(NULL, sizeof(test_sys_id)), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskValidateSystemData_Impl(&test_sys_id, sizeof(test_sys_id)-1), OS_INVALID_POINTER);
+}
+
+void Test_OS_TaskIdMatchSystemData_Impl(void)
+{
+    /*
+     * Test Case For:
+     * bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+     */
+    OCS_TASK_ID test_sys_id;
+
+    memset(&test_sys_id, 'x', sizeof(test_sys_id));
+
+    UT_TaskTest_SetImplTaskId(0, test_sys_id);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskIdMatchSystemData_Impl(&test_sys_id, 0, NULL), true);
+
+    memset(&test_sys_id, 'y', sizeof(test_sys_id));
+    OSAPI_TEST_FUNCTION_RC(OS_TaskIdMatchSystemData_Impl(&test_sys_id, 0, NULL), false);
+}
+
 
 /* ------------------- End of test cases --------------------------------------*/
 
@@ -234,6 +266,8 @@ void UtTest_Setup(void)
     ADD_TEST(OS_TaskRegister_Impl);
     ADD_TEST(OS_TaskGetId_Impl);
     ADD_TEST(OS_TaskGetInfo_Impl);
+    ADD_TEST(OS_TaskValidateSystemData_Impl);
+    ADD_TEST(OS_TaskIdMatchSystemData_Impl);
 }
 
 

--- a/src/unit-tests/inc/ut_os_support.h
+++ b/src/unit-tests/inc/ut_os_support.h
@@ -79,7 +79,7 @@ static inline bool UtOsalImplemented(int32 Fn, const char *File, uint32 Line)
 /*--------------------------------------------------------------------------------*/
 
 #define UT_os_sprintf(buf,...)  \
-    snprintf(buf,sizeof(buf),__VA_ARGS__)
+    do { int x = snprintf(buf,sizeof(buf),__VA_ARGS__); if (x > 0 && x < sizeof(buf)) buf[x] = 0; } while (0)
 
 /*--------------------------------------------------------------------------------*/
 

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -264,7 +264,6 @@ int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop)
     {
         task_prop->creator = 1;
         UT_FIXUP_ID(task_prop->creator, UT_OBJTYPE_TASK);
-        task_prop->OStask_id = task_id & 0xFFFF;
         task_prop->stack_size = 100;
         task_prop->priority = 150;
         strncpy(task_prop->name, "UnitTest", OS_MAX_API_NAME - 1);


### PR DESCRIPTION
**Describe the contribution**

Fix #437, add new API for obtaining exception task ID
Fix #435, Changes for string ops warnings 

**Testing performed**
See PRs
Bundle CI - https://travis-ci.com/github/nasa/cFS/builds/165726730

**Expected behavior changes**
PR #441 - Resized buffers and added explicit termination to string copies. No warnings on GCC9 with strict settings and optimization enabled.

PR #446 - New API to reverse lookup an OS-provided thread/task identifier back to an OSAL ID.
Any use of existing OStask_id field within the task property structure is now deprecated.


**System(s) tested on**
See PRs

**Additional context**
Part of nasa/cfs#83

**Contributor Info - All information REQUIRED for consideration of pull request**
 Joseph Hickey, Vantage Systems, Inc.