### PR TITLE
Fix #453, Select API and unit test updates

### DIFF
--- a/src/os/inc/osapi.h
+++ b/src/os/inc/osapi.h
@@ -77,6 +77,7 @@
 #define OS_ERR_INCORRECT_OBJ_STATE     (-35) /**< @brief Incorrect object state */
 #define OS_ERR_INCORRECT_OBJ_TYPE      (-36) /**< @brief Incorrect object type */
 #define OS_ERR_STREAM_DISCONNECTED     (-37) /**< @brief Stream disconnected */
+#define OS_ERR_OPERATION_NOT_SUPPORTED (-38) /**< @brief Requested operation is not support on the supplied object(s) */
 /**@}*/
 
 /*

--- a/src/os/shared/inc/os-shared-select.h
+++ b/src/os/shared/inc/os-shared-select.h
@@ -42,6 +42,7 @@
             Bits in "SelectFlags" will be unset according to activity
 
     Returns: OS_SUCCESS on success, or relevant error code
+             OS_ERR_OPERATION_NOT_SUPPORTED if the specified file handle does not support select
  ------------------------------------------------------------------*/
 int32 OS_SelectSingle_Impl(uint32 stream_id, uint32 *SelectFlags, int32 msecs);
 
@@ -66,6 +67,7 @@ int32 OS_SelectSingle_Impl(uint32 stream_id, uint32 *SelectFlags, int32 msecs);
           File descriptors in sets be modified according to activity
 
     Returns: OS_SUCCESS on success, or relevant error code
+             OS_ERR_OPERATION_NOT_SUPPORTED if the specified file handle(s) do not support select
  ------------------------------------------------------------------*/
 int32 OS_SelectMultiple_Impl(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs);
 

--- a/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
@@ -17,6 +17,7 @@
  *
  */
 #include "os-portable-coveragetest.h"
+#include "ut-adaptor-portable-posix-io.h"
 #include "os-shared-select.h"
 
 #include <OCS_sys_select.h>
@@ -32,7 +33,10 @@ void Test_OS_SelectSingle_Impl(void)
     struct OCS_timespec latertime;
 
     StreamID = 0;
+    UT_PortablePosixIOTest_Set_Selectable(0, false);
     SelectFlags = OS_STREAM_STATE_READABLE | OS_STREAM_STATE_WRITABLE;
+    OSAPI_TEST_FUNCTION_RC(OS_SelectSingle_Impl, (StreamID, &SelectFlags, 0), OS_ERR_OPERATION_NOT_SUPPORTED);
+    UT_PortablePosixIOTest_Set_Selectable(0, true);
     OSAPI_TEST_FUNCTION_RC(OS_SelectSingle_Impl, (StreamID, &SelectFlags, 0), OS_SUCCESS);
     SelectFlags = OS_STREAM_STATE_READABLE | OS_STREAM_STATE_WRITABLE;
     OSAPI_TEST_FUNCTION_RC(OS_SelectSingle_Impl, (StreamID, &SelectFlags, -1), OS_SUCCESS);

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.c
@@ -43,8 +43,8 @@
 char *fsAddrPtr = NULL;
 static int32 setup_file(void)
 {
-    OS_mkfs(fsAddrPtr, "/ramdev3", " ", 512, 20);
-    OS_mount("/ramdev3", "/drive3");
+    UT_SETUP(OS_mkfs(fsAddrPtr, "/ramdev3", "RAM3", 512, 20));
+    UT_SETUP(OS_mount("/ramdev3", "/drive3"));
     return OS_creat("/drive3/select_test.txt", OS_READ_WRITE);
 }
 
@@ -105,20 +105,25 @@ void UT_os_select_single_test(void)
 {
     uint32 StateFlags;
     int32 fd = setup_file();
+    int32 rc;
 
-    if(OS_SelectSingle(fd, &StateFlags, 0) == OS_ERR_NOT_IMPLEMENTED)
+    UT_RETVAL(OS_SelectSingle(fd, NULL, 0), OS_INVALID_POINTER, "NULL flags pointer");
+
+    StateFlags = OS_STREAM_STATE_WRITABLE;
+    rc = OS_SelectSingle(fd, &StateFlags, 0);
+    if(rc == OS_ERR_NOT_IMPLEMENTED || rc == OS_ERR_OPERATION_NOT_SUPPORTED)
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectSingle() not implemented");
+        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectSingle() not supported");
         goto UT_os_select_single_test_exit_tag;
     }
 
-    UtAssert_Simple(OS_SelectSingle(fd, NULL, 0) != OS_SUCCESS);
-
-    StateFlags = OS_STREAM_STATE_WRITABLE;
-    UtAssert_Simple(OS_SelectSingle(fd, &StateFlags, 0) == OS_SUCCESS && StateFlags & OS_STREAM_STATE_WRITABLE);
+    UT_RETVAL(rc, OS_SUCCESS, "OS_SelectSingle(fd, OS_STREAM_STATE_WRITABLE, 0)");
+    UtAssert_True((StateFlags & OS_STREAM_STATE_WRITABLE) != 0, "StateFlags (0x%x) & OS_STREAM_STATE_WRITABLE", (unsigned int)StateFlags);
 
     StateFlags = OS_STREAM_STATE_READABLE;
-    UtAssert_Simple(OS_SelectSingle(fd, &StateFlags, 1) == OS_SUCCESS);
+    rc = OS_SelectSingle(fd, &StateFlags, 1);
+    UT_RETVAL(rc, OS_SUCCESS, "OS_SelectSingle(fd, OS_STREAM_STATE_READABLE, 0)");
+    UtAssert_True((StateFlags & OS_STREAM_STATE_READABLE) != 0, "StateFlags (0x%x) & OS_STREAM_STATE_READABLE", (unsigned int)StateFlags);
 
 UT_os_select_single_test_exit_tag:
     teardown_file(fd);
@@ -135,25 +140,26 @@ void UT_os_select_multi_test(void)
 {
     OS_FdSet ReadSet, WriteSet;
     int32 fd = setup_file();
-
-    if(OS_SelectMultiple(&ReadSet, &WriteSet, 1) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectMultiple() not implemented");
-        goto UT_select_multi_test_exit_tag;
-    }
+    int32 rc;
 
     OS_SelectFdZero(&WriteSet);
     OS_SelectFdAdd(&WriteSet, fd);
-    UtAssert_Simple(OS_SelectMultiple(NULL, &WriteSet, 1) == OS_SUCCESS);
+    rc = OS_SelectMultiple(NULL, &WriteSet, 1);
+    if(rc == OS_ERR_NOT_IMPLEMENTED || rc == OS_ERR_OPERATION_NOT_SUPPORTED)
+    {
+        UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, "OS_SelectMultiple() not supported");
+        goto UT_select_multi_test_exit_tag;
+    }
+
+
+    UT_RETVAL(rc, OS_SUCCESS, "OS_SelectMultiple(NULL, &WriteSet, 1)");
+    UtAssert_True(OS_SelectFdIsSet(&WriteSet, fd), "OS_SelectFdIsSet(&WriteSet, fd)");
 
     OS_SelectFdZero(&ReadSet);
     OS_SelectFdAdd(&ReadSet, fd);
-    UtAssert_Simple(OS_SelectMultiple(&ReadSet, NULL, 1) == OS_SUCCESS);
-
-    OS_SelectFdZero(&ReadSet);
-    OS_SelectFdAdd(&ReadSet, fd);
-    OS_SelectFdZero(&WriteSet);
-    UtAssert_Simple(OS_SelectMultiple(&ReadSet, &WriteSet, 0) == OS_SUCCESS);
+    rc = OS_SelectMultiple(&ReadSet, NULL, 1);
+    UT_RETVAL(rc, OS_SUCCESS, "OS_SelectMultiple(&ReadSet, NULL, 1)");
+    UtAssert_True(OS_SelectFdIsSet(&ReadSet, fd), "!OS_SelectFdIsSet(&ReadSet, fd)");
 
 UT_select_multi_test_exit_tag:
     teardown_file(fd);


### PR DESCRIPTION
**Describe the contribution**
On some OS's  (notably RTEMS) one must only call select() socket file handles.  This is indicated in OSAL via the "selectable" flag on each file handle.  The select implementation needs to check this before invoking select().

Also update unit tests to match.

Fix #453

**Testing performed**
Confirm unit tests passing on relevant platforms

**Expected behavior changes**
Calls to select APIs on RTEMS where unsupported will return OS_ERR_OPERATION_NOT_SUPPORTED, rather than crashing.

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11 on i686 via QEMU

**Additional context**
This also affects #377 in that it improves the test, but the functional test still could be better in that it currently only checks for file handles being set, not file handles being unset, after select.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.