### PR TITLE
Fix #455, correct length of device_name in filesys

### DIFF
--- a/src/os/shared/inc/os-shared-filesys.h
+++ b/src/os/shared/inc/os-shared-filesys.h
@@ -95,7 +95,7 @@ typedef struct
 
 typedef struct
 {
-    char device_name[OS_MAX_API_NAME];      /**< The name of the underlying block device, if applicable */
+    char device_name[OS_FS_DEV_NAME_LEN];      /**< The name of the underlying block device, if applicable */
     char volume_name[OS_FS_VOL_NAME_LEN];
     char system_mountpt[OS_MAX_LOCAL_PATH_LEN]; /**< The name/prefix where the contents are accessible in the host operating system */
     char virtual_mountpt[OS_MAX_PATH_LEN];  /**< The name/prefix in the OSAL Virtual File system exposed to applications */

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -443,7 +443,7 @@ int32 OS_FileSysAddFixedMap(uint32 *filesys_id, const char *phys_path, const cha
         return OS_INVALID_POINTER;
     }
 
-    if (strlen(phys_path) >= OS_MAX_PATH_LEN ||
+    if (strlen(phys_path) >= OS_MAX_LOCAL_PATH_LEN ||
             strlen(virt_path) >= OS_MAX_PATH_LEN)
     {
         return OS_ERR_NAME_TOO_LONG;
@@ -462,7 +462,7 @@ int32 OS_FileSysAddFixedMap(uint32 *filesys_id, const char *phys_path, const cha
         ++dev_name;
     }
 
-    if (strlen(dev_name) >= OS_MAX_API_NAME)
+    if (strlen(dev_name) >= OS_FS_DEV_NAME_LEN)
     {
         return OS_ERR_NAME_TOO_LONG;
     }

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -51,12 +51,14 @@ void Test_OS_FileSysAddFixedMap(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_SUCCESS);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, NULL, NULL), OS_INVALID_POINTER);
 
-    UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_PATH_LEN);
+    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 1, 2 + OS_MAX_LOCAL_PATH_LEN);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_ERR_NAME_TOO_LONG);
-    UT_ClearForceFail(UT_KEY(OCS_strlen));
+    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 2, 2 + OS_MAX_PATH_LEN);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_ERR_NAME_TOO_LONG);
+    UT_ResetState(UT_KEY(OCS_strlen));
 
     UT_SetForceFail(UT_KEY(OCS_strrchr), -1);
-    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 3, 2 + OS_MAX_API_NAME);
+    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 3, 2 + OS_FS_DEV_NAME_LEN);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_ERR_NAME_TOO_LONG);
     UT_ResetState(UT_KEY(OCS_strlen));
     UT_ResetState(UT_KEY(OCS_strrchr));


### PR DESCRIPTION
**Describe the contribution**
The `device_name` field was using the wrong length, it should be of `OS_FS_DEV_NAME_LEN`
Also correct another length check on the local path name.

Fix #455 

**Testing performed**
Build and execute unit tests, and sanity check CFE operation.

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11 on pc686 via QEMU

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
