### PR TITLE
Fix #457, provide BSP shutdown handler

### DIFF
--- a/src/bsp/mcp750-vxworks/src/bsp_start.c
+++ b/src/bsp/mcp750-vxworks/src/bsp_start.c
@@ -24,6 +24,17 @@
 
 #include "mcp750_bsp_internal.h"
 
+/* ---------------------------------------------------------
+    OS_BSP_Shutdown_Impl()
+
+     Helper function to abort the running task
+   --------------------------------------------------------- */
+void OS_BSP_Shutdown_Impl(void)
+{
+    abort();
+}
+
+
 /******************************************************************************
 **  Function:  OS_BSPMain()
 **

--- a/src/bsp/pc-linux/src/bsp_start.c
+++ b/src/bsp/pc-linux/src/bsp_start.c
@@ -132,6 +132,17 @@ int OS_BSP_GetReturnStatus(void)
     return retcode;
 }
 
+/* ---------------------------------------------------------
+    OS_BSP_Shutdown_Impl()
+
+     Helper function to abort the running task
+   --------------------------------------------------------- */
+void OS_BSP_Shutdown_Impl(void)
+{
+    abort();
+}
+
+
 /******************************************************************************
 **  Function:  main()
 **

--- a/src/bsp/pc-rtems/src/bsp_start.c
+++ b/src/bsp/pc-rtems/src/bsp_start.c
@@ -324,6 +324,30 @@ rtems_status_code OS_BSP_GetReturnStatus(void)
     return retcode;
 }
 
+/* ---------------------------------------------------------
+    OS_BSP_Shutdown_Impl()
+
+     Helper function to abort the running task
+   --------------------------------------------------------- */
+void OS_BSP_Shutdown_Impl(void)
+{
+    /*
+     * Not calling exit() under RTEMS, this simply shuts down the executive,
+     * forcing the user to reboot the system.
+     *
+     * Calling suspend causes execution to get stuck here, but the RTEMS
+     * shell thread will still be active so the user can poke around, read results,
+     * then use a shell command to reboot when ready.
+     */
+    while (!OS_BSP_PcRtemsGlobal.BatchMode)
+    {
+        printf("\n\nInit thread idle.\nPress <enter> for shell or reset machine...\n\n");
+        rtems_task_suspend(rtems_task_self());
+    }
+
+    rtems_shutdown_executive(OS_BSP_GetReturnStatus());
+}
+
 /*
  ** A simple entry point to start from the loader
  */
@@ -355,20 +379,11 @@ rtems_task Init(rtems_task_argument ignored)
     OS_Application_Run();
 
     /*
-     * Not calling exit() under RTEMS, this simply shuts down the executive,
-     * forcing the user to reboot the system.
-     *
-     * Calling suspend causes execution to get stuck here, but the RTEMS
-     * shell thread will still be active so the user can poke around, read results,
-     * then use a shell command to reboot when ready.
+     * Enter the BSP default shutdown mode
+     * depending on config, this may reset/reboot or suspend
+     * so the operator can use the shell.
      */
-    while (!OS_BSP_PcRtemsGlobal.BatchMode)
-    {
-        printf("\n\nInit thread idle.\nPress <enter> for shell or reset machine...\n\n");
-        rtems_task_suspend(rtems_task_self());
-    }
-
-    rtems_shutdown_executive(OS_BSP_GetReturnStatus());
+    OS_BSP_Shutdown_Impl();
 }
 
 /* configuration information */

--- a/src/bsp/shared/inc/bsp-impl.h
+++ b/src/bsp/shared/inc/bsp-impl.h
@@ -133,6 +133,16 @@ void OS_BSP_ConsoleOutput_Impl(const char *Str, uint32 DataLen);
  ------------------------------------------------------------------*/
 void OS_BSP_ConsoleSetMode_Impl(uint32 ModeBits);
 
+/*----------------------------------------------------------------
+   Function: OS_BSP_Shutdown_Impl
+
+    Purpose: Causes the calling task to abort in a BSP-safe way.
+             This may map to the abort() system call, but on some systems
+             that causes a reboot or undesirable side effect.  The
+             BSP may implement this call in a different manner.
+ ------------------------------------------------------------------*/
+void OS_BSP_Shutdown_Impl(void);
+
 /*********************
    END bsp-impl.h
  *********************/

--- a/ut_assert/src/utbsp.c
+++ b/ut_assert/src/utbsp.c
@@ -170,11 +170,11 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
 
     /*
      * If any ABORT (major failure) message is thrown,
-     * then actually call abort() to stop the test and dump a core
+     * then call a BSP-provided routine to stop the test and possibly dump a core
      */
     if (MessageType == UTASSERT_CASETYPE_ABORT)
     {
-        abort();
+        OS_BSP_Shutdown_Impl();
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
This provides a better method of handling test abort, in a BSP-specific manner.

Fixes #457

**Testing performed**
Build and execute unit tests on RTEMS platform, and run a test that has a problem causing an abort.  (e.g. `UtAssert_Abort`).
Confirm that in normal (non-batch) mode the system stays alive and allows use of the shell to check the system state.  When using batch mode the system still shuts down (as expected).

**Expected behavior changes**
No impact to behavior on Linux/VxWorks.
For RTEMS, will not shutdown the kernel if test abort occurs.

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11 on pc686 via QEMU

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
