### PR TITLE
Fix #459, dynamically create RAM disk devices on RTEMS

### DIFF
--- a/src/bsp/pc-rtems/src/bsp_start.c
+++ b/src/bsp/pc-rtems/src/bsp_start.c
@@ -48,29 +48,6 @@ extern rtems_status_code rtems_ide_part_table_initialize(const char *);
 extern int rtems_rtl_shell_command (int argc, char* argv[]);
 
 /*
- * The RAM Disk configuration.
- */
-rtems_ramdisk_config rtems_ramdisk_configuration[RTEMS_NUMBER_OF_RAMDISKS];
-
-/*
- * The number of RAM Disk configurations.
- */
-size_t rtems_ramdisk_configuration_size = RTEMS_NUMBER_OF_RAMDISKS;
-
-/*
-** RAM Disk IO op table.
-*/
-rtems_driver_address_table rtems_ramdisk_io_ops =
-{
-        .initialization_entry = ramdisk_initialize,
-        .open_entry =           rtems_blkdev_generic_open,
-        .close_entry =          rtems_blkdev_generic_close,
-        .read_entry =           rtems_blkdev_generic_read,
-        .write_entry =          rtems_blkdev_generic_write,
-        .control_entry =        rtems_blkdev_generic_ioctl
-};
-
-/*
  * Additional shell commands for the RTL functionality
  */
 rtems_shell_cmd_t rtems_shell_RTL_Command = {

--- a/src/bsp/pc-rtems/src/pcrtems_bsp_internal.h
+++ b/src/bsp/pc-rtems/src/pcrtems_bsp_internal.h
@@ -28,7 +28,6 @@
  * BSP compile-time tuning
  */
 #define RTEMS_MAX_USER_OPTIONS   4
-#define RTEMS_NUMBER_OF_RAMDISKS 1
 #define RTEMS_MAX_CMDLINE        256
 
 /*

--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -56,7 +56,7 @@ int32 UT_os_setup_fs()
 {
     int32 res;
 
-    res = OS_mkfs(g_fsAddrPtr, g_devName, " ", 512, 20);
+    res = OS_mkfs(g_fsAddrPtr, g_devName, "RAM3", 512, 64);
     if (res != OS_SUCCESS)
     {
         UT_OS_LOG("OS_mkfs() returns %d\n", (int)res);;


### PR DESCRIPTION
**Describe the contribution**
Rather than relying on the BSP to preallocate, the ram disk block devices can be created based on request.  This correlates with the way RAM disks are implemented on VxWorks and is
cleaner and more flexible by making it more independent of the BSP.

This allows all the unit tests to work on RTEMS without the needing the BSP to preallocate a ramdisk.

Fixes #459 

**Testing performed**
Build and run all unit tests, and sanity check CFE operation

**Expected behavior changes**
Unit tests work on RTEMS without BSP preallocating ramdisks

**System(s) tested on**
RTEMS 4.11 on pc686 via QEMU

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
