### PR TITLE
Fix #293, Expand API for object queries

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -47,6 +47,13 @@
 /** @brief Upper limit for OSAL task priorities */
 #define OS_MAX_TASK_PRIORITY        255
 
+/**
+ * @brief Constant that may be passed to OS_ForEachObject()/OS_ForEachObjectOfType() to match any
+ * creator (i.e. get all objects)
+ */
+#define OS_OBJECT_CREATOR_ANY       0
+
+
 /** @defgroup OSSemaphoreStates OSAL Semaphore State Defines
  * @{
  */
@@ -280,6 +287,24 @@ void OS_ApplicationExit(int32 Status);
 
 /*-------------------------------------------------------------------------------------*/
 /**
+ * @brief Obtain the name of an object given an arbitrary object ID
+ *
+ * All OSAL resources generally have a name associated with them.  This
+ * allows application code to retrieve the name of any valid OSAL object ID.
+ *
+ * @param[in]  object_id The object ID to operate on
+ * @param[out] buffer Buffer in which to store the name
+ * @param[in]  buffer_size Size of the output storage buffer
+ *
+ * @returns #OS_SUCCESS if successful
+ *          #OS_ERR_INVALID_ID if the passed-in ID is not a valid OSAL ID
+ *          #OS_INVALID_POINTER if the passed-in buffer is invalid
+ *          #OS_ERR_NAME_TOO_LONG if the name will not fit in the buffer provided
+ */
+int32 OS_GetResourceName(uint32 id, char *buffer, uint32 buffer_size);
+
+/*-------------------------------------------------------------------------------------*/
+/**
  * @brief Obtain the type of an object given an arbitrary object ID
  *
  * Given an arbitrary object ID, get the type of the object
@@ -315,11 +340,32 @@ int32 OS_ConvertToArrayIndex   (uint32 object_id, uint32 *ArrayIndex);
 /**
  * @brief call the supplied callback function for all valid object IDs
  *
- * Loops through all defined OSAL objects and calls callback_ptr on each one
+ * Loops through all defined OSAL objects of all types and calls callback_ptr on each one
  * If creator_id is nonzero then only objects with matching creator id are processed.
+ *
+ * @param[in]  creator_id   Filter objects to those created by a specific task
+ *                          This may be passed as OS_OBJECT_CREATOR_ANY to return all objects
+ * @param[in]  callback_ptr Function to invoke for each matching object ID
+ * @param[in]  callback_arg Opaque Argument to pass to callback function
  */
 void OS_ForEachObject           (uint32 creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg);
 /**@}*/
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief call the supplied callback function for valid object IDs of a specific type
+ *
+ * Loops through all defined OSAL objects of a specific type and calls callback_ptr on each one
+ * If creator_id is nonzero then only objects with matching creator id are processed.
+ *
+ * @param[in]  objtype      The type of objects to iterate
+ * @param[in]  creator_id   Filter objects to those created by a specific task
+ *                          This may be passed as OS_OBJECT_CREATOR_ANY to return all objects
+ * @param[in]  callback_ptr Function to invoke for each matching object ID
+ * @param[in]  callback_arg Opaque Argument to pass to callback function
+  */
+void OS_ForEachObjectOfType     (uint32 objtype, uint32 creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg);
+
 
 /** @defgroup OSAPITask OSAL Task APIs
  * @{

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -130,6 +130,38 @@ int32 OS_Unlock_Global_Impl(uint32 idtype);
  */
 
 /*----------------------------------------------------------------
+   Function: OS_ObjectIdToSerialNumber
+
+    Purpose: Obtain the serial number component of a generic OSAL Object ID
+ ------------------------------------------------------------------*/
+static inline uint32 OS_ObjectIdToSerialNumber_Impl(uint32 id)
+{
+    return (id & OS_OBJECT_INDEX_MASK);
+}
+
+/*----------------------------------------------------------------
+   Function: OS_ObjectIdToType
+
+    Purpose: Obtain the object type component of a generic OSAL Object ID
+ ------------------------------------------------------------------*/
+static inline uint32 OS_ObjectIdToType_Impl(uint32 id)
+{
+    return (id >> OS_OBJECT_TYPE_SHIFT);
+}
+
+
+/*----------------------------------------------------------------
+   Function: OS_ObjectIdCompose
+
+    Purpose: Convert an object serial number and resource type into an external 32-bit OSAL ID
+ ------------------------------------------------------------------*/
+static inline void OS_ObjectIdCompose_Impl(uint32 idtype, uint32 idserial, uint32 *result)
+{
+    *result = (idtype << OS_OBJECT_TYPE_SHIFT) | idserial;
+}
+
+
+/*----------------------------------------------------------------
    Function: OS_GetMaxForObjectType
 
     Purpose: Obtains the maximum number of objects for "idtype" in the global table

--- a/src/os/shared/src/osapi-time.c
+++ b/src/os/shared/src/osapi-time.c
@@ -436,7 +436,7 @@ int32 OS_TimerDelete(uint32 timer_id)
         {
             if (local->next_ref != local_id)
             {
-                OS_ObjectIdMap(OS_OBJECT_TYPE_OS_TIMEBASE, local->next_ref, &OS_timebase_table[local->timebase_ref].first_cb);
+                OS_ObjectIdCompose_Impl(OS_OBJECT_TYPE_OS_TIMEBASE, local->next_ref, &OS_timebase_table[local->timebase_ref].first_cb);
             }
             else
             {

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -392,6 +392,33 @@ int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_inde
 }
 
 /*--------------------------------------------------------------------------------------
+     Name: OS_GetResourceName
+
+    Purpose: Stub function for OS_GetResourceName, returns either the test-supplied string
+             or an empty string.
+
+    returns: status
+---------------------------------------------------------------------------------------*/
+int32 OS_GetResourceName(uint32 id, char *buffer, uint32 buffer_size)
+{
+    int32 return_code;
+
+    return_code = UT_DEFAULT_IMPL(OS_GetResourceName);
+
+    if (return_code == OS_SUCCESS)
+    {
+        if (buffer_size > 0 &&
+                UT_Stub_CopyToLocal(UT_KEY(OS_GetResourceName), buffer, buffer_size) == 0)
+        {
+            /* return an empty string by default */
+            buffer[0] = 0;
+        }
+    }
+
+    return return_code;
+}
+
+/*--------------------------------------------------------------------------------------
      Name: OS_ConvertToArrayIndex
 
     Purpose: Converts any abstract ID into a number suitable for use as an array index.
@@ -429,6 +456,36 @@ int32 OS_ConvertToArrayIndex(uint32 object_id, uint32 *ArrayIndex)
    return return_code;
 } /* end OS_ConvertToArrayIndex */
 
+/*--------------------------------------------------------------------------------------
+     Name: OS_ForEachObjectOfType
+
+    Purpose: Stub function for OS_ForEachObjectOfType
+
+    returns: None
+---------------------------------------------------------------------------------------*/
+void OS_ForEachObjectOfType     (uint32 objtype, uint32 creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg)
+{
+    uint32 NextId;
+    uint32 IdSize;
+    OS_U32ValueWrapper_t wrapper;
+
+    wrapper.arg_callback_func = callback_ptr;
+
+    /* Although this is "void", Invoke the default impl to log it and invoke any hooks */
+    UT_Stub_RegisterContext(UT_KEY(OS_ForEachObjectOfType), wrapper.opaque_arg);
+    UT_Stub_RegisterContext(UT_KEY(OS_ForEachObjectOfType), callback_arg);
+    UT_DEFAULT_IMPL(OS_ForEachObjectOfType);
+
+    while (1)
+    {
+        IdSize = UT_Stub_CopyToLocal(UT_KEY(OS_ForEachObjectOfType), &NextId, sizeof(NextId));
+        if (IdSize < sizeof(NextId))
+        {
+            break;
+        }
+        (*callback_ptr)(NextId, callback_arg);
+    }
+}
 
 /*--------------------------------------------------------------------------------------
      Name: OS_ForEachOject


### PR DESCRIPTION
**Describe the contribution**

Implement `OS_GetResourceName()` and `OS_ForEachObjectOfType()`, which are new functions that allow for additional query capabilities.   `OS_ObjectIdToArrayIndex()` modified to accept `OS_OBJECT_TYPE_UNDEFINED` as the first parameter, to allow it to work with any object type, not just objects for which a specific type is expected/known.

Also adds unit test (functional + coverage)  for `OS_ForEachObjectByType` and `OS_GetResourceName`

Fixes #293

**Testing performed**
Run all unit tests, sanity check CFE and confirm normal operation

**Expected behavior changes**
No impact to _current_ behavior as the FSW does not currently use any of these new APIs.  Existing APIs are unchanged.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Querying objects by type is potentially needed for nasa/cfe#701 and nasa/fm#2

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
