### PR TITLE
Fix #470, Binary sem task delete issues

### DIFF
--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -137,9 +137,26 @@ void task_1(void)
 void BinSemCheck(void)
 {
     uint32 status;
+    OS_bin_sem_prop_t  bin_sem_prop;
+
+    /* Delete the task, which should be pending in OS_BinSemTake() */
+    status = OS_TaskDelete(task_1_id);
+    UtAssert_True(status == OS_SUCCESS, "OS_TaskDelete Rc=%d", (int)status);
 
     status = OS_TimerDelete(timer_id);
     UtAssert_True(status == OS_SUCCESS, "OS_TimerDelete Rc=%d", (int)status);
+
+    OS_TaskDelay(100);
+
+    /* Confirm that the semaphore itself is still operational after task deletion */
+    status = OS_BinSemGive(bin_sem_id);
+    UtAssert_True(status == OS_SUCCESS, "BinSem give Rc=%d", (int)status);
+    status = OS_BinSemGetInfo (bin_sem_id, &bin_sem_prop);
+    UtAssert_True(status == OS_SUCCESS, "BinSem value=%d Rc=%d", (int)bin_sem_prop.value, (int)status);
+    status = OS_BinSemTake(bin_sem_id);
+    UtAssert_True(status == OS_SUCCESS, "BinSem take Rc=%d", (int)status);
+    status = OS_BinSemDelete(bin_sem_id);
+    UtAssert_True(status == OS_SUCCESS, "BinSem delete Rc=%d", (int)status);
 
     UtAssert_True(counter < timer_counter, "Task counter (%d) < timer counter (%d)", (int)counter, (int)timer_counter);
     UtAssert_True(task_1_failures == 0, "Task 1 failures = %u", (unsigned int)task_1_failures);


### PR DESCRIPTION
**Describe the contribution**
Corrects issue when a task waiting on a binary semaphore is deleted, it left the mutex in a locked state preventing other tasks from using the mutex.

This has 3 parts:
1. A functional test enhancement to bin-sem-test which replicates the specific conditions for the observed bug to occur.  It deletes the task calling `OS_BinSemTake()` and then attempts to use the semaphore after this.  (without the rest of this change, it fails).
2. Employ a pthread "cleanup handler" to handle the situation where a task is canceled during the `pthread_cond_wait()` call.  This ensures that the mutex is unlocked as part of the cleanup, so other tasks may continue using the semaphore.  This is the main fix as it directly addresses the root cause of the issue, which is that the mutex was left in a locked state.
3. Change all initial mutex locking to be a finite "timed" wait rather than an infinite wait.  In all cases, the condition variable is only held for brief periods of time and should be readily available; tasks should almost never block on this initial lock.  If a task blocks for a long time, this considers the mutex "broken" and aborts, thereby avoiding deadlock.  This is a "contingency" fix in that if an exception or signal or other unknown/unhandled async event occurs that leaves the mutex permanently locked, it at least does not deadlock the system and allows it to be restarted.

Fixes #470 
Fixes nasa/cfe#701

**Testing performed**
Build and run all unit tests.

Confirm that including only the unit test change (item 1 above) reliably reproduces the failure.  In this mode, bin-sem-test will get stuck when attempting to give the semaphore after task deletion.

Confirm that the bin sem changes (items 2 and 3 above) correct the issue.  Note each one taken individually will avoid deadlock in a different way.  Item 3 (timed mutex) alone will cause the subsequent calls to return `OS_SEM_FAILURE` rather than deadlock, so shutdown will continue and the test exits with a failed status rather than pending forever.

Sanity check CFE operation and CTRL+C handling - all works OK.

**Expected behavior changes**
Binary semaphores after task deletion continue to work as expected and are usable by other tasks.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.