### PR TITLE
Fix #474, Add timecb global mutex

### DIFF
--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -42,6 +42,7 @@ static POSIX_GlobalLock_t OS_count_sem_table_mut;
 static POSIX_GlobalLock_t OS_stream_table_mut;
 static POSIX_GlobalLock_t OS_dir_table_mut;
 static POSIX_GlobalLock_t OS_timebase_table_mut;
+static POSIX_GlobalLock_t OS_timecb_table_mut;
 static POSIX_GlobalLock_t OS_module_table_mut;
 static POSIX_GlobalLock_t OS_filesys_table_mut;
 static POSIX_GlobalLock_t OS_console_mut;
@@ -57,6 +58,7 @@ static POSIX_GlobalLock_t * const MUTEX_TABLE[] =
             [OS_OBJECT_TYPE_OS_STREAM] = &OS_stream_table_mut,
             [OS_OBJECT_TYPE_OS_DIR] = &OS_dir_table_mut,
             [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_mut,
+            [OS_OBJECT_TYPE_OS_TIMECB] = &OS_timecb_table_mut,
             [OS_OBJECT_TYPE_OS_MODULE] = &OS_module_table_mut,
             [OS_OBJECT_TYPE_OS_FILESYS] = &OS_filesys_table_mut,
             [OS_OBJECT_TYPE_OS_CONSOLE] = &OS_console_mut,

--- a/src/os/rtems/src/os-impl-idmap.c
+++ b/src/os/rtems/src/os-impl-idmap.c
@@ -45,6 +45,7 @@ rtems_id            OS_count_sem_table_sem;
 rtems_id            OS_stream_table_mut;
 rtems_id            OS_dir_table_mut;
 rtems_id            OS_timebase_table_mut;
+rtems_id            OS_timecb_table_mut;
 rtems_id            OS_module_table_mut;
 rtems_id            OS_filesys_table_mut;
 rtems_id            OS_console_mut;
@@ -60,6 +61,7 @@ static rtems_id * const MUTEX_TABLE[] =
             [OS_OBJECT_TYPE_OS_STREAM] = &OS_stream_table_mut,
             [OS_OBJECT_TYPE_OS_DIR] = &OS_dir_table_mut,
             [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_mut,
+            [OS_OBJECT_TYPE_OS_TIMECB] = &OS_timecb_table_mut,
             [OS_OBJECT_TYPE_OS_MODULE] = &OS_module_table_mut,
             [OS_OBJECT_TYPE_OS_FILESYS] = &OS_filesys_table_mut,
             [OS_OBJECT_TYPE_OS_CONSOLE] = &OS_console_mut,

--- a/src/os/vxworks/src/os-impl-idmap.c
+++ b/src/os/vxworks/src/os-impl-idmap.c
@@ -45,6 +45,7 @@ VX_MUTEX_SEMAPHORE(OS_count_sem_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_stream_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_dir_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_timebase_table_mut_mem);
+VX_MUTEX_SEMAPHORE(OS_timecb_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_module_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_filesys_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_console_mut_mem);
@@ -60,6 +61,7 @@ VxWorks_GlobalMutex_t VX_MUTEX_TABLE[] =
         [OS_OBJECT_TYPE_OS_STREAM] = { .mem = OS_stream_table_mut_mem },
         [OS_OBJECT_TYPE_OS_DIR] = { .mem = OS_dir_table_mut_mem },
         [OS_OBJECT_TYPE_OS_TIMEBASE] = { .mem = OS_timebase_table_mut_mem },
+        [OS_OBJECT_TYPE_OS_TIMECB] = { .mem = OS_timecb_table_mut_mem },
         [OS_OBJECT_TYPE_OS_MODULE] = { .mem = OS_module_table_mut_mem },
         [OS_OBJECT_TYPE_OS_FILESYS] = { .mem = OS_filesys_table_mut_mem },
         [OS_OBJECT_TYPE_OS_CONSOLE] = { .mem = OS_console_mut_mem },


### PR DESCRIPTION
**Describe the contribution**
Adds the mutex to protect the timer callback (timecb) resource table.

Fixes #474 

**Testing performed**
Build and confirm all unit tests pass, CFE runs normally.

**Expected behavior changes**
Timer callback (timcb) resource types are mutex protected.

**System(s) tested on**
Ubuntu 20.04 
RTEMS 4.11 on pc686 via QEMU

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
