### PR TITLE
Fix #476, add global lock/unlock wrapper

### DIFF
--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -80,14 +80,7 @@ int32 OS_Lock_Global_Impl(uint32 idtype)
    POSIX_GlobalLock_t *mut;
    sigset_t previous;
 
-   if (idtype < MUTEX_TABLE_SIZE)
-   {
-      mut = MUTEX_TABLE[idtype];
-   }
-   else
-   {
-      mut = NULL;
-   }
+   mut = MUTEX_TABLE[idtype];
 
    if (mut == NULL)
    {

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -102,7 +102,16 @@ int32 OS_ObjectIdInit                (void);
 
 
 /*----------------------------------------------------------------
-   Function: OS_Lock_Global_Impl
+   Function: OS_Lock_Global
+
+    Purpose: Locks the global table identified by "idtype"
+
+   Returns: OS_SUCCESS on success, or relevant error code
+ ------------------------------------------------------------------*/
+void OS_Lock_Global(uint32 idtype);
+
+/*----------------------------------------------------------------
+   Function: OS_Lock_Global
 
     Purpose: Locks the global table identified by "idtype"
 
@@ -111,7 +120,17 @@ int32 OS_ObjectIdInit                (void);
 int32 OS_Lock_Global_Impl(uint32 idtype);
 
 /*----------------------------------------------------------------
-   Function: OS_Unlock_Global_Impl
+   Function: OS_Unlock_Global
+
+    Purpose: Unlocks the global table identified by "idtype"
+
+    Returns: OS_SUCCESS on success, or relevant error code
+ ------------------------------------------------------------------*/
+void OS_Unlock_Global(uint32 idtype);
+
+
+/*----------------------------------------------------------------
+   Function: OS_Unlock_Global
 
     Purpose: Unlocks the global table identified by "idtype"
 

--- a/src/os/shared/src/osapi-binsem.c
+++ b/src/os/shared/src/osapi-binsem.c
@@ -157,7 +157,7 @@ int32 OS_BinSemDelete (uint32 sem_id)
          record->active_id = 0;
       }
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -318,7 +318,7 @@ int32 OS_BinSemGetInfo (uint32 sem_id, OS_bin_sem_prop_t *bin_prop)
       strncpy(bin_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
       bin_prop->creator = record->creator;
       return_code = OS_BinSemGetInfo_Impl (local_id, bin_prop);
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;

--- a/src/os/shared/src/osapi-countsem.c
+++ b/src/os/shared/src/osapi-countsem.c
@@ -150,7 +150,7 @@ int32 OS_CountSemDelete (uint32 sem_id)
          record->active_id = 0;
       }
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -288,7 +288,7 @@ int32 OS_CountSemGetInfo (uint32 sem_id, OS_count_sem_prop_t *count_prop)
       count_prop->creator = record->creator;
 
       return_code = OS_CountSemGetInfo_Impl (local_id, count_prop);
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;

--- a/src/os/shared/src/osapi-dir.c
+++ b/src/os/shared/src/osapi-dir.c
@@ -187,7 +187,7 @@ int32 OS_DirectoryClose(uint32 dir_id)
            record->active_id = 0;
        }
 
-       OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+       OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -229,7 +229,7 @@ int32 OS_DirectoryRead(uint32 dir_id, os_dirent_t *dirent)
        */
       return_code = OS_DirRead_Impl(local_id, dirent);
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -223,7 +223,7 @@ int32 OS_close (uint32 filedes)
             record->active_id = 0;
         }
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     return return_code;
@@ -454,7 +454,7 @@ int32 OS_rename (const char *old, const char *new)
 
    if (return_code == OS_SUCCESS)
    {
-      OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Lock_Global(LOCAL_OBJID_TYPE);
       for ( i =0; i < OS_MAX_NUM_OPEN_FILES; i++)
       {
          if (OS_global_stream_table[i].active_id != 0 &&
@@ -464,7 +464,7 @@ int32 OS_rename (const char *old, const char *new)
             strcpy (OS_stream_table[i].stream_name, new);
          }
       }
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     return return_code;
@@ -609,7 +609,7 @@ int32 OS_FDGetInfo (uint32 filedes, OS_file_prop_t *fd_prop)
       strncpy(fd_prop->Path, record->name_entry, OS_MAX_PATH_LEN - 1);
       fd_prop->User = record->creator;
       fd_prop->IsValid = true;
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -637,7 +637,7 @@ int32 OS_FileOpenCheck(const char *Filename)
 
    return_code = OS_ERROR;
 
-   OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+   OS_Lock_Global(LOCAL_OBJID_TYPE);
 
    for ( i = 0; i < OS_MAX_NUM_OPEN_FILES; i++)
    {
@@ -650,7 +650,7 @@ int32 OS_FileOpenCheck(const char *Filename)
       }
    }/* end for */
 
-   OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+   OS_Unlock_Global(LOCAL_OBJID_TYPE);
 
    return return_code;
 } /* end OS_FileOpenCheck */
@@ -678,7 +678,7 @@ int32 OS_CloseFileByName(const char *Filename)
 
    return_code = OS_FS_ERR_PATH_INVALID;
 
-   OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+   OS_Lock_Global(LOCAL_OBJID_TYPE);
 
    for ( i = 0; i < OS_MAX_NUM_OPEN_FILES; i++)
    {
@@ -698,7 +698,7 @@ int32 OS_CloseFileByName(const char *Filename)
       }
    }/* end for */
 
-   OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+   OS_Unlock_Global(LOCAL_OBJID_TYPE);
 
    return (return_code);
 
@@ -721,7 +721,7 @@ int32 OS_CloseAllFiles(void)
 
    return_code = OS_SUCCESS;
 
-   OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+   OS_Lock_Global(LOCAL_OBJID_TYPE);
 
    for ( i = 0; i < OS_MAX_NUM_OPEN_FILES; i++)
    {
@@ -739,7 +739,7 @@ int32 OS_CloseAllFiles(void)
       }
    }/* end for */
 
-   OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+   OS_Unlock_Global(LOCAL_OBJID_TYPE);
 
    return (return_code);
 

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -576,7 +576,7 @@ int32 OS_rmfs (const char *devname)
            global->active_id = 0;
         }
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
     else
     {
@@ -685,7 +685,7 @@ int32 OS_mount (const char *devname, const char* mountpoint)
             strcpy(local->virtual_mountpt, mountpoint);
         }
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
 
@@ -764,7 +764,7 @@ int32 OS_unmount (const char *mountpoint)
             local->flags &= ~(OS_FILESYS_FLAG_IS_MOUNTED_SYSTEM | OS_FILESYS_FLAG_IS_MOUNTED_VIRTUAL);
         }
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
 
@@ -811,7 +811,7 @@ int32 OS_fsBlocksFree (const char *name)
 
         return_code = OS_FileSysStatVolume_Impl(local_id, &statfs);
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
 
         if (return_code == OS_SUCCESS)
         {
@@ -863,7 +863,7 @@ int32 OS_fsBytesFree (const char *name, uint64 *bytes_free)
 
         return_code = OS_FileSysStatVolume_Impl(local_id, &statfs);
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
 
         if (return_code == OS_SUCCESS)
         {
@@ -974,7 +974,7 @@ int32 OS_FS_GetPhysDriveName(char * PhysDriveName, const char * MountPoint)
             return_code = OS_ERR_INCORRECT_OBJ_STATE;
         }
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
     else
     {
@@ -1012,7 +1012,7 @@ int32 OS_GetFsInfo(os_fsinfo_t  *filesys_info)
    filesys_info->MaxFds = OS_MAX_NUM_OPEN_FILES;
    filesys_info->MaxVolumes = OS_MAX_FILE_SYSTEMS;
 
-   OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_STREAM);
+   OS_Lock_Global(OS_OBJECT_TYPE_OS_STREAM);
 
    for ( i = 0; i < OS_MAX_NUM_OPEN_FILES; i++ )
    {
@@ -1022,9 +1022,9 @@ int32 OS_GetFsInfo(os_fsinfo_t  *filesys_info)
       }
    }
 
-   OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_STREAM);
+   OS_Unlock_Global(OS_OBJECT_TYPE_OS_STREAM);
 
-   OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_FILESYS);
+   OS_Lock_Global(OS_OBJECT_TYPE_OS_FILESYS);
 
    for ( i = 0; i < NUM_TABLE_ENTRIES; i++ )
    {
@@ -1034,7 +1034,7 @@ int32 OS_GetFsInfo(os_fsinfo_t  *filesys_info)
        }
    }
 
-   OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_FILESYS);
+   OS_Unlock_Global(OS_OBJECT_TYPE_OS_FILESYS);
 
    return(OS_SUCCESS);
 } /* end OS_GetFsInfo */
@@ -1128,7 +1128,7 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
             return_code = OS_ERR_INCORRECT_OBJ_STATE;
         }
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     if (return_code == OS_SUCCESS)

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -74,8 +74,16 @@ typedef enum
 /* Tables where the OS object information is stored */
 static OS_common_record_t OS_common_table[OS_MAX_TOTAL_RECORDS];
 
-/* Keep track of the last successfully-issued object ID of each type */
-static uint32 OS_last_id_issued[OS_OBJECT_TYPE_USER];
+typedef struct
+{
+    /* Keep track of the last successfully-issued object ID of each type */
+    uint32 last_id_issued;
+
+    /* The last task to lock/own this global table */
+    uint32 table_owner;
+} OS_objtype_state_t;
+
+OS_objtype_state_t OS_objtype_state[OS_OBJECT_TYPE_USER];
 
 
 OS_common_record_t * const OS_global_task_table       = &OS_common_table[OS_TASK_BASE];
@@ -108,7 +116,7 @@ OS_common_record_t * const OS_global_console_table    = &OS_common_table[OS_CONS
 int32 OS_ObjectIdInit(void)
 {
     memset(OS_common_table, 0, sizeof(OS_common_table));
-    memset(OS_last_id_issued, 0, sizeof(OS_last_id_issued));
+    memset(OS_objtype_state, 0, sizeof(OS_objtype_state));
     return OS_SUCCESS;
 } /* end OS_ObjectIdInit */
 
@@ -255,7 +263,7 @@ void OS_ObjectIdInitiateLock(OS_lock_mode_t lock_mode, uint32 idtype)
 {
     if (lock_mode != OS_LOCK_MODE_NONE)
     {
-        OS_Lock_Global_Impl(idtype);
+        OS_Lock_Global(idtype);
     }
 } /* end OS_ObjectIdInitiateLock */
 
@@ -378,9 +386,9 @@ int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, uint32 idtype, uint32 ref
             break;
         }
 
-        OS_Unlock_Global_Impl(idtype);
+        OS_Unlock_Global(idtype);
         OS_TaskDelay_Impl(attempts);
-        OS_Lock_Global_Impl(idtype);
+        OS_Lock_Global(idtype);
     }
 
     /*
@@ -407,7 +415,7 @@ int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, uint32 idtype, uint32 ref
         if (return_code != OS_SUCCESS ||
                 lock_mode == OS_LOCK_MODE_REFCOUNT)
         {
-            OS_Unlock_Global_Impl(idtype);
+            OS_Unlock_Global(idtype);
         }
     }
 
@@ -509,7 +517,7 @@ int32 OS_ObjectIdFindNext(uint32 idtype, uint32 *array_index, OS_common_record_t
    else
    {
        return_code = OS_ERR_NO_FREE_IDS;
-       idvalue = OS_last_id_issued[idtype] & OS_OBJECT_INDEX_MASK;
+       idvalue = OS_objtype_state[idtype].last_id_issued & OS_OBJECT_INDEX_MASK;
    }
 
    for (i = 0; i < max_id; ++i)
@@ -565,6 +573,127 @@ int32 OS_ObjectIdFindNext(uint32 idtype, uint32 *array_index, OS_common_record_t
  *  but are NOT directly invoked by applications
  *********************************************************************************
  */
+
+/*----------------------------------------------------------------
+   Function: OS_Lock_Global
+
+    Purpose: Locks the global table identified by "idtype"
+ ------------------------------------------------------------------*/
+void OS_Lock_Global(uint32 idtype)
+{
+    int32 return_code;
+    uint32 self_task_id;
+    OS_objtype_state_t *objtype;
+
+    if (idtype < OS_OBJECT_TYPE_USER)
+    {
+        objtype = &OS_objtype_state[idtype];
+        self_task_id = OS_TaskGetId();
+
+        return_code = OS_Lock_Global_Impl(idtype);
+        if (return_code == OS_SUCCESS)
+        {
+            /*
+             * Track ownership of this table.  It should only be owned by one
+             * task at a time, and this aids in recovery if the owning task is
+             * deleted or experiences an exception causing it to not be freed.
+             *
+             * This is done after successfully locking, so this has exclusive access
+             * to the state object.
+             */
+            if (self_task_id == 0)
+            {
+                /*
+                 * This just means the calling context is not an OSAL-created task.
+                 * This is not necessarily an error, but it should be tracked.
+                 * Also note that the root/initial task also does not have an ID.
+                 */
+                self_task_id = 0xFFFFFFFF; /* nonzero, but also won't alias a known task */
+            }
+
+            if (objtype->table_owner != 0)
+            {
+                /* this is almost certainly a bug */
+                OS_DEBUG("ERROR: global %u acquired by task 0x%lx when already owned by task 0x%lx\n",
+                        (unsigned int)idtype, (unsigned long)self_task_id,
+                        (unsigned long)objtype->table_owner);
+            }
+            else
+            {
+                objtype->table_owner = self_task_id;
+            }
+        }
+    }
+    else
+    {
+        return_code = OS_ERR_INCORRECT_OBJ_TYPE;
+    }
+
+    if (return_code != OS_SUCCESS)
+    {
+        OS_DEBUG("ERROR: unable to lock global %u, error=%d\n", (unsigned int)idtype, (int)return_code);
+    }
+}
+
+/*----------------------------------------------------------------
+   Function: OS_Unlock_Global
+
+    Purpose: Unlocks the global table identified by "idtype"
+ ------------------------------------------------------------------*/
+void OS_Unlock_Global(uint32 idtype)
+{
+    int32 return_code;
+    uint32 self_task_id;
+    OS_objtype_state_t *objtype;
+
+    if (idtype < OS_OBJECT_TYPE_USER)
+    {
+        objtype = &OS_objtype_state[idtype];
+        self_task_id = OS_TaskGetId();
+
+        /*
+         * Un-track ownership of this table.  It should only be owned by one
+         * task at a time, and this aids in recovery if the owning task is
+         * deleted or experiences an exception causing it to not be freed.
+         *
+         * This is done before unlocking, while this has exclusive access
+         * to the state object.
+         */
+        if (self_task_id == 0)
+        {
+            /*
+             * This just means the calling context is not an OSAL-created task.
+             * This is not necessarily an error, but it should be tracked.
+             * Also note that the root/initial task also does not have an ID.
+             */
+            self_task_id = 0xFFFFFFFF; /* nonzero, but also won't alias a known task */
+        }
+
+        if (objtype->table_owner != self_task_id)
+        {
+            /* this is almost certainly a bug */
+            OS_DEBUG("ERROR: global %u released by task 0x%lx when owned by task 0x%lx\n",
+                    (unsigned int)idtype, (unsigned long)self_task_id,
+                    (unsigned long)objtype->table_owner);
+        }
+        else
+        {
+            objtype->table_owner = 0;
+        }
+
+        return_code = OS_Unlock_Global_Impl(idtype);
+    }
+    else
+    {
+        return_code = OS_ERR_INCORRECT_OBJ_TYPE;
+    }
+
+    if (return_code != OS_SUCCESS)
+    {
+        OS_DEBUG("ERROR: unable to unlock global %u, error=%d\n", (unsigned int)idtype, (int)return_code);
+    }
+}
+
 
 /*----------------------------------------------------------------
  *
@@ -640,7 +769,7 @@ int32 OS_ObjectIdFinalizeNew(int32 operation_status, OS_common_record_t *record,
     else
     {
         /* success */
-        OS_last_id_issued[idtype] = record->active_id;
+        OS_objtype_state[idtype].last_id_issued = record->active_id;
     }
 
     if (outid != NULL)
@@ -650,7 +779,7 @@ int32 OS_ObjectIdFinalizeNew(int32 operation_status, OS_common_record_t *record,
     }
 
     /* Either way we must unlock the object type */
-    OS_Unlock_Global_Impl(idtype);
+    OS_Unlock_Global(idtype);
 
     return operation_status;
 } /* end OS_ObjectIdFinalizeNew */
@@ -690,7 +819,7 @@ int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectM
     }
     else if (lock_mode != OS_LOCK_MODE_NONE)
     {
-        OS_Unlock_Global_Impl(idtype);
+        OS_Unlock_Global(idtype);
     }
 
     if (record != NULL)
@@ -757,7 +886,7 @@ int32 OS_ObjectIdFindByName (uint32 idtype, const char *name, uint32 *object_id)
     if (return_code == OS_SUCCESS)
     {
         *object_id = global->active_id;
-        OS_Unlock_Global_Impl(idtype);
+        OS_Unlock_Global(idtype);
     }
 
     return return_code;
@@ -849,7 +978,7 @@ int32 OS_ObjectIdRefcountDecr(OS_common_record_t *record)
    }
    else
    {
-      OS_Lock_Global_Impl(idtype);
+      OS_Lock_Global(idtype);
 
       if (record->refcount > 0)
       {
@@ -861,7 +990,7 @@ int32 OS_ObjectIdRefcountDecr(OS_common_record_t *record)
          return_code = OS_ERR_INCORRECT_OBJ_STATE;
       }
 
-      OS_Unlock_Global_Impl(idtype);
+      OS_Unlock_Global(idtype);
    }
 
    return return_code;
@@ -912,7 +1041,7 @@ int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_inde
        return OS_ERR_INCORRECT_OBJ_TYPE;
    }
 
-   OS_Lock_Global_Impl(idtype);
+   OS_Lock_Global(idtype);
 
    /*
     * Check if an object of the same name already exits.
@@ -940,7 +1069,7 @@ int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_inde
     * otherwise the global should stay locked so remaining initialization can be done */
    if (return_code != OS_SUCCESS)
    {
-      OS_Unlock_Global_Impl(idtype);
+      OS_Unlock_Global(idtype);
    }
 
    return return_code;
@@ -1000,7 +1129,7 @@ void OS_ForEachObject (uint32 creator_id, OS_ArgCallback_t callback_ptr, void *c
         obj_max = OS_GetMaxForObjectType(idtype);
         if (obj_max > 0)
         {
-            OS_Lock_Global_Impl(idtype);
+            OS_Lock_Global(idtype);
             obj_index = OS_GetBaseForObjectType(idtype);
             while (obj_max > 0)
             {
@@ -1011,15 +1140,15 @@ void OS_ForEachObject (uint32 creator_id, OS_ArgCallback_t callback_ptr, void *c
                      * Handle the object - Note that we must UN-lock before callback.
                      * The callback function might lock again in a different manner.
                      */
-                    OS_Unlock_Global_Impl(idtype);
+                    OS_Unlock_Global(idtype);
                     (*callback_ptr)(obj_id, callback_arg);
-                    OS_Lock_Global_Impl(idtype);
+                    OS_Lock_Global(idtype);
 
                 }
                 ++obj_index;
                 --obj_max;
             }
-            OS_Unlock_Global_Impl(idtype);
+            OS_Unlock_Global(idtype);
         }
     }
 } /* end OS_ForEachObject */

--- a/src/os/shared/src/osapi-module.c
+++ b/src/os/shared/src/osapi-module.c
@@ -289,7 +289,7 @@ int32 OS_ModuleUnload ( uint32 module_id )
         }
 
         /* Unlock the global from OS_ObjectIdGetAndLock() */
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     return return_code;
@@ -325,7 +325,7 @@ int32 OS_ModuleInfo ( uint32 module_id, OS_module_prop_t *module_prop )
 
         return_code = OS_ModuleGetInfo_Impl(local_id, module_prop);
 
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     return return_code;
@@ -428,11 +428,11 @@ int32 OS_SymbolTableDump ( const char *filename, uint32 SizeLimit )
      * underlying implementation may safely use globals for
      * state storage.
      */
-    OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+    OS_Lock_Global(LOCAL_OBJID_TYPE);
 
     return_code = OS_SymbolTableDump_Impl(translated_path, SizeLimit);
 
-    OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+    OS_Unlock_Global(LOCAL_OBJID_TYPE);
 
     return(return_code);
 

--- a/src/os/shared/src/osapi-mutex.c
+++ b/src/os/shared/src/osapi-mutex.c
@@ -145,7 +145,7 @@ int32 OS_MutSemDelete (uint32 sem_id)
          record->active_id = 0;
       }
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -258,7 +258,7 @@ int32 OS_MutSemGetInfo (uint32 sem_id, OS_mut_sem_prop_t *mut_prop)
 
       return_code = OS_MutSemGetInfo_Impl(local_id, mut_prop);
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;

--- a/src/os/shared/src/osapi-printf.c
+++ b/src/os/shared/src/osapi-printf.c
@@ -236,7 +236,7 @@ int32 OS_ConsoleWrite(uint32 console_id, const char *Str)
          */
         OS_ConsoleWakeup_Impl(local_id);
 
-        OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_CONSOLE);
+        OS_Unlock_Global(OS_OBJECT_TYPE_OS_CONSOLE);
     }
 
 

--- a/src/os/shared/src/osapi-queue.c
+++ b/src/os/shared/src/osapi-queue.c
@@ -151,7 +151,7 @@ int32 OS_QueueDelete (uint32 queue_id)
          record->active_id = 0;
       }
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -292,7 +292,7 @@ int32 OS_QueueGetInfo (uint32 queue_id, OS_queue_prop_t *queue_prop)
        * But this could be added in the future (i.e. current/max depth, msg size, etc)
        */
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -194,7 +194,7 @@ int32 OS_SocketBind(uint32 sock_id, const OS_SockAddr_t *Addr)
          }
       }
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -274,7 +274,7 @@ int32 OS_SocketAccept(uint32 sock_id, uint32 *connsock_id, OS_SockAddr_t *Addr, 
       /* The actual accept impl is done without global table lock, only refcount lock */
       return_code = OS_SocketAccept_Impl(local_id, conn_id, Addr, timeout);
 
-      OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Lock_Global(LOCAL_OBJID_TYPE);
       if (return_code == OS_SUCCESS)
       {
          /* Generate an entry name based on the remote address */
@@ -291,7 +291,7 @@ int32 OS_SocketAccept(uint32 sock_id, uint32 *connsock_id, OS_SockAddr_t *Addr, 
       /* Decrement both ref counters that were increased earlier */
       --record->refcount;
       --connrecord->refcount;
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -334,20 +334,20 @@ int32 OS_SocketConnect(uint32 sock_id, const OS_SockAddr_t *Addr, int32 Timeout)
       {
          ++record->refcount;
       }
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    if (return_code == OS_SUCCESS)
    {
       return_code = OS_SocketConnect_Impl (local_id, Addr, Timeout);
 
-      OS_Lock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Lock_Global(LOCAL_OBJID_TYPE);
       if (return_code == OS_SUCCESS)
       {
          OS_stream_table[local_id].stream_state |= OS_STREAM_STATE_CONNECTED | OS_STREAM_STATE_READABLE | OS_STREAM_STATE_WRITABLE;
       }
       --record->refcount;
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
 
@@ -488,7 +488,7 @@ int32 OS_SocketGetInfo (uint32 sock_id, OS_socket_prop_t *sock_prop)
       strncpy(sock_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
       sock_prop->creator = record->creator;
       return_code = OS_SocketGetInfo_Impl (local_id, sock_prop);
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -89,7 +89,7 @@ static int32 OS_TaskPrepare(uint32 task_id, osal_task_entry *entrypt)
        * This ensures that the parent thread's OS_TaskCreate() call is fully completed,
        * and that nobody can call OS_TaskDelete() and possibly overwrite this data.
        */
-      OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+      OS_Lock_Global(OS_OBJECT_TYPE_OS_TASK);
 
       /*
        * Verify that we still appear to own the table entry
@@ -104,7 +104,7 @@ static int32 OS_TaskPrepare(uint32 task_id, osal_task_entry *entrypt)
           *entrypt = OS_task_table[local_id].entry_function_pointer;
       }
 
-      OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+      OS_Unlock_Global(OS_OBJECT_TYPE_OS_TASK);
    }
 
    if (return_code == OS_SUCCESS)
@@ -266,7 +266,7 @@ int32 OS_TaskDelete (uint32 task_id)
          delete_hook = NULL;
       }
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    /*
@@ -300,7 +300,7 @@ void OS_TaskExit()
    {
       /* Only need to clear the ID as zero is the "unused" flag */
       record->active_id = 0;
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    /* call the implementation */
@@ -358,7 +358,7 @@ int32 OS_TaskSetPriority (uint32 task_id, uint32 new_priority)
          }
 
          /* Unlock the global from OS_ObjectIdGetAndLock() */
-         OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+         OS_Unlock_Global(LOCAL_OBJID_TYPE);
       }
    }
 
@@ -475,7 +475,7 @@ int32 OS_TaskGetInfo (uint32 task_id, OS_task_prop_t *task_prop)
 
       return_code = OS_TaskGetInfo_Impl(local_id, task_prop);
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -507,7 +507,7 @@ int32 OS_TaskInstallDeleteHandler(osal_task_entry function_pointer)
       */
       OS_task_table[local_id].delete_hook_pointer = function_pointer;
 
-      OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+      OS_Unlock_Global(LOCAL_OBJID_TYPE);
    }
 
    return return_code;
@@ -543,7 +543,7 @@ int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sys
     if (return_code == OS_SUCCESS)
     {
         *task_id = record->active_id;
-        OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     return return_code;

--- a/src/os/shared/src/osapi-time.c
+++ b/src/os/shared/src/osapi-time.c
@@ -358,7 +358,7 @@ int32 OS_TimerSet(uint32 timer_id, uint32 start_time, uint32 interval_time)
        OS_TimeBaseUnlock_Impl(local->timebase_ref);
 
        /* Unlock the global from OS_ObjectIdCheck() */
-       OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TIMECB);
+       OS_Unlock_Global(OS_OBJECT_TYPE_OS_TIMECB);
    }
 
    /*
@@ -457,7 +457,7 @@ int32 OS_TimerDelete(uint32 timer_id)
 
         OS_TimeBaseUnlock_Impl(local->timebase_ref);
 
-        OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TIMECB);
+        OS_Unlock_Global(OS_OBJECT_TYPE_OS_TIMECB);
     }
 
     /*
@@ -555,7 +555,7 @@ int32 OS_TimerGetInfo (uint32 timer_id, OS_timer_prop_t *timer_prop)
        timer_prop->interval_time =   (uint32)OS_timecb_table[local_id].interval_time;
        timer_prop->accuracy =   OS_timebase_table[OS_timecb_table[local_id].timebase_ref].accuracy_usec;
 
-       OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TIMECB);
+       OS_Unlock_Global(OS_OBJECT_TYPE_OS_TIMECB);
     }
 
     return return_code;

--- a/src/os/shared/src/osapi-timebase.c
+++ b/src/os/shared/src/osapi-timebase.c
@@ -217,7 +217,7 @@ int32 OS_TimeBaseSet(uint32 timer_id, uint32 start_time, uint32 interval_time)
 
         OS_TimeBaseUnlock_Impl(local_id);
 
-        OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TIMEBASE);
+        OS_Unlock_Global(OS_OBJECT_TYPE_OS_TIMEBASE);
     }
 
     return return_code;
@@ -260,7 +260,7 @@ int32 OS_TimeBaseDelete(uint32 timer_id)
             record->active_id = 0;
         }
 
-        OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TIMEBASE);
+        OS_Unlock_Global(OS_OBJECT_TYPE_OS_TIMEBASE);
     }
 
     return return_code;
@@ -345,7 +345,7 @@ int32 OS_TimeBaseGetInfo (uint32 timebase_id, OS_timebase_prop_t *timebase_prop)
 
        return_code = OS_TimeBaseGetInfo_Impl(local_id, timebase_prop);
 
-       OS_Unlock_Global_Impl(LOCAL_OBJID_TYPE);
+       OS_Unlock_Global(LOCAL_OBJID_TYPE);
     }
 
     return return_code;
@@ -428,7 +428,7 @@ void OS_TimeBase_CallbackThread(uint32 timebase_id)
     syncfunc = timebase->external_sync;
     spin_cycles = 0;
 
-    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TIMEBASE);
+    OS_Unlock_Global(OS_OBJECT_TYPE_OS_TIMEBASE);
 
     while (1)
     {

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -118,6 +118,30 @@ void Test_OS_ObjectIdMapUnmap(void)
     }
 }
 
+void Test_OS_LockUnlockGlobal(void)
+{
+    /*
+     * Test Case For:
+     * void OS_Lock_Global(uint32 idtype)
+     * void OS_Unlock_Global(uint32 idtype)
+     */
+
+    /*
+     * As these have no return codes, these tests
+     * exist to get coverage of the paths.
+     */
+    OS_Lock_Global(OS_OBJECT_TYPE_OS_COUNTSEM);
+    OS_Unlock_Global(OS_OBJECT_TYPE_OS_COUNTSEM);
+    OS_Lock_Global(0);
+    OS_Unlock_Global(0);
+    OS_Lock_Global(55555);
+    OS_Unlock_Global(55555);
+
+    UT_SetForceFail(UT_KEY(OS_TaskGetId), 0);
+    OS_Lock_Global(OS_OBJECT_TYPE_OS_BINSEM);
+    OS_Unlock_Global(OS_OBJECT_TYPE_OS_BINSEM);
+}
+
 void Test_OS_ObjectIdConvertLock(void)
 {
     /*
@@ -678,6 +702,7 @@ void UtTest_Setup(void)
 {
     ADD_TEST(OS_ObjectIdInit);
     ADD_TEST(OS_ObjectIdMapUnmap);
+    ADD_TEST(OS_LockUnlockGlobal);
     ADD_TEST(OS_ObjectIdFindNext);
     ADD_TEST(OS_ObjectIdToArrayIndex);
     ADD_TEST(OS_ObjectIdFindByName);

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -32,6 +32,16 @@
 
 UT_DEFAULT_STUB(OS_ObjectIdInit,(void))
 
+/* Lock/Unlock for global tables */
+void OS_Lock_Global(uint32 idtype)
+{
+    UT_DEFAULT_IMPL(OS_Lock_Global);
+}
+void OS_Unlock_Global(uint32 idtype)
+{
+    UT_DEFAULT_IMPL(OS_Unlock_Global);
+}
+
 /*****************************************************************************
  *
  * Stub function for OS_ObjectIdMap()


### PR DESCRIPTION
**Describe the contribution**
Add a wrapper at the shared layer to provide a common location to check the status of global lock/unlock ops.

All calls to OS_Lock_Global_Impl and OS_Unlock_Global_Impl from the shared modules are replaced with calls to this wrapper.

Notably - this detects and reports the problem described in #474, in case something similar happens in the future.  

Fixes #476

**Testing performed**
Build and execute all unit tests, and sanity check CFE operations.

**Expected behavior changes**
Now detects and reports errors in global mutex lock/unlock ops.

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11 on pc686 via QEMU

**Additional context**
If this patch is applied in isolation without any other changes, one will see debug trace generated as it is detecting the problem previously reported in #474:

```
OS_Lock_Global():634:ERROR: unable to lock global 9, error=-1
OS_Unlock_Global():677:ERROR: global 9 released by task 0x10005 when owned by task 0x0
OS_Unlock_Global():693:ERROR: unable to lock global 9, error=-1
```

These errors go away as soon as the PR #475 is also applied

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
