### PR TITLE
Fix #485 - add text to make clear that IDs are non-zero

### DIFF
--- a/src/os/inc/osapi-os-core.h
+++ b/src/os/inc/osapi-os-core.h
@@ -378,7 +378,7 @@ void OS_ForEachObjectOfType     (uint32 objtype, uint32 creator_id, OS_ArgCallba
  * Creates a task and passes back the id of the task created. Task names must be unique;
  * if the name already exists this function fails. Names cannot be NULL.
  *
- * @param[out]  task_id will be set to the ID of the newly-created resource
+ * @param[out]  task_id will be set to the non-zero ID of the newly-created resource
  * @param[in]   task_name the name of the new resource to create
  * @param[in]   function_pointer the entry point of the new task
  * @param[in]   stack_pointer pointer to the stack for the task, or NULL
@@ -566,7 +566,7 @@ int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sys
  * function fails. Names cannot be NULL.
  *
  *
- * @param[out]  queue_id will be set to the ID of the newly-created resource
+ * @param[out]  queue_id will be set to the non-zero ID of the newly-created resource
  * @param[in]   queue_name the name of the new resource to create
  * @param[in]   queue_depth the maximum depth of the queue
  * @param[in]   data_size the size of each entry in the queue
@@ -694,7 +694,7 @@ int32 OS_QueueGetInfo          (uint32 queue_id, OS_queue_prop_t *queue_prop);
  * sem_initial_value and name specified by sem_name. sem_id will be
  * returned to the caller
  *
- * @param[out]  sem_id will be set to the ID of the newly-created resource
+ * @param[out]  sem_id will be set to the non-zero ID of the newly-created resource
  * @param[in]   sem_name the name of the new resource to create
  * @param[in]   sem_initial_value the initial value of the binary semaphore
  * @param[in]   options Reserved for future use, should be passed as 0.
@@ -846,7 +846,7 @@ int32 OS_BinSemGetInfo         (uint32 sem_id, OS_bin_sem_prop_t *bin_prop);
  * sem_initial_value and name specified by sem_name. sem_id will be
  * returned to the caller
  *
- * @param[out]  sem_id will be set to the ID of the newly-created resource
+ * @param[out]  sem_id will be set to the non-zero ID of the newly-created resource
  * @param[in]   sem_name the name of the new resource to create
  * @param[in]   sem_initial_value the initial value of the counting semaphore
  * @param[in]   options Reserved for future use, should be passed as 0.
@@ -978,7 +978,7 @@ int32 OS_CountSemGetInfo         (uint32 sem_id, OS_count_sem_prop_t *count_prop
  *
  * Mutex semaphores are always created in the unlocked (full) state.
  *
- * @param[out]  sem_id will be set to the ID of the newly-created resource
+ * @param[out]  sem_id will be set to the non-zero ID of the newly-created resource
  * @param[in]   sem_name the name of the new resource to create
  * @param[in]   options reserved for future use.  Should be passed as 0.
  *

--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -664,7 +664,7 @@ os_dirent_t *   OS_readdir (os_dirp_t directory);
  *
  * Prepares for reading the files within a directory
  *
- * @param[out] dir_id    The handle ID of the directory
+ * @param[out] dir_id    The non-zero handle ID of the directory
  * @param[in]  path      The directory to open
  *
  * @return Execution status, see @ref OSReturnCodes
@@ -765,7 +765,7 @@ int32           OS_rmdir   (const char *path);
  * This mimics the behavior of a "FS_BASED" entry in the VolumeTable but is registered
  * at runtime.  It is intended to be called by the PSP/BSP prior to starting the application.
  *
- * @param[out]  filesys_id  An OSAL ID reflecting the file system
+ * @param[out]  filesys_id  A non-zero OSAL ID reflecting the file system
  * @param[in]   phys_path   The native system directory (an existing mount point)
  * @param[in]   virt_path   The virtual mount point of this filesystem
  *

--- a/src/os/inc/osapi-os-loader.h
+++ b/src/os/inc/osapi-os-loader.h
@@ -132,7 +132,7 @@ int32 OS_SymbolTableDump ( const char *filename, uint32 size_limit );
  *
  * Loads an object file into the running operating system
  *
- * @param[out] module_id    OSAL ID corresponding to the loaded module
+ * @param[out] module_id    Non-zero OSAL ID corresponding to the loaded module
  * @param[in]  module_name  Name of module
  * @param[in]  filename     File containing the object code to load
  *

--- a/src/os/inc/osapi-os-net.h
+++ b/src/os/inc/osapi-os-net.h
@@ -229,7 +229,7 @@ int32 OS_SocketAddrSetPort(OS_SockAddr_t *Addr, uint16 PortNum);
  *
  * A new, unconnected and unbound socket is allocated of the given domain and type.
  *
- * @param[out]  sock_id  Buffer to hold the OSAL ID
+ * @param[out]  sock_id  Buffer to hold the non-zero OSAL ID
  * @param[in]   Domain   The domain / address family of the socket (INET or INET6, etc)
  * @param[in]   Type     The type of the socket (STREAM or DATAGRAM)
  *

--- a/src/os/inc/osapi-os-timer.h
+++ b/src/os/inc/osapi-os-timer.h
@@ -74,7 +74,7 @@ typedef struct
  * be configured to support at least (OS_MAX_TASKS + OS_MAX_TIMEBASES) threads,
  * to account for the helper threads associated with time base objects.
  *
- * @param[out]  timebase_id     An identifier corresponding to the timebase resource
+ * @param[out]  timebase_id     A non-zero ID corresponding to the timebase resource
  * @param[in]   timebase_name   The name of the time base
  * @param[in]   external_sync   A synchronization function for BSP hardware-based timer ticks
  *
@@ -204,7 +204,7 @@ int32 OS_TimeBaseGetFreeRun     (uint32 timebase_id, uint32 *freerun_val);
  *          interrupt service routine. Calls that cause the code to block or require
  *          an application context (like sending events) are generally not supported.
  *
- * @param[out]  timer_id        The resource ID of the timer object
+ * @param[out]  timer_id        The non-zero resource ID of the timer object
  * @param[in]   timer_name      Name of the timer object
  * @param[out]  clock_accuracy  Expected precision of the timer, in microseconds. This
  *                              is the underlying tick value rounded to the nearest
@@ -245,7 +245,7 @@ int32 OS_TimerCreate            (uint32 *timer_id, const char *timer_name, uint3
  *          interrupt service routine. Calls that cause the code to block or require
  *          an application context (like sending events) are generally not supported.
  *
- * @param[out]  timer_id        The resource ID of the timer object
+ * @param[out]  timer_id        The non-zero resource ID of the timer object
  * @param[in]   timer_name      Name of the timer object
  * @param[in]   timebase_id     The time base resource to use as a reference
  * @param[in]   callback_ptr    Application-provided function to invoke


### PR DESCRIPTION
**Describe the contribution**
Fix #485 - adds "non-zero" to the out variable description for OS_<obj>Create (and related) API's.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov