### PR TITLE
Fix #196, Fix timer-test to be able to use OS_MAX_TIMERS value

### DIFF
--- a/src/tests/timer-test/timer-test.c
+++ b/src/tests/timer-test/timer-test.c
@@ -20,12 +20,16 @@
 #define TASK_1_STACK_SIZE 4096
 #define TASK_1_PRIORITY   101
 
+
 void TimerTestSetup(void);
 void TimerTestTask(void);
 void TimerTestCheck(void);
 
 OS_time_t        StartTime;
 OS_time_t        EndTime;
+uint32           TimerStart[NUMBER_OF_TIMERS];
+uint32           TimerInterval[NUMBER_OF_TIMERS]; 
+
 uint32           TimerStart[NUMBER_OF_TIMERS] = {1000, 2000000, 3000000, 4000000 };
 uint32           TimerInterval[NUMBER_OF_TIMERS] = {500000, 400000, 800000, 600000 };
 
@@ -33,11 +37,12 @@ uint32 TimerTestTaskStack[TASK_1_STACK_SIZE];
 int32 timer_counter[NUMBER_OF_TIMERS];
 uint32 timer_idlookup[OS_MAX_TIMERS];
 
+
 /*
-** Test timer function.
-** Note: For some Host OSs, this is the equivalent of an ISR, so the calls available are limited.
-** For example, Linux and vxWorks can call functions like printf, but RTEMS cannot.
-*/
+ * Test timer function.
+ * Note: For some Host OSs, this is the equivalent of an ISR, so the calls available are limited.
+ * For example, Linux and vxWorks can call functions like printf, but RTEMS cannot.
+ */
 void test_func(uint32 timer_id)
 {
    OS_ConvertToArrayIndex(timer_id, &timer_id);
@@ -99,7 +104,7 @@ void TimerTestTask(void)
    uint32           ClockAccuracy;
 
 
-   for ( i = 0; i < NUMBER_OF_TIMERS; i++ )
+   for ( i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++ )
    {
       TimerStatus[i] = OS_TimerCreate(&TimerID[i], TimerName[i], &ClockAccuracy, &(test_func));
       UtAssert_True(TimerStatus[i] == OS_SUCCESS, "Timer %d Created RC=%d ID=%d", i, (int)TimerStatus[i], (int)TimerID[i]);
@@ -112,7 +117,7 @@ void TimerTestTask(void)
 
    /* Sample the clock now, before starting any timer */
    OS_GetLocalTime(&StartTime);
-   for ( i = 0; i < NUMBER_OF_TIMERS; i++ )
+   for ( i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++ )
    {
       /*
        * to ensure that all timers are started as closely as possible,
@@ -124,7 +129,7 @@ void TimerTestTask(void)
    /*
     * Now the actual OS_TimerSet() return code can be checked.
     */
-   for ( i = 0; i < NUMBER_OF_TIMERS; i++ )
+   for ( i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++ )
    {
        UtAssert_True(TimerStatus[i] == OS_SUCCESS, "Timer %d programmed RC=%d", i, (int)TimerStatus[i]);
    }
@@ -145,12 +150,12 @@ void TimerTestTask(void)
    }
    OS_GetLocalTime(&EndTime);
 
-   for ( i = 0; i < NUMBER_OF_TIMERS; i++ )
+   for ( i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++ )
    {
        TimerStatus[i] =  OS_TimerDelete(TimerID[i]);
    }
 
-   for ( i = 0; i < NUMBER_OF_TIMERS; i++ )
+   for ( i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++ )
    {
        UtAssert_True(TimerStatus[i] == OS_SUCCESS, "Timer %d delete RC=%d. Count total = %d",
                i, (int)TimerStatus[i], (int)timer_counter[i]);
@@ -180,7 +185,7 @@ void TimerTestCheck(void)
    }
 
    /* Make sure the ratio of the timers are OK */
-   for ( i = 0; i < NUMBER_OF_TIMERS; i++ )
+   for ( i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++ )
    {
       /*
        * Expect one tick after the start time (i.e. first tick)

--- a/src/tests/timer-test/timer-test.c
+++ b/src/tests/timer-test/timer-test.c
@@ -27,9 +27,6 @@ void TimerTestCheck(void);
 
 OS_time_t        StartTime;
 OS_time_t        EndTime;
-uint32           TimerStart[NUMBER_OF_TIMERS];
-uint32           TimerInterval[NUMBER_OF_TIMERS]; 
-
 uint32           TimerStart[NUMBER_OF_TIMERS] = {1000, 2000000, 3000000, 4000000 };
 uint32           TimerInterval[NUMBER_OF_TIMERS] = {500000, 400000, 800000, 600000 };
 


### PR DESCRIPTION
Fix #196, Fix timer-test to be able to use OS_MAX_TIMERS value

**Describe the contribution**
Changed timer-test to be able to use OS_MAX_TIMERS value on top of the hard-coded NUMBER_OF_TIMERS value.  This will allow the test to be functional even if the OS_MAX_TIMERS value is reconfigured.

**Testing performed**
Steps taken to test the contribution:
1. Standard build and ran unit tests.

**System(s) tested on**
cFS Dev Server
OS: Ubuntu 18.04
Versions: OSAL 5.0.11.0

**Contributor Info - All information REQUIRED for consideration of pull request**
Yasir Majeed Khan
NASA GSFC/Emergent Space