### PR TITLE
Fix #494, add missing stub functions for OSAL API

### DIFF
--- a/src/ut-stubs/osapi-utstub-file.c
+++ b/src/ut-stubs/osapi-utstub-file.c
@@ -198,6 +198,27 @@ int32 OS_write(uint32 filedes, const void *buffer, uint32 nbytes)
 
 /*****************************************************************************
  *
+ * Stub function for OS_TimedRead()
+ *
+ *****************************************************************************/
+int32 OS_TimedRead(uint32  filedes, void *buffer, uint32 nbytes, int32 timeout)
+{
+    return UT_GenericReadStub(__func__,UT_KEY(OS_TimedRead),buffer,nbytes);
+}
+
+/*****************************************************************************
+ *
+ * Stub function for OS_TimedWrite()
+ *
+ *****************************************************************************/
+int32 OS_TimedWrite(uint32  filedes, const void *buffer, uint32 nbytes, int32 timeout)
+{
+    return UT_GenericWriteStub(__func__,UT_KEY(OS_TimedWrite),buffer,nbytes);
+}
+
+
+/*****************************************************************************
+ *
  * Stub function for OS_chmod()
  *
  *****************************************************************************/

--- a/src/ut-stubs/osapi-utstub-filesys.c
+++ b/src/ut-stubs/osapi-utstub-filesys.c
@@ -30,6 +30,33 @@ UT_DEFAULT_STUB(OS_FileSysAPI_Init,(void))
 
 /*****************************************************************************
  *
+ * Stub function for OS_FileSysAddFixedMap()
+ *
+ *****************************************************************************/
+int32           OS_FileSysAddFixedMap(uint32 *filesys_id, const char *phys_path,
+                                const char *virt_path)
+{
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(OS_FileSysAddFixedMap);
+
+    if (status == OS_SUCCESS)
+    {
+        *filesys_id = UT_AllocStubObjId(UT_OBJTYPE_FILESYS);
+    }
+    else
+    {
+        *filesys_id = 0xDEADBEEFU;
+    }
+
+
+
+    return status;
+}
+
+
+/*****************************************************************************
+ *
  * Stub function for OS_mkfs()
  *
  *****************************************************************************/

--- a/src/ut-stubs/osapi-utstub-printf.c
+++ b/src/ut-stubs/osapi-utstub-printf.c
@@ -32,6 +32,17 @@ int32 OS_ConsoleAPI_Init(void)
 
 /*****************************************************************************
  *
+ * Stub function for OS_ConsoleWrite()
+ *
+ *****************************************************************************/
+int32 OS_ConsoleWrite(uint32 console_id, const char *Str)
+{
+    UT_Stub_RegisterContext(UT_KEY(OS_ConsoleWrite), Str);
+    return UT_DEFAULT_IMPL(OS_ConsoleWrite);
+}
+
+/*****************************************************************************
+ *
  * Stub function for OS_printf()
  *
  *****************************************************************************/

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -292,7 +292,7 @@ int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sys
     status = UT_DEFAULT_IMPL(OS_TaskFindIdBySystemData);
 
     if (status == OS_SUCCESS &&
-            UT_Stub_CopyToLocal(UT_KEY(OS_TaskFindIdBySystemData), (void**)&task_id, sizeof(task_id)) < sizeof(task_id))
+            UT_Stub_CopyToLocal(UT_KEY(OS_TaskFindIdBySystemData), task_id, sizeof(*task_id)) < sizeof(*task_id))
     {
         *task_id = 1;
         UT_FIXUP_ID(*task_id, UT_OBJTYPE_TASK);

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -260,7 +260,7 @@ int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop)
     status = UT_DEFAULT_IMPL(OS_TaskGetInfo);
 
     if (status == OS_SUCCESS &&
-            UT_Stub_CopyToLocal(UT_KEY(OS_MutSemGetInfo), task_prop, sizeof(*task_prop)) < sizeof(*task_prop))
+            UT_Stub_CopyToLocal(UT_KEY(OS_TaskGetInfo), task_prop, sizeof(*task_prop)) < sizeof(*task_prop))
     {
         task_prop->creator = 1;
         UT_FIXUP_ID(task_prop->creator, UT_OBJTYPE_TASK);
@@ -273,6 +273,33 @@ int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop)
     return status;
 }
 
+/*****************************************************************************/
+/**
+** \brief OS_TaskGetInfo stub function
+**
+** \par Description
+**        This function is used to mimic the response of the OS API function
+**        OS_TaskFindIdBySystemData.
+**
+** \returns
+**        The return value instructed by the test case setup
+**
+******************************************************************************/
+int32 OS_TaskFindIdBySystemData(uint32 *task_id, const void *sysdata, size_t sysdata_size)
+{
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(OS_TaskFindIdBySystemData);
+
+    if (status == OS_SUCCESS &&
+            UT_Stub_CopyToLocal(UT_KEY(OS_TaskFindIdBySystemData), (void**)&task_id, sizeof(task_id)) < sizeof(task_id))
+    {
+        *task_id = 1;
+        UT_FIXUP_ID(*task_id, UT_OBJTYPE_TASK);
+    }
+
+    return status;
+}
 
 /*****************************************************************************
  *


### PR DESCRIPTION
**Describe the contribution**
Did a quick scrub for public OSAL APIs defined in `libosal.a` but not defined in stub library.

Added stub functions for:

```
OS_TaskFindIdBySystemData()
OS_FileSysAddFixedMap()
OS_TimedRead()
OS_TimedWrite()
OS_FileSysAddFixedMap()
```
Required for testing other modules that use these functions. Also correct a name mismatch issue in `OS_TaskGetInfo()`.

Fixes #494

**Testing performed**
Build and run all unit tests.

**Expected behavior changes**
No change to behavior or FSW.  Just adds stubs for future use.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
These were not actively used anywhere yet (otherwise would be a link failure) but likely to become an issue as PSP coverage tests are implemented.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
