### PR TITLE
Fix #499, store all arguments in generic-linux BSP

### DIFF
--- a/src/bsp/generic-linux/src/bsp_start.c
+++ b/src/bsp/generic-linux/src/bsp_start.c
@@ -140,14 +140,12 @@ int main(int argc, char *argv[])
      * Note that the first argument (0) is the command name.  The
      * first "real" argument is at position 1.
      *
-     * The first arg is ignored to be more consistent with other platforms
-     * where this is not passed in.
+     * However this still needs to pass it through as the appliction
+     * might still want to use library "getopt" and this expects the
+     * first parameter to be this way.
      */
-    if (argc > 1)
-    {
-        OS_BSP_Global.ArgC = argc - 1;
-        OS_BSP_Global.ArgV = &argv[1];
-    }
+    OS_BSP_Global.ArgC = argc;
+    OS_BSP_Global.ArgV = argv;
 
     /*
      * Only attempt terminal control if the stdout is a TTY


### PR DESCRIPTION
**Describe the contribution**

Keep the entire argc/argv from the shell.  Do not prune the command name as getopt expects this to be there.

Fixes #499 

**Testing performed**
Execute unit tests, confirm all passing.
Execute new PSP tests, confirm command line options are being recognized.

**Expected behavior changes**
Command line options in Linux are recognized, no longer ignored/dropped.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.