### PR TITLE
Fix #506, enforce nonzero stack size

### DIFF
--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -31,13 +31,6 @@
 #include "os-shared-task.h"
 #include "os-shared-idmap.h"
 
-/*
- * Defines
- */
-#ifndef PTHREAD_STACK_MIN
-#define PTHREAD_STACK_MIN   (8*1024)
-#endif
-
 /* Tables where the OS object information is stored */
 OS_impl_task_internal_record_t      OS_impl_task_table          [OS_MAX_TASKS];
 
@@ -467,19 +460,11 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t 
        /*
        ** Set the Stack Size
        */
-       if (stacksz > 0)
+       return_code = pthread_attr_setstacksize(&custom_attr, stacksz);
+       if (return_code != 0)
        {
-           if (stacksz < PTHREAD_STACK_MIN)
-           {
-              stacksz = PTHREAD_STACK_MIN;
-           }
-
-           return_code = pthread_attr_setstacksize(&custom_attr, stacksz);
-           if (return_code != 0)
-           {
-              OS_DEBUG("pthread_attr_setstacksize error in OS_TaskCreate: %s\n",strerror(return_code));
-              return(OS_ERROR);
-           }
+           OS_DEBUG("pthread_attr_setstacksize error in OS_TaskCreate: %s\n",strerror(return_code));
+           return(OS_ERROR);
        }
 
        /*

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -196,6 +196,13 @@ int32 OS_TaskCreate (uint32 *task_id, const char *task_name, osal_task_entry fun
       return OS_INVALID_POINTER;
    }
 
+   /* Check for bad stack size.  Note that NULL stack_pointer is
+    * OK (impl will allocate) but size must be nonzero. */
+   if (stack_size == 0)
+   {
+       return OS_ERROR;
+   }
+
    /* we don't want to allow names too long*/
    /* if truncated, two names might be the same */
    if (strlen(task_name) >= OS_MAX_API_NAME)

--- a/src/tests/idmap-api-test/idmap-api-test.c
+++ b/src/tests/idmap-api-test/idmap-api-test.c
@@ -100,7 +100,7 @@ void TestIdMapApi_Setup(void)
     /*
      * Create all allowed objects
      */
-    status = OS_TaskCreate( &task_id, "Task", Test_Void_Fn, 0, 0, 0, 0);
+    status = OS_TaskCreate( &task_id, "Task", Test_Void_Fn, NULL, 4096, 50, 0);
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate() (%ld) == OS_SUCCESS", (long)status);
     status = OS_QueueCreate( &queue_id, "Queue", 5, 5, 0);
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate() (%ld) == OS_SUCCESS", (long)status);

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -106,15 +106,16 @@ void Test_OS_TaskCreate(void)
      */
     int32 expected = OS_SUCCESS;
     uint32 objid = 0xFFFFFFFF;
-    int32 actual = OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 0, 0,0);
+    int32 actual = OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 128, 0, 0);
 
     UtAssert_True(actual == expected, "OS_TaskCreate() (%ld) == OS_SUCCESS", (long)actual);
     UtAssert_True(objid != 0, "objid (%lu) != 0", (unsigned long)objid);
 
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(NULL, NULL, NULL, NULL, 0, 0,0), OS_INVALID_POINTER);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 0, 10 + OS_MAX_TASK_PRIORITY,0), OS_ERR_INVALID_PRIORITY);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 0, 0, 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 128, 10 + OS_MAX_TASK_PRIORITY,0), OS_ERR_INVALID_PRIORITY);
     UT_SetForceFail(UT_KEY(OCS_strlen), 10 + OS_MAX_API_NAME);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 0, 0,0), OS_ERR_NAME_TOO_LONG);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 128, 0,0), OS_ERR_NAME_TOO_LONG);
 }
 
 void Test_OS_TaskDelete(void)


### PR DESCRIPTION
**Describe the contribution**
Resolve inconsistency in how the stack size is treated across different OS implemntations.  POSIX would enforce a minimum, where RTEMS would not.

With this change the user requested size is passed through to the underlying OS exactly as is, no enforced minimum.

An additional sanity check is added at the shared layer to ensure that the stack size is never passed as 0.

Fixes #506 

**Testing performed**
Build and execute CFE and sanity test
Build and execute all unit tests.
Also tested creating a task with zero stack size and confirm error is generated on Linux.

**Expected behavior changes**
The `idmap-api-test` passes on RTEMS.
Attempting to create a task with zero stack now will result in error.

**System(s) tested on**
Ubuntu 20.04
RTEMS 4.11.3 via QEMU/pc686

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
