### PR TITLE
Fix #509, Remove uintmax_t usage

### DIFF
--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -599,7 +599,7 @@ const void* UT_Hook_GetArgPtr(const UT_StubContext_t *ContextPtr, const char *Na
 
     static const union
     {
-        uintmax_t AsInt;
+        unsigned long AsInt;
         void *AsPtr;
         double AsFloat;
     } ARG_DEFAULT_ZERO_VALUE = { 0 };


### PR DESCRIPTION
**Describe the contribution**
Some systems may not provide this type.  Using `unsigned long` instead should be sufficient.

Fixes #509

**Testing performed**
Build on vxworks
Run all unit tests on native system and on RTEMS.

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04
GSFC VxWorks lab build machine (gs582w-cfelnx)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
