### PR TITLE
Fast Track for Integration Candidate 2020-06-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ This distribution contains:
 
 ## Version History
 
+
+### Development Build: 5.0.20
+-  Add "non-zero" to the out variable description for OS_Create (and related) API's.
+- Increases the buffer for context info from 128 to 256 bytes and the total report buffer to 320 bytes.
+- Add stub functions for `OS_TaskFindIdBySystemData()`, `OS_FileSysAddFixedMap()`,
+`OS_TimedRead()`, `OS_TimedWrite()`, and `OS_FileSysAddFixedMap()`
+- See <https://github.com/nasa/osal/pull/511>
+
 ### Development Build: 5.0.19
 
 - Rename BSPs that can be used on multiple platforms. 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ This distribution contains:
 ### Development Build: 5.0.20
 -  Add "non-zero" to the out variable description for OS_Create (and related) API's.
 - Increases the buffer for context info from 128 to 256 bytes and the total report buffer to 320 bytes.
-- Add stub functions for `OS_TaskFindIdBySystemData()`, `OS_FileSysAddFixedMap()`,
-`OS_TimedRead()`, `OS_TimedWrite()`, and `OS_FileSysAddFixedMap()`
-- See <https://github.com/nasa/osal/pull/511>
+- Add stub functions for `OS_TaskFindIdBySystemData()`, `OS_FileSysAddFixedMap()`, `OS_TimedRead()`, `OS_TimedWrite()`, and `OS_FileSysAddFixedMap()`
+- Added the following wrappers macros around `UtAssert_True` for commonly-used asserts:
+  - `UtAssert_INT32_EQ` - check equality as 32 bit signed int
+  - `UtAssert_UINT32_EQ` - check equality as 32 bit unsigned int
+  - `UtAssert_NOT_NULL` - check pointer not null
+  - `UtAssert_NULL` - check pointer is null
+  - `UtAssert_NONZERO` - check integer is nonzero
+  - `UtAssert_ZERO` - check integer is zero
+  - `UtAssert_STUB_COUNT` - check stub count
+-  Using `unsigned long` instead of `uintmax_t` to fix support for VxWorks
+
+- See <https://github.com/nasa/osal/pull/511> and <https://github.com/nasa/osal/pull/513>
 
 ### Development Build: 5.0.19
 

--- a/src/os/inc/osapi-version.h
+++ b/src/os/inc/osapi-version.h
@@ -20,7 +20,7 @@
 
 #define OS_MAJOR_VERSION 5  /**< @brief Major version number */
 #define OS_MINOR_VERSION 0  /**< @brief Minor version number */
-#define OS_REVISION      19  /**< @brief Revision number */
+#define OS_REVISION      20  /**< @brief Revision number */
 #define OS_MISSION_REV   0  /**< @brief Mission revision */
 
 /**


### PR DESCRIPTION
**Describe the contribution**
Fast Tracked Changes to Integration Candidate 2020-06-10

Fix #509 
Fix #502 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/102/checks

**Expected behavior changes**

PR #503 - Added the following wrappers macros around `UtAssert_True` for commonly-used asserts:
- `UtAssert_INT32_EQ` - check equality as 32 bit signed int
- `UtAssert_UINT32_EQ` - check equality as 32 bit unsigned int
- `UtAssert_NOT_NULL` - check pointer not null
- `UtAssert_NULL` - check pointer is null
- `UtAssert_NONZERO` - check integer is nonzero
- `UtAssert_ZERO` - check integer is zero
- `UtAssert_STUB_COUNT` - check stub count

PR #510 -  Using `unsigned long` instead of `uintmax_t` to fix support for VxWorks

**System(s) tested on**
Ubuntu:Bionic

**Additional context**
Part of nasa/cfs#102

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc. 