### PR TITLE
Fix #522 - SocketOpen stub should set sock_id

### DIFF
--- a/src/ut-stubs/osapi-utstub-sockets.c
+++ b/src/ut-stubs/osapi-utstub-sockets.c
@@ -37,7 +37,7 @@ int32 OS_SocketOpen(uint32 *sock_id, OS_SocketDomain_t Domain, OS_SocketType_t T
 
     if (status == OS_SUCCESS)
     {
-        status = UT_AllocStubObjId(UT_OBJTYPE_SOCKET);
+        *sock_id = UT_AllocStubObjId(UT_OBJTYPE_SOCKET);
     }
 
     return status;


### PR DESCRIPTION
**Describe the contribution**
Fix #522 - OS_SocketOpen() should, on "success", set sock_id and return a status.

**Additional context**
See OS_SocketOpen() definition in https://github.com/nasa/osal/blob/bc73437ea95af54078ba40ce4001a567b1bbc393/src/os/inc/osapi-os-net.h#L232

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov