### PR TITLE
Fix #525, ensure POSIX stack size meets requirements

### DIFF
--- a/src/os/posix/inc/os-posix.h
+++ b/src/os/posix/inc/os-posix.h
@@ -80,6 +80,7 @@ typedef struct
    pthread_key_t ThreadKey;
    sigset_t      MaximumSigMask;
    sigset_t      NormalSigMask;
+   size_t        PageSize;
    POSIX_PriorityLimits_t PriLimits;
    int           SelectedRtScheduler;
 } POSIX_GlobalVars_t;

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -38,6 +38,13 @@
 #include "os-shared-task.h"
 #include "os-shared-idmap.h"
 
+/*
+ * Defines
+ */
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN   (8*1024)
+#endif
+
 /* Tables where the OS object information is stored */
 OS_impl_task_internal_record_t      OS_impl_task_table          [OS_MAX_TASKS];
 
@@ -416,6 +423,8 @@ int32 OS_Posix_TaskAPI_Impl_Init(void)
    }
 #endif
 
+   POSIX_GlobalVars.PageSize = sysconf(_SC_PAGESIZE);
+
    return OS_SUCCESS;
 } /* end OS_Posix_TaskAPI_Impl_Init */
 
@@ -446,14 +455,42 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t 
        return(OS_ERROR);
     }
 
-
-     /*
-     ** Test to see if the original main task scheduling priority worked.
-     ** If so, then also set the attributes for this task.  Otherwise attributes
-     ** are left at default.
+    /*
+     * Adjust the stack size parameter.
+     *
+     * POSIX has additional restrictions/limitations on the stack size of tasks that
+     * other RTOS environments may not have.  Specifically POSIX says that the stack
+     * size must be at least PTHREAD_STACK_MIN and may also need to be a multiple of the
+     * system page size.
+     *
+     * Rounding up means the user might get a bigger stack than they requested, but
+     * that should not break anything aside from consuming extra memory.
      */
-     if (POSIX_GlobalVars.EnableTaskPriorities)
-     {
+    if (stacksz < PTHREAD_STACK_MIN)
+    {
+        stacksz = PTHREAD_STACK_MIN;
+    }
+
+    stacksz += POSIX_GlobalVars.PageSize - 1;
+    stacksz -= stacksz % POSIX_GlobalVars.PageSize;
+
+    /*
+    ** Set the Stack Size
+    */
+    return_code = pthread_attr_setstacksize(&custom_attr, stacksz);
+    if (return_code != 0)
+    {
+        OS_DEBUG("pthread_attr_setstacksize error in OS_TaskCreate: %s\n",strerror(return_code));
+        return(OS_ERROR);
+    }
+
+    /*
+    ** Test to see if the original main task scheduling priority worked.
+    ** If so, then also set the attributes for this task.  Otherwise attributes
+    ** are left at default.
+    */
+    if (POSIX_GlobalVars.EnableTaskPriorities)
+    {
         /*
         ** Set the scheduling inherit attribute to EXPLICIT
         */
@@ -464,15 +501,6 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t 
             return(OS_ERROR);
         }
 
-       /*
-       ** Set the Stack Size
-       */
-       return_code = pthread_attr_setstacksize(&custom_attr, stacksz);
-       if (return_code != 0)
-       {
-           OS_DEBUG("pthread_attr_setstacksize error in OS_TaskCreate: %s\n",strerror(return_code));
-           return(OS_ERROR);
-       }
 
        /*
        ** Set the scheduling policy
@@ -503,7 +531,7 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t 
           return(OS_ERROR);
        }
 
-     } /* End if user is root */
+    } /* End if user is root */
 
     /*
      ** Create thread


### PR DESCRIPTION
**Describe the contribution**
The `pthread_attr_setstacksize()` function stipulates that it may fail if the user-supplied stack size is not at least
`PTHREAD_STACK_MIN` and also possibly a multiple of page size.

This partially reverts previous PR #508 and adds back rounding up to `PTHREAD_STACK_MIN` and also adds rounding up to a system page size.  However the check for zero stack still remains at the shared level so attempts to create a task with zero
stack will still fail.  This allows internal helper threads to be created with a default minimum stack size, however.

Fixes #525 

**Testing performed**
Build and sanity check CFE executing as both normal user and root user.
Execute all unit tests as both normal user and root user.

**Expected behavior changes**
No failure due to stack size not meeting system requirements.

**System(s) tested on**
Ubuntu 20.04, running as normal user.
CentOS 8.1 in VM running as root user.

**Additional context**
This also moves the `pthread_attr_setstacksize()` call such that it is configured regardless of whether task priorities are enabled nor not (i.e. non root user).  The normal user should still be able to configure the stack size even if they lack permission to set scheduling priority.

Also confirmed that by moving the call to `pthread_attr_setstacksize()` that the original bug report is reproducible in a non-root environment - which is also fixed by this change.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
