### PR TITLE
Fix #532, Set pthread names to match CFE tasks names

### DIFF
--- a/src/bsp/pc-linux/config/osconfig.h
+++ b/src/bsp/pc-linux/config/osconfig.h
@@ -196,4 +196,10 @@
  */
 #define OSAL_DEBUG_PERMISSIVE_MODE
 
+/*
+ * If OS_HAVE_PTHREAD_SETNAME_NP is defined, this will allow underlying pthread names
+ * to match CFE task names
+ */
+#define OS_HAVE_PTHREAD_SETNAME_NP
+
 #endif

--- a/src/os/posix/os-posix.h
+++ b/src/os/posix/os-posix.h
@@ -107,7 +107,4 @@ int32 OS_Posix_StreamAPI_Impl_Init(void);
 int32 OS_Posix_DirAPI_Impl_Init(void);
 int32 OS_Posix_FileSysAPI_Impl_Init(void);
 
-int32 OS_Posix_InternalTaskCreate_Impl (pthread_t *thr, uint32 priority, size_t stacksz, PthreadFuncPtr_t Entry, void *entry_arg);
-
-
-
+int32 OS_Posix_InternalTaskCreate_Impl (pthread_t *thr, const char *thread_name, uint32 priority, size_t stacksz, PthreadFuncPtr_t Entry, void *entry_arg);

--- a/src/os/posix/ostimer.c
+++ b/src/os/posix/ostimer.c
@@ -351,7 +351,7 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
     OS_impl_timebase_internal_record_t *local;
     OS_common_record_t *global;
     OS_U32ValueWrapper_t arg;
-
+    char timer_name[OS_MAX_API_NAME];
 
     local = &OS_impl_timebase_table[timer_id];
     global = &OS_global_timebase_table[timer_id];
@@ -368,7 +368,14 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
      */
     arg.opaque_arg = NULL;
     arg.value = global->active_id;
-    return_code = OS_Posix_InternalTaskCreate_Impl(&local->handler_thread, 0, 0, OS_TimeBasePthreadEntry, arg.opaque_arg);
+
+    /*
+    ** Construct the timer thread name:
+    ** The name will consist of "timer.{timer id}"
+    */
+    snprintf(timer_name, sizeof(timer_name), "timer.%d", timer_id);
+
+    return_code = OS_Posix_InternalTaskCreate_Impl(&local->handler_thread, timer_name, 0, 0, OS_TimeBasePthreadEntry, arg.opaque_arg);
     if (return_code != OS_SUCCESS)
     {
         return return_code;


### PR DESCRIPTION
**Describe the contribution**
This change allows underlying OS tools to view thread names for platforms that support the pthread_setname_np function.

**Testing performed**
Steps taken to test the contribution:
1. Set #define OS_HAVE_PTHREAD_SETNAME_NP in osconfig for target
2. Run CFE environment
3. Run htop under Linux and verify thread names appear

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: Adds a task_name parameter to the OS_Posix_InternalTaskCreate_Impl function
 - Behavior Change: None

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: cFE 6.7.0, OSAL 5.0.0

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Daniel Burns
GSFC - Code 596.0
daniel.s.burns@nasa.gov
