### PR TITLE
Fix #534, adjust UT assert buffer sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ UT Hook functions now have the capability to get argument values by name, which 
 
 - Minor updates (see <https://github.com/nasa/osal/pull/264>)
 
-### **_OFFICIAL RELEASE: 5.0.0_**
+### **_OFFICIAL RELEASE: 5.0.0 - Aquila_**
 
 - Changes are detailed in [cFS repo](https://github.com/nasa/cFS) release 6.7.0 documentation
 - Released under the Apache 2.0 license

--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -42,7 +42,7 @@
 UtAssert_CaseType_t DefaultContext = UTASSERT_CASETYPE_FAILURE;
 UtAssert_TestCounter_t UT_SegmentCounters = { 0 };
 UtAssert_TestCounter_t UT_TotalCounters = { 0 };
-static char CurrentSegment[128];
+static char CurrentSegment[64];
 
 /*
  * Function Definitions
@@ -76,7 +76,7 @@ void UtAssert_DoReport(const char *File, uint32 LineNum, uint32 SegmentNum, uint
 
 void UtAssert_DoTestSegmentReport(const char *SegmentName, const UtAssert_TestCounter_t *TestCounters)
 {
-    char ReportBuffer[128];
+    char ReportBuffer[144];
 
     snprintf(ReportBuffer, sizeof(ReportBuffer),
              "%02u %-20s TOTAL::%-4u  PASS::%-4u  FAIL::%-4u   MIR::%-4u   TSF::%-4u   N/A::%-4u\n",


### PR DESCRIPTION
**Describe the contribution**

Avoids a possible truncation in snprintf call.
Fixes #534 

**Testing performed**
Build and run unit tests.

**Expected behavior changes**
No buffer size/truncation warning when building with optimization enabled.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
