### PR TITLE
Resolve #531, Add baseline and build number

### DIFF
--- a/src/os/inc/osapi-version.h
+++ b/src/os/inc/osapi-version.h
@@ -23,19 +23,62 @@
  *
  * Purpose:
  *  The OSAL version numbers
+ *  See cfe documentation for version and build number descriptions
  */
 
 #ifndef _osapi_version_h_
 #define _osapi_version_h_
 
-#define OS_MAJOR_VERSION 5  /**< @brief Major version number */
-#define OS_MINOR_VERSION 0  /**< @brief Minor version number */
-#define OS_REVISION      21  /**< @brief Revision number */
-#define OS_MISSION_REV   0  /**< @brief Mission revision */
+/* Development Build Macro Definitions */
+#define OS_BUILD_NUMBER 242 
+#define OS_BUILD_BASELINE "v5.0.0+dev"
 
-/**
- * Combine the revision components into a single value that application code can check against
- * e.g. "#if OSAL_API_VERSION >= 40100" would check if some feature added in OSAL 4.1 is present.
+/* Version Macro Definitions
+* ONLY APPLY for OFFICIAL release builds
+*/
+#define OS_MAJOR_VERSION 5 /**< @brief Major version number */
+#define OS_MINOR_VERSION 0 /**< @brief Minor version number */
+#define OS_REVISION      0 /**< @brief Revision number */
+#define OS_MISSION_REV   0 /**< @brief Mission revision */
+
+/* Helper functions to concatenate integer macro definitions into a string */
+#define OS_STR_HELPER(x) #x
+#define OS_STR(x)        OS_STR_HELPER(x)
+
+/* Development Build format for OS_VERSION */
+/* Baseline git tag + Number of commits since baseline */
+#define OS_VERSION OS_BUILD_BASELINE OS_STR(OS_BUILD_NUMBER)
+
+/* Development Build format for OS_VERSION_STRING */
+#define OS_VERSION_STRING                                                          \
+    " OSAL Development Build\n"                                                    \
+    " " OS_VERSION " (Codename: Bootes)\n"  /* Codename for current development */ \
+    " Latest Official Version: osal v5.0.0" /* For full support please use official release version */
+
+/* Use the following templates for Official Releases ONLY */
+
+/* Official Release format for OS_VERSION */
+  /*
+  #define OS_VERSION "v"            \
+       OS_STR(OS_MAJOR_VERSION) "." \
+       OS_STR(OS_MINOR_VERSION) "." \
+       OS_STR(OS_REVISION) "."      \
+       OS_STR(OS_MISSION_REV)
+  */
+
+  /* Official Release OS_VERSION_STRING Format */
+  /*
+  #define OS_VERSION_STRING " OSAL " OS_VERSION
+  */
+  
+/* END TEMPLATES */
+
+
+/*
+ * Combine the revision components into a single value that application code can
+check against
+ * e.g. "#if OSAL_API_VERSION >= 40100" would check if some feature added in
+OSAL 4.1 is present.
  */
 #define OSAL_API_VERSION ((OS_MAJOR_VERSION * 10000) + (OS_MINOR_VERSION * 100) + OS_REVISION)
 


### PR DESCRIPTION
**Describe the contribution**
Resolve #531 

**Testing performed**
Bundle CI
Docker-based testing using gcc image

**Expected behavior changes**
New macros defined. No changes on it's own. When combined with nasa/cfe#771 and nasa/psp#178 then startup reporting looks like 
<img width="331" alt="Screen Shot 2020-07-15 at 8 56 43 AM" src="https://user-images.githubusercontent.com/59618057/87557256-ab977000-c685-11ea-893c-a27e54441639.png">
<img width="340" alt="Screen Shot 2020-07-15 at 8 56 52 AM" src="https://user-images.githubusercontent.com/59618057/87557332-c5d14e00-c685-11ea-8fd7-4ad987984e72.png">
<img width="208" alt="Screen Shot 2020-07-15 at 8 56 35 AM" src="https://user-images.githubusercontent.com/59618057/87557452-ebf6ee00-c685-11ea-8914-c4ea6844fde4.png">



**System(s) tested on**
Ubuntu 

**Additional context**
Left in a commented-out section for replacing the version string for official releases. 

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC
