### PR TITLE
Fix #538, correct loop variable for coverage install

### DIFF
--- a/src/unit-test-coverage/CMakeLists.txt
+++ b/src/unit-test-coverage/CMakeLists.txt
@@ -84,7 +84,7 @@ function (add_coverage_testrunner TESTNAME FSW_SRCFILE TESTCASE_SRCFILE)
     add_test(${TESTNAME} ${TESTNAME}-testrunner)
 
     foreach(TGT ${INSTALL_TARGET_LIST})
-        install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+        install(TARGETS ${TESTNAME}-testrunner DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
     endforeach()
 
 endfunction()


### PR DESCRIPTION
**Describe the contribution**
Install use the loop variable (TGT) not TGTNAME for DESTINATION.

Fixes #538 

**Testing performed**
Build with ENABLE_UNIT_TESTS=TRUE and a configuration with multiple CPUs sharing a single arch+platform config.

**Expected behavior changes**
Without this fix, the coverage binaries are installed twice to CPU2 but not at all for CPU1.
With this fix, they are correctly installed for CPU1 and CPU2.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
No change to behavior at all - just an install path fix.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
