### PR TITLE
Fix #540, add event callback framework

### DIFF
--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -57,6 +57,12 @@ struct OS_shared_global_vars
    int32             MicroSecPerTick;
    int32             TicksPerSecond;
 
+   /*
+    * The event handler is an application-defined callback
+    * that gets invoked as resources are created/configured/deleted.
+    */
+   OS_EventHandler_t EventHandler;
+
 #ifdef OSAL_CONFIG_DEBUG_PRINTF
    uint8             DebugLevel;
 #endif
@@ -68,6 +74,16 @@ struct OS_shared_global_vars
  * Shared data structure for global values
  */
 extern OS_SharedGlobalVars_t OS_SharedGlobalVars;
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_NotifyEvent
+
+   Purpose: Notify the user application of a change in the state of an OSAL resource
+
+   returns: OS_SUCCESS on success, or relevant error code
+---------------------------------------------------------------------------------------*/
+int32 OS_NotifyEvent(OS_Event_t event, osal_id_t object_id, void *data);
+
 
 /*---------------------------------------------------------------------------------------
    Name: OS_API_Impl_Init

--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -65,10 +65,35 @@ OS_SharedGlobalVars_t OS_SharedGlobalVars =
             .ShutdownFlag = 0,
             .MicroSecPerTick = 0, /* invalid, _must_ be set by implementation init */
             .TicksPerSecond = 0,  /* invalid, _must_ be set by implementation init */
+            .EventHandler = NULL,
 #if defined(OSAL_CONFIG_DEBUG_PRINTF)
             .DebugLevel = 1,
 #endif
       };
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_NotifyEvent
+ *
+ *  Purpose: Helper function to invoke the user-defined event handler
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_NotifyEvent(OS_Event_t event, osal_id_t object_id, void *data)
+{
+    int32 status;
+
+    if (OS_SharedGlobalVars.EventHandler != NULL)
+    {
+        status = OS_SharedGlobalVars.EventHandler(event, object_id, data);
+    }
+    else
+    {
+        status = OS_SUCCESS;
+    }
+
+    return status;
+}
 
 /*
  *********************************************************************************
@@ -199,6 +224,24 @@ int32 OS_API_Init(void)
    return(return_code);
 } /* end OS_API_Init */
 
+/*----------------------------------------------------------------
+ *
+ * Function: OS_RegisterEventHandler
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_RegisterEventHandler (OS_EventHandler_t handler)
+{
+    if (handler == NULL)
+    {
+        return OS_INVALID_POINTER;
+    }
+
+    OS_SharedGlobalVars.EventHandler = handler;
+    return OS_SUCCESS;
+}
 
 /*----------------------------------------------------------------
  *

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -120,6 +120,12 @@ static int32 OS_TaskPrepare(osal_id_t task_id, osal_task_entry *entrypt)
        return_code = OS_TaskRegister_Impl(task_id);
    }
 
+   if (return_code == OS_SUCCESS)
+   {
+      /* Give event callback to the application */
+      return_code = OS_NotifyEvent(OS_EVENT_TASK_STARTUP, task_id, NULL);
+   }
+
    if (return_code != OS_SUCCESS)
    {
       *entrypt = NULL;

--- a/src/ut-stubs/osapi-utstub-common.c
+++ b/src/ut-stubs/osapi-utstub-common.c
@@ -49,6 +49,40 @@ int32 OS_API_Init(void)
     return status;
 }
 
+/*****************************************************************************
+ *
+ * Stub function for OS_NotifyEvent()
+ *
+ *****************************************************************************/
+int32 OS_NotifyEvent(OS_Event_t event, osal_id_t object_id, void *data)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_NotifyEvent), event);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_NotifyEvent), object_id);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_NotifyEvent), data);
+
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(OS_NotifyEvent);
+
+    return status;
+}
+
+/*****************************************************************************
+ *
+ * Stub function for OS_RegisterEventHandler()
+ *
+ *****************************************************************************/
+int32 OS_RegisterEventHandler (OS_EventHandler_t handler)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_RegisterEventHandler), handler);
+
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(OS_RegisterEventHandler);
+
+    return status;
+}
+
 
 /*****************************************************************************
  *


### PR DESCRIPTION
**Describe the contribution**
Adds an event callback mechanism to certain state changes in OSAL.  This allows the CFE PSP to be notified at these points, and therefore it can add platform-specific functionality.  This can, for instance, set the task name as requested in #532 or set the processor affinity in a multi-core setup (TBD).

Fixes #540 

**Testing performed**
Create an event handler in the pc-linux CFE PSP and register it, and print out each event received.  Confirm events are generated as expected, and that it didn't break the FSW in any way.

Note - Not completely tested yet -- this is mainly a proof of concept and pushed for design review at this time.

**Expected behavior changes**
Adds ability to implement custom platform-specific functionality for defined events.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Previous discussion in #532.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
