### PR TITLE
Fix #557, remove OS_ObjectIdMap/Unmap prototype and stub

### DIFF
--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -206,24 +206,6 @@ uint32 OS_GetMaxForObjectType(uint32 idtype);
 uint32 OS_GetBaseForObjectType(uint32 idtype);
 
 /*----------------------------------------------------------------
-   Function: OS_ObjectIdMap
-
-    Purpose: Convert an object serial number into a 32-bit OSAL ID of the given type
-
-    Returns: OS_SUCCESS on success, or relevant error code
- ------------------------------------------------------------------*/
-int32 OS_ObjectIdMap(uint32 idtype, uint32 idvalue, uint32 *result);
-
-/*----------------------------------------------------------------
-   Function: OS_ObjectIdUnMap
-
-    Purpose: Convert a 32-bit OSAL ID of the expected type into an object serial number
-
-    Returns: OS_SUCCESS on success, or relevant error code
- ------------------------------------------------------------------*/
-int32 OS_ObjectIdUnMap(uint32 id, uint32 idtype, uint32 *idvalue);
-
-/*----------------------------------------------------------------
    Function: OS_ObjectIdFindByName
 
     Purpose: Finds an entry in the global resource table matching the given name

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -54,49 +54,6 @@ void OS_Unlock_Global(uint32 idtype)
 
 /*****************************************************************************
  *
- * Stub function for OS_ObjectIdMap()
- *
- *****************************************************************************/
-int32 OS_ObjectIdMap(uint32 idtype, uint32 idvalue, uint32 *result)
-{
-    int32 Status;
-
-    Status = UT_DEFAULT_IMPL(OS_ObjectIdMap);
-
-    if (Status == 0 &&
-            UT_Stub_CopyToLocal(UT_KEY(OS_ObjectIdMap), result, sizeof(*result)) < sizeof(*result))
-    {
-        /* this needs to output something valid or code will break */
-        *result = idvalue;
-        UT_FIXUP_ID(*result, idtype);
-    }
-
-    return Status;
-}
-
-/*****************************************************************************
- *
- * Stub function for OS_ObjectIdUnMap()
- *
- *****************************************************************************/
-int32 OS_ObjectIdUnMap(uint32 id, uint32 idtype, uint32 *idvalue)
-{
-    int32 Status;
-
-    Status = UT_DEFAULT_IMPL(OS_ObjectIdUnMap);
-
-    if (Status == 0 &&
-            UT_Stub_CopyToLocal(UT_KEY(OS_ObjectIdUnMap), idvalue, sizeof(*idvalue)) < sizeof(*idvalue))
-    {
-        /* this needs to output something valid or code will break */
-        *idvalue = id & 0xFFFF;
-    }
-
-    return Status;
-}
-
-/*****************************************************************************
- *
  * Stub function for OS_GetMaxForObjectType()
  *
  *****************************************************************************/


### PR DESCRIPTION
**Describe the contribution**
These internal functions were no longer used or defined but the prototype and stub were still present.  This removes them.

Fixes #557 

**Testing performed**
Compile and run unit tests.

**Expected behavior changes**
None - unused/stale code cleanup.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
