### PR TITLE
Fix #565, propagate return code from OS_TaskRegister_Impl()

### DIFF
--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -116,9 +116,10 @@ static int32 OS_TaskPrepare(uint32 task_id, osal_task_entry *entrypt)
 
    if (return_code == OS_SUCCESS)
    {
-      OS_TaskRegister_Impl(task_id);
+       return_code = OS_TaskRegister_Impl(task_id);
    }
-   else
+
+   if (return_code != OS_SUCCESS)
    {
       *entrypt = NULL;
    }


### PR DESCRIPTION
**Describe the contribution**
If this routine fails then return the error to the caller, which will also prevent the task from starting.

Fixes #565 

**Testing performed**
Build and sanity check CFE
Build and run all unit tests incl. coverage.

**Expected behavior changes**
No impact to behavior, as no known way to force this error, but will correctly propagate an error if one were to occur.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
