### PR TITLE
Fix #537, Fail tests on startup and tear down failures

### DIFF
--- a/ut_assert/src/utbsp.c
+++ b/ut_assert/src/utbsp.c
@@ -210,7 +210,9 @@ void UT_BSP_EndTest(const UtAssert_TestCounter_t *TestCounters)
              (unsigned int)TestCounters->TestSegmentCount);
     OS_BSP_ConsoleOutput_Impl(Message, strlen(Message));
 
-    if (TestCounters->CaseCount[UTASSERT_CASETYPE_FAILURE] > 0)
+    if ((TestCounters->CaseCount[UTASSERT_CASETYPE_FAILURE] > 0) ||
+        (TestCounters->CaseCount[UTASSERT_CASETYPE_TSF] > 0) ||
+        (TestCounters->CaseCount[UTASSERT_CASETYPE_TTF] > 0))
     {
         OS_BSP_SetExitCode(OS_ERROR);
     }


### PR DESCRIPTION
**Describe the contribution**
Fix #537 - fail tests on startup or tear down failures... these are failures, just a different severity (likely mean the test didn't work as expected and needs to be fixed)

**Testing performed**
Built tests with a known startup failure, test failed as expected

**Expected behavior changes**
Now will fail on startup/tear down failures

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+ cfe/osal main) + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC