### PR TITLE
Apply #585 to Bootes, Set Revision to 99 for development build

### DIFF
--- a/src/os/inc/osapi-version.h
+++ b/src/os/inc/osapi-version.h
@@ -38,7 +38,7 @@
  */
 #define OS_MAJOR_VERSION 5 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define OS_MINOR_VERSION 0 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define OS_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number. */
+#define OS_REVISION      99/*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. If set to "99" it indicates a development version.  */
 #define OS_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Fix #584 for Bootes

**Testing performed**
Built and ran locally based on bundle tag for bootes-rc1
Built in CI, See https://travis-ci.com/github/astrogeco/cFS/builds/189834136

**Expected behavior changes**
Revision version number now reports `99` during development versions. ES Housekeeping data reports `6.7.99` in the version string.

**System(s) tested on**
Built and ran on Docker container. 

**Additional context**
Also see nasa/cfe#830

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC