### PR TITLE
Fix #593, change OCS_off_t to a signed type

### DIFF
--- a/src/unit-test-coverage/ut-stubs/inc/OCS_sys_types.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_sys_types.h
@@ -32,7 +32,7 @@
 /* types normally defined in sys/types.h */
 /* ----------------------------------------- */
 typedef ptrdiff_t       OCS_ssize_t;
-typedef size_t          OCS_off_t;
+typedef long            OCS_off_t;
 typedef unsigned int    OCS_mode_t;
 typedef long            OCS_time_t;
 typedef int             OCS_pid_t;


### PR DESCRIPTION
**Describe the contribution**
The C library type is signed, and this makes the result check work as intended.

Fixes #593 

**Testing performed**
Run all unit tests.  
Note OCS_off_t is only used in coverage testing for OSAL.

**Expected behavior changes**
Fixes issue if caller uses correct type `off_t` to store result.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Issue was exposed by Travis CI failure in change suggested in PR #592, but really a separate issue.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
