### PR TITLE
Fix #604, Add ut_assert address equal macro

### DIFF
--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -144,6 +144,17 @@ typedef struct
                 UtAssertEx(Expression, UTASSERT_CASETYPE_##Type, __FILE__, __LINE__, __VA_ARGS__)
 
 /**
+ * \brief Compare addresses for equality with an auto-generated description message
+ */
+#define UtAssert_ADDRESS_EQ(actual,expect)   do       \
+{                                                     \
+    void *exp = (void*)(expect);                      \
+    void *act = (void*)(actual);                      \
+    UtAssert_True(act == exp, "%s (%p) == %s (%p)",   \
+                  #actual, act, #expect, exp);        \
+} while(0)                                            \
+
+/**
  * \brief Compare two values for equality with an auto-generated description message
  * Values will be compared in an "int32" type context.
  */


### PR DESCRIPTION
**Describe the contribution**
Fix #604 - adds the macro

**Testing performed**
Used the macro in work related to nasa/cfe#903 (built and ran unit tests locally using it)

**Expected behavior changes**
Additional macro available

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: main bundle + this commit

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC