### PR TITLE
Fixed typo in rtems binsem TimeInTicks variable name

### DIFF
--- a/src/os/rtems/src/os-impl-binsem.c
+++ b/src/os/rtems/src/os-impl-binsem.c
@@ -246,7 +246,7 @@ int32 OS_BinSemTimedWait_Impl (uint32 sem_id, uint32 msecs)
     rtems_status_code status;
     int               TimeInTicks;
 
-    if (OS_Milli2Ticks(msecs, &TimInTicks) != OS_SUCCESS)
+    if (OS_Milli2Ticks(msecs, &TimeInTicks) != OS_SUCCESS)
     {
         return OS_ERROR;
     }


### PR DESCRIPTION
**Describe the contribution**
This addresses a typo in the rtems os-impl-binsem.c file for a variable name. 

Fixes https://github.com/nasa/osal/issues/613 

**Testing performed**
Compiled using rtems toolchain, but not run on hardware.

**Expected behavior changes**
Prior to this change, compilation failed for an rtems platform. The code should now compile for rtems.

**System(s) tested on**
 - Hardware: Dell latptop(Build Machine) - AAC Sirius(Host Machine)
 - OS: Ubuntu 18.04(Build Machine) - RTEMS 4.11(Host Machine)
 - Versions: OSAL Main

**Contributor Info - All information REQUIRED for consideration of pull request**
Adam St. Amand - Personal
