### PR TITLE
Fix #615, RTEMS build issues

### DIFF
--- a/src/os/rtems/src/os-impl-binsem.c
+++ b/src/os/rtems/src/os-impl-binsem.c
@@ -39,6 +39,7 @@
 #include "os-impl-binsem.h"
 #include "os-shared-binsem.h"
 #include "os-shared-idmap.h"
+#include "os-shared-timebase.h"
 
 
 /****************************************************************************************
@@ -246,7 +247,7 @@ int32 OS_BinSemTimedWait_Impl (uint32 sem_id, uint32 msecs)
     rtems_status_code status;
     int               TimeInTicks;
 
-    if (OS_Milli2Ticks(msecs, &TimInTicks) != OS_SUCCESS)
+    if (OS_Milli2Ticks(msecs, &TimeInTicks) != OS_SUCCESS)
     {
         return OS_ERROR;
     }

--- a/src/os/rtems/src/os-impl-countsem.c
+++ b/src/os/rtems/src/os-impl-countsem.c
@@ -40,6 +40,7 @@
 
 #include "os-shared-countsem.h"
 #include "os-shared-idmap.h"
+#include "os-shared-timebase.h"
 
 /****************************************************************************************
                                      DEFINES
@@ -207,9 +208,12 @@ int32 OS_CountSemTake_Impl (uint32 sem_id)
 int32 OS_CountSemTimedWait_Impl (uint32 sem_id, uint32 msecs)
 {
     rtems_status_code status;
-    uint32            TimeInTicks;
+    int               TimeInTicks;
 
-    TimeInTicks = OS_Milli2Ticks(msecs);
+    if (OS_Milli2Ticks(msecs, &TimeInTicks) != OS_SUCCESS)
+    {
+        return OS_ERROR;
+    }
 
     status = rtems_semaphore_obtain(OS_impl_count_sem_table[sem_id].id, RTEMS_WAIT, TimeInTicks);
     if (status == RTEMS_TIMEOUT)

--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -40,6 +40,8 @@
 
 #include "os-shared-queue.h"
 #include "os-shared-idmap.h"
+#include "os-shared-timebase.h"
+
 
 /****************************************************************************************
                                      DEFINES
@@ -162,6 +164,7 @@ int32 OS_QueueGet_Impl (uint32 queue_id, void *data, uint32 size, uint32 *size_c
     int32              return_code;
     rtems_status_code  status;
     rtems_interval     ticks;
+    int                tick_count;
     rtems_option       option_set;
     size_t             rtems_size;
     rtems_id           rtems_queue_id;
@@ -182,8 +185,14 @@ int32 OS_QueueGet_Impl (uint32 queue_id, void *data, uint32 size, uint32 *size_c
     else
     {
         option_set = RTEMS_WAIT;
+
         /* msecs rounded to the closest system tick count */
-        ticks = OS_Milli2Ticks(timeout);
+        if (OS_Milli2Ticks(timeout, &tick_count) != OS_SUCCESS)
+        {
+            return OS_ERROR;
+        }
+
+        ticks = (rtems_interval)tick_count;
     }
 
     /*


### PR DESCRIPTION
**Describe the contribution**

Correct issues involving recent OS_Milli2Ticks change.

Note - for OS_TaskDelay it is important that this doesn't degrade into a no-op.  So if OS_Milli2Ticks fails here, this returns the
error but still also does a non-zero delay.

**Testing performed**
Build and sanity check CFE under RTEMS
Run all unit tests

**Expected behavior changes**
Builds and runs correctly

**System(s) tested on**
RTEMS 4.11.3 + pc686 BSP target (QEMU) using Ubuntu 20.04 build host

**Additional context**
Includes the typo fix in #614 plus others.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
