### PR TITLE
Fix #556, Deprecate OS_open and OS_creat

### DIFF
--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -178,6 +178,8 @@ typedef enum
  * @{
  */
 
+#ifndef OSAL_OMIT_DEPRECATED
+
 /*-------------------------------------------------------------------------------------*/
 /**
  * @brief Creates a file specified by path
@@ -199,6 +201,9 @@ typedef enum
  * @retval #OS_FS_ERR_NAME_TOO_LONG if the name of the file is too long
  * @retval #OS_ERROR if permissions are unknown or OS call fails
  * @retval #OS_ERR_NO_FREE_IDS if there are no free file descriptors left
+ *
+ * @deprecated Replaced by OS_OpenCreate() with flags set to
+ *             OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE.
  */
 int32           OS_creat  (const char *path, int32  access);
 
@@ -225,8 +230,13 @@ int32           OS_creat  (const char *path, int32  access);
  * @retval #OS_FS_ERR_NAME_TOO_LONG if the name of the file is too long
  * @retval #OS_ERROR if permissions are unknown or OS call fails
  * @retval #OS_ERR_NO_FREE_IDS if there are no free file descriptors left
+ *
+ * @deprecated Replaced by OS_OpenCreate() with flags set to
+ *             OS_FILE_FLAG_NONE.
  */
 int32           OS_open   (const char *path,  int32 access,  uint32 mode);
+
+#endif
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -99,6 +99,21 @@ int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 acc
    OS_common_record_t *record;
    char   local_path[OS_MAX_LOCAL_PATH_LEN];
 
+   if (filedes == NULL)
+   {
+       return OS_INVALID_POINTER;
+   }
+
+   /*
+   ** Check for a valid access mode
+   */
+   if (access != OS_WRITE_ONLY &&
+           access != OS_READ_ONLY &&
+           access != OS_READ_WRITE)
+   {
+       return OS_ERROR;
+   }
+
    /*
     * Translate the path
     */
@@ -126,6 +141,12 @@ int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 acc
    return return_code;
 } /* end OS_OpenCreate */
 
+
+/*
+ * The OS_open and OS_creat functions are deprecated, replaced by
+ * the generic OS_OpenCreate above
+ */
+#ifndef OSAL_OMIT_DEPRECATED
 
 /*----------------------------------------------------------------
  *
@@ -205,7 +226,7 @@ int32 OS_open   (const char *path,  int32 access,  uint32  mode)
    return return_code;
 } /* end OS_open */
 
-
+#endif
 
 /*----------------------------------------------------------------
  *

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -147,22 +147,16 @@ void TestCreatRemove(void)
     }
     
     /* create a file with short name */
-    status = OS_creat(filename,OS_READ_WRITE);
-    UtAssert_True(status >= 0, "fd after creat short name length file = %d",(int)status);
-
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
+    UtAssert_True(status == OS_SUCCESS, "fd after creat short name length file = %d",(int)status);
 
     /* close the first file */
     status = OS_close(fd);
     UtAssert_True(status == OS_SUCCESS, "status after close short name length file = %d",(int)status);
 
     /* create a file with max name size */
-    status = OS_creat(maxfilename,OS_READ_WRITE);
-    UtAssert_True(status >= 0, "fd after creat max name length file = %d",(int)status);
-
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
+    status = OS_OpenCreate(&fd, maxfilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
+    UtAssert_True(status == OS_SUCCESS, "fd after creat max name length file = %d",(int)status);
 
     /* close the second file */
     status = OS_close(fd);
@@ -177,7 +171,7 @@ void TestCreatRemove(void)
     UtAssert_True(status == OS_SUCCESS, "status after remove max name length file = %d",(int)status);
 
     /* try creating with file name too big, should fail */
-    status = OS_creat(longfilename,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd, longfilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status < OS_SUCCESS, "status after create file name too long = %d",(int)status);
 
     /* try removing with file name too big. Should Fail */
@@ -207,12 +201,9 @@ void TestOpenClose(void)
     filename[sizeof(filename) - 1] = 0;
 
     /* create a file of reasonable length (but over 8 chars) */
-    status = OS_creat(filename,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat = %d",(int)status);
         
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
-
     /*
     ** try to close the file
     */
@@ -220,12 +211,9 @@ void TestOpenClose(void)
     UtAssert_True(status == OS_SUCCESS, "status after close = %d",(int)status);
 
     /*  reopen the file */
-    status = OS_open(filename,OS_READ_WRITE,0644);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_NONE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after reopen = %d",(int)status);
 
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
-   
     /*
     ** try to close the file again
     */
@@ -243,7 +231,7 @@ void TestOpenClose(void)
     UtAssert_True(status != OS_SUCCESS, "status after close = %d",(int)status);
 
     /*  open a file that was never in the system */
-    status = OS_open("/drive0/FileNotHere",OS_READ_ONLY,0644);
+    status = OS_OpenCreate(&fd, "/drive0/FileNotHere", OS_FILE_FLAG_NONE, OS_READ_ONLY);
     UtAssert_True(status < OS_SUCCESS, "status after open = %d",(int)status);
 
     /* try removing the file from the drive  to end the function */
@@ -279,11 +267,9 @@ void TestReadWriteLseek(void)
     /* create a file of reasonable length (but over 8 chars) */
     
     /* Open In R/W mode */
-    status = OS_creat(filename,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
     size = strlen(buffer);
     
     /* test write portion of R/W mode */
@@ -310,11 +296,8 @@ void TestReadWriteLseek(void)
     UtAssert_True(status == OS_SUCCESS, "status after close = %d",(int)status);
 
     /*  open a file again, but only in READ mode */
-    status = OS_open(filename,OS_READ_ONLY,0644);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
     UtAssert_True(status >= OS_SUCCESS, "status after reopen = %d",(int)status);
-
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
 
     /* test write in READ ONLY mode */
     status = OS_write(fd, (void*)buffer, size);
@@ -349,11 +332,8 @@ void TestReadWriteLseek(void)
     UtAssert_True(status == OS_SUCCESS, "status after close = %d",(int)status);
 
     /*  open a file again, but only in WRITE mode */
-    status = OS_open(filename,OS_WRITE_ONLY,0644);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_NONE, OS_WRITE_ONLY);
     UtAssert_True(status >= OS_SUCCESS, "status after reopen = %d",(int)status);
-
-    /* conversion to osal_id_t */
-    fd = OS_ObjectIdFromInteger(status);
 
     /* test write in WRITE ONLY mode */
     status = OS_write(fd, (void*)buffer, size);
@@ -423,18 +403,12 @@ void TestMkRmDirFreeBytes(void)
     
     /* now create two files in the two directories (1 file per directory) */
 
-    status = OS_creat(filename1,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd1, filename1, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 1 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd1 = OS_ObjectIdFromInteger(status);
-
-    status = OS_creat(filename2,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd2, filename2, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 2 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd2 = OS_ObjectIdFromInteger(status);
-
     /* write the propper buffers into each of the files */
     size = strlen(buffer1);
     status = OS_write(fd1, buffer1, size);
@@ -537,18 +511,12 @@ void TestOpenReadCloseDir(void)
     
     /* now create two files in the two directories (1 file per directory) */
 
-    status = OS_creat(filename1,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd1, filename1, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 1 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd1 = OS_ObjectIdFromInteger(status);
-
-    status = OS_creat(filename2,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd2, filename2, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 2 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd2 = OS_ObjectIdFromInteger(status);
-
     /* write the proper buffers into each of the files */
     size = strlen(buffer1);
     status = OS_write(fd1, buffer1, size);
@@ -756,12 +724,9 @@ void TestRename(void)
                
     /* now create a file in the directory */
 
-    status = OS_creat(filename1,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd1, filename1, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 1 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd1 = OS_ObjectIdFromInteger(status);
-
     /* write the propper buffes into  the file */
     
     size = strlen(buffer1);
@@ -787,12 +752,9 @@ void TestRename(void)
 
     /* try to read the new file out */
 
-    status = OS_open(newfilename1,OS_READ_ONLY,0644);
+    status = OS_OpenCreate(&fd1, newfilename1, OS_FILE_FLAG_NONE, OS_READ_ONLY);
     UtAssert_True(status >= OS_SUCCESS, "status after open 1 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd1 = OS_ObjectIdFromInteger(status);
-
     size  = strlen(copybuffer1);
     status = OS_read(fd1,buffer1,size);
     UtAssert_True(status == size, "status after read 1 = %d size = %d",(int)status, (int)size);
@@ -838,12 +800,9 @@ void TestStat(void)
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 1 = %d",(int)status);
     
     /* now create a file  */
-    status = OS_creat(filename1,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd1, filename1, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 1 = %d",(int)status);
     
-    /* conversion to osal_id_t */
-    fd1 = OS_ObjectIdFromInteger(status);
-
     /* Write some data into the file */
     
     size = strlen(buffer1);
@@ -887,21 +846,22 @@ void TestOpenFileAPI(void)
     char filename2 [OS_MAX_PATH_LEN];
     char filename3 [OS_MAX_PATH_LEN];
     int status;
+    osal_id_t fd;
     
     strcpy(filename1,"/drive0/Filename1");
     strcpy(filename2,"/drive0/Filename2");
     strcpy(filename3,"/drive0/Filename3");
 
     /* Create/open a file */
-    status = OS_creat(filename1,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd, filename1, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 1 = %d",(int)status);
 
     /* Create/open a file */
-    status = OS_creat(filename2,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd, filename2, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 2 = %d",(int)status);
    
     /* Create/open a file */
-    status = OS_creat(filename3,OS_READ_WRITE);
+    status = OS_OpenCreate(&fd, filename3, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat 3 = %d",(int)status);
 
     /* 

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.c
@@ -64,11 +64,9 @@ char *fsAddrPtr = NULL;
 static osal_id_t setup_file(void)
 {
     osal_id_t id;
-    int32 status;
     UT_SETUP(OS_mkfs(fsAddrPtr, "/ramdev3", "RAM3", 512, 20));
     UT_SETUP(OS_mount("/ramdev3", "/drive3"));
-    status = OS_creat("/drive3/select_test.txt", OS_READ_WRITE);
-    id = OS_ObjectIdFromInteger(status);
+    UT_SETUP(OS_OpenCreate(&id, "/drive3/select_test.txt", OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE));
     return id;
 }
 

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -176,14 +176,13 @@ void UT_os_makedir_test()
 
     memset(g_fileName, '\0', sizeof(g_fileName));
     UT_os_sprintf(g_fileName, "%s/mkdir_File.txt", g_dirName);
-    status = OS_creat(g_fileName, OS_READ_WRITE);
+    status = OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE|OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     if (status >= 0)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_FAILURE);
 
     /* Reset test environment */
-    fileDesc = OS_ObjectIdFromInteger(status);
     OS_close(fileDesc);
     OS_remove(g_fileName);
     OS_rmdir(g_dirName);
@@ -776,7 +775,7 @@ void UT_os_removedir_test()
 
     memset(g_fileName, '\0', sizeof(g_fileName));
     UT_os_sprintf(g_fileName, "%s/rmdir_File1.txt", g_dirName);
-    status = OS_creat(g_fileName, OS_READ_WRITE);
+    status = OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE|OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     if (status < 0)
     {
         testDesc = "#5 Nominal - File-create failed";
@@ -784,7 +783,6 @@ void UT_os_removedir_test()
     }
 
     /* Must close and remove all files before the directory can be removed */
-    fileDesc = OS_ObjectIdFromInteger(status);
     OS_close(fileDesc);
     OS_remove(g_fileName);
 
@@ -796,7 +794,7 @@ void UT_os_removedir_test()
 
     memset(g_fileName, '\0', sizeof(g_fileName));
     UT_os_sprintf(g_fileName, "%s/rmdir_File2.txt", g_dirName);
-    status = OS_creat(g_fileName, OS_READ_WRITE);
+    status = OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE|OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     if (status < 0)
         UT_OS_TEST_RESULT( testDesc, UTASSERT_CASETYPE_PASS);
     else

--- a/src/ut-stubs/osapi-utstub-file.c
+++ b/src/ut-stubs/osapi-utstub-file.c
@@ -107,6 +107,7 @@ static int32 UT_GenericWriteStub(const char *fname, UT_EntryKey_t fkey, const vo
     return status;
 }
 
+#ifndef OSAL_OMIT_DEPRECATED
 
 /*****************************************************************************
  *
@@ -154,6 +155,8 @@ int32 OS_open(const char *path, int32 access, uint32 mode)
 
     return status;
 }
+
+#endif
 
 /*****************************************************************************
  *


### PR DESCRIPTION
**Describe the contribution**

These functions are replaced by OS_OpenCreate, which implements both functions via flags, and follows the correct OSAL API patterns.

Fixes #556 

**Testing performed**
Build and run all tests, sanity check CFE
Check coverage of file-related APIs (still 100%)

**Expected behavior changes**
`OS_open()` and `OS_create()` are deprecated.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This initially puts the items inside an `OSAL_OMIT_DEPRECATED` block for review and testing, like has been done traditionally.
Should discuss at CCB whether this should become a hard-cut given that the next release will be a major one.
Although the previous discussions on the topic agreed to hard cut at major releases, these are such widely-used routines that this will cause grief to a lot of users.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
