### PR TITLE
Fix #618, Use osal_id_t in RTEMS implementation

### DIFF
--- a/src/os/rtems/src/os-impl-binsem.c
+++ b/src/os/rtems/src/os-impl-binsem.c
@@ -103,7 +103,7 @@ int32 OS_BinSemCreate_Impl (uint32 sem_id, uint32 sem_initial_value, uint32 opti
     ** It is convenient to use the OSAL ID in here, as we know it is already unique
     ** and trying to use the real name would be less than useful (only 4 chars)
     */
-    r_name = OS_global_bin_sem_table[sem_id].active_id;
+    r_name = OS_ObjectIdToInteger(OS_global_bin_sem_table[sem_id].active_id);
 
     /* Check to make sure the sem value is going to be either 0 or 1 */
     if (sem_initial_value > 1)

--- a/src/os/rtems/src/os-impl-console.c
+++ b/src/os/rtems/src/os-impl-console.c
@@ -156,7 +156,7 @@ int32 OS_ConsoleCreate_Impl(uint32 local_id)
             ** It is convenient to use the OSAL ID in here, as we know it is already unique
             ** and trying to use the real name would be less than useful (only 4 chars)
             */
-            r_name = OS_global_console_table[local_id].active_id;
+            r_name = OS_ObjectIdToInteger(OS_global_console_table[local_id].active_id);
             status = rtems_semaphore_create( r_name, 0,
                                              RTEMS_PRIORITY,
                                              0,

--- a/src/os/rtems/src/os-impl-countsem.c
+++ b/src/os/rtems/src/os-impl-countsem.c
@@ -105,7 +105,7 @@ int32 OS_CountSemCreate_Impl (uint32 sem_id, uint32 sem_initial_value, uint32 op
     ** It is convenient to use the OSAL ID in here, as we know it is already unique
     ** and trying to use the real name would be less than useful (only 4 chars)
     */
-    r_name = OS_global_count_sem_table[sem_id].active_id;
+    r_name = OS_ObjectIdToInteger(OS_global_count_sem_table[sem_id].active_id);
     status = rtems_semaphore_create( r_name, sem_initial_value,
                                      OSAL_COUNT_SEM_ATTRIBS,
                                      0,

--- a/src/os/rtems/src/os-impl-mutex.c
+++ b/src/os/rtems/src/os-impl-mutex.c
@@ -99,7 +99,7 @@ int32 OS_MutSemCreate_Impl (uint32 sem_id, uint32 options)
     /*
     ** Try to create the mutex
     */
-    r_name = OS_global_mutex_table[sem_id].active_id;
+    r_name = OS_ObjectIdToInteger(OS_global_mutex_table[sem_id].active_id);
     status = rtems_semaphore_create ( r_name, 1,
                                       OSAL_MUTEX_ATTRIBS ,
                                       0,

--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -92,7 +92,7 @@ int32 OS_QueueCreate_Impl (uint32 queue_id, uint32 flags)
     ** It is convenient to use the OSAL queue ID in here, as we know it is already unique
     ** and trying to use the real queue name would be less than useful (only 4 chars)
     */
-    r_name = OS_global_queue_table[queue_id].active_id;
+    r_name = OS_ObjectIdToInteger(OS_global_queue_table[queue_id].active_id);
 
     /*
     ** Create the message queue.

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -62,7 +62,7 @@ OS_impl_task_internal_record_t    OS_impl_task_table          [OS_MAX_TASKS];
 ---------------------------------------------------------------------------------------*/
 static rtems_task OS_RtemsEntry(rtems_task_argument arg)
 {
-    OS_TaskEntryPoint((uint32)arg);
+    OS_TaskEntryPoint(OS_ObjectIdFromInteger(arg));
 } /* end OS_RtemsEntry */
 
 
@@ -106,7 +106,7 @@ int32 OS_TaskCreate_Impl (uint32 task_id, uint32 flags)
     ** It is convenient to use the OSAL task ID in here, as we know it is already unique
     ** and trying to use the real task name would be less than useful (only 4 chars)
     */
-    r_name = OS_global_task_table[task_id].active_id;
+    r_name = OS_ObjectIdToInteger(OS_global_task_table[task_id].active_id);
     r_mode = RTEMS_PREEMPT | RTEMS_NO_ASR | RTEMS_NO_TIMESLICE | RTEMS_INTERRUPT_LEVEL(0);
 
     /*
@@ -138,7 +138,7 @@ int32 OS_TaskCreate_Impl (uint32 task_id, uint32 flags)
     /* will place the task in 'ready for scheduling' state */
     status = rtems_task_start (OS_impl_task_table[task_id].id, /*rtems task id*/
 			     (rtems_task_entry) OS_RtemsEntry, /* task entry point */
-			     (rtems_task_argument) OS_global_task_table[task_id].active_id );  /* passed argument  */
+			     (rtems_task_argument) OS_ObjectIdToInteger(OS_global_task_table[task_id].active_id) );  /* passed argument  */
 
     if (status != RTEMS_SUCCESSFUL )
     {
@@ -300,9 +300,9 @@ int32 OS_TaskRegister_Impl (osal_id_t global_task_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-uint32 OS_TaskGetId_Impl (void)
+osal_id_t OS_TaskGetId_Impl (void)
 {
-    uint32            global_task_id;
+    osal_id_t         global_task_id;
     rtems_id          task_self;
     rtems_name        self_name;
     rtems_status_code status;
@@ -313,11 +313,11 @@ uint32 OS_TaskGetId_Impl (void)
     status = rtems_object_get_classic_name(task_self, &self_name);
     if (status == RTEMS_SUCCESSFUL)
     {
-        global_task_id = self_name;
+        global_task_id = OS_ObjectIdFromInteger(self_name);
     }
     else
     {
-        global_task_id = 0;
+        global_task_id = OS_OBJECT_ID_UNDEFINED;
     }
 
     return global_task_id;


### PR DESCRIPTION
**Describe the contribution**

Change use of uint32 for ID to the correct typedef.  Also use ObjectIdFromInteger/ObjectIdToInteger where it is intended to
convert these values to integers e.g. for the "name" fields in RTEMS.

Fixes #618 

**Testing performed**
Build and sanity test CFE on RTEMS
Confirm all unit tests working

**Expected behavior changes**
None

**System(s) tested on**
RTEMS 4.11.3 / pc686 (QEMU) via Ubuntu 20.04 build host

**Additional context**
For consistency with all other modules

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
