### PR TITLE
Fix #628, Update UtAssert macros with dynamic string formatting

### DIFF
--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -90,49 +90,50 @@ typedef struct
 #define UtAssert_True(Expression, ...) UtAssertEx(Expression, UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Evaluates a expression as either true or false.  true means the test passed, false means the test failed. */
-#define UtAssert_Bool(Expression, Description) UtAssert(Expression, Description, __FILE__, __LINE__)
+#define     UtAssert_Bool(Expression, ...) \
+        UtAssertEx(Expression, UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Asserts a test failure */
 #define UtAssert_Failed(...) UtAssertEx(false, UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares two integers and determines if they are equal within a specified absolute tolerance. */
-#define UtAssert_IntegerCmpAbs(x, y, Tolerance, Description) \
-    UtAssert((abs((x) - (y)) <= (Tolerance)), Description, __FILE__, __LINE__)
+#define     UtAssert_IntegerCmpAbs(x, y, Tolerance, ...) \
+                UtAssertEx((abs((x) - (y)) <= (Tolerance)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares two floating point numbers and determines if they are equal within a specified absolute tolerance. */
-#define UtAssert_DoubleCmpAbs(x, y, Tolerance, Description) \
-    UtAssert((fabs((x) - (y)) <= (Tolerance)), Description, __FILE__, __LINE__)
+#define     UtAssert_DoubleCmpAbs(x, y, Tolerance, ...) \
+                UtAssertEx((fabs((x) - (y)) <= (Tolerance)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares two floating point numbers and determines if they are equal within a specified relative tolerance. */
-#define UtAssert_DoubleCmpRel(x, y, Ratio, Description) \
-    UtAssert((fabs((x) - (y)) / (x) <= (Ratio)), Description, __FILE__, __LINE__)
+#define     UtAssert_DoubleCmpRel(x, y, Ratio, ...) \
+                UtAssertEx((fabs((x) - (y))/(x) <= (Ratio)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares two strings and determines if they are equal. */
-#define UtAssert_StrCmp(String1, String2, Description) \
-    UtAssert((strcmp(String1, String2) == 0), Description, __FILE__, __LINE__)
+#define     UtAssert_StrCmp(String1, String2, ...) \
+                UtAssertEx((strcmp(String1, String2) == 0), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares at most Length characters of two strings and determines if they are equal. */
-#define UtAssert_StrnCmp(String1, String2, Length, Description) \
-    UtAssert((strncmp(String1, String2, Length) == 0), Description, __FILE__, __LINE__)
+#define     UtAssert_StrnCmp(String1, String2, Length, ...) \
+                UtAssertEx((strncmp(String1, String2, Length) == 0), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares two regions of memory and determines if they are equal. */
-#define UtAssert_MemCmp(Memory1, Memory2, Length, Description) \
-    UtAssert((memcmp(Memory1, Memory2, Length) == 0), Description, __FILE__, __LINE__)
+#define     UtAssert_MemCmp(Memory1, Memory2, Length, ...) \
+                UtAssertEx((memcmp(Memory1, Memory2, Length) == 0), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares a region of memory to a static pattern and determines if they are equal.  Note: Use UtMemSet to
  * fill a region of memory with a static pattern. */
-#define UtAssert_MemCmpValue(Memory, Value, Length, Description) \
-    UtAssert((UtMemCmpValue(Memory, Value, Length)), Description, __FILE__, __LINE__)
+#define     UtAssert_MemCmpValue(Memory, Value, Length, ...) \
+                UtAssertEx((UtMemCmpValue(Memory, Value, Length)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares a region of memory to a byte count pattern and determines if they are equal.  Note: Use UtMemFill to
  * fill a region of memory with a byte count pattern. */
-#define UtAssert_MemCmpCount(Memory, Length, Description) \
-    UtAssert((UtMemCmpCount(Memory, Length)), Description, __FILE__, __LINE__)
+#define     UtAssert_MemCmpCount(Memory, Length, ...) \
+                UtAssertEx((UtMemCmpCount(Memory, Length)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* Compares a region of memory with the contents of a binary file and determines if they are equal.  Note: Use
  * UtMem2BinFile to copy a region of memory to a binary file. */
-#define UtAssert_Mem2BinFileCmp(Memory, Filename, Description) \
-    UtAssert((UtMem2BinFileCmp(Memory, Filename)), Description, __FILE__, __LINE__)
+#define     UtAssert_Mem2BinFileCmp(Memory, Filename, ...) \
+                UtAssertEx((UtMem2BinFileCmp(Memory, Filename)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /* A wrapper around UtAssertEx that allows the user to specify the failure type and a more descriptive message */
 #define UtAssert_Type(Type, Expression, ...) \


### PR DESCRIPTION
**Describe the contribution**
Changed all UtAssert macros to take variable string arguments, feature request #628 

**Testing performed**
Steps taken to test the contribution, cFS/main branch commit 20097ef64e455ace25a1535ea43090a739eb7c0c:
https://github.com/nasa/cFS/
1. make clean
2. make ENABLE_UNIT_TESTS=TRUE SIMULATION=native
3. make test
4. All cFE unit tests pass

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
UtAssert_True wrapper around call will no longer be necessary to accommodate dynamic string output, thus removing the double assert.  UtAssert macros will now be able to offer more information by themselves.

**System(s) tested on**
PC, RHEL 7.6

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Gibson  NASA GSFC/587
