### PR TITLE
Fix #327 and #333, Squash LGTM warnings

### DIFF
--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -157,7 +157,7 @@ typedef struct
  */
 typedef enum
 {
-    OS_FILE_FLAG_NONE,
+    OS_FILE_FLAG_NONE     = 0x00,
     OS_FILE_FLAG_CREATE   = 0x01,
     OS_FILE_FLAG_TRUNCATE = 0x02,
 } OS_file_flag_t;

--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -538,6 +538,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
             break;
 #endif
         default:
+            sa_family = 0;
             addrlen = 0;
             break;
     }

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -178,9 +178,13 @@ int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fs
             }
             else
             {
-                /* to avoid leaving in an intermediate state,
-                 * this also stops the volume if formatting failed. */
-                OS_FileSysStopVolume_Impl(local_id);
+                /* 
+                 * To avoid leaving in an intermediate state,
+                 * this also stops the volume if formatting failed.
+                 * Cast to void to repress analysis warnings for
+                 * ignored return value.
+                 */
+                (void)OS_FileSysStopVolume_Impl(local_id);
             }
         }
 

--- a/src/os/shared/src/osapi-select.c
+++ b/src/os/shared/src/osapi-select.c
@@ -90,7 +90,6 @@ int32 OS_SelectMultiple(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs)
     int32 return_code;
 
     /*
-     * FIXME:
      * This does not currently increment any refcounts.
      * That means a file/socket can be closed while actively inside a
      * OS_SelectMultiple() call in another thread.

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
@@ -96,15 +96,20 @@ void Test_OS_FileChmod_Impl(void)
      */
     struct OCS_stat RefStat;
 
-    /* failure mode 1 (stat) */
-    UT_SetForceFail(UT_KEY(OCS_stat), -1);
+    /* failure mode 0 (open) */
+    UT_SetForceFail(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_stat));
+    UT_ClearForceFail(UT_KEY(OCS_open));
 
-    /* failure mode 2 (chmod) */
-    UT_SetForceFail(UT_KEY(OCS_chmod), -1);
+    /* failure mode 1 (fstat) */
+    UT_SetForceFail(UT_KEY(OCS_fstat), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_chmod));
+    UT_ClearForceFail(UT_KEY(OCS_fstat));
+
+    /* failure mode 2 (fchmod) */
+    UT_SetForceFail(UT_KEY(OCS_fchmod), -1);
+    OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_ERROR);
+    UT_ClearForceFail(UT_KEY(OCS_fchmod));
 
     /* all permission bits with uid/gid match */
     RefStat.st_uid   = UT_PortablePosixFileTest_GetSelfEUID();
@@ -112,7 +117,7 @@ void Test_OS_FileChmod_Impl(void)
     RefStat.st_mode  = ~0;
     RefStat.st_size  = 1234;
     RefStat.st_mtime = 5678;
-    UT_SetDataBuffer(UT_KEY(OCS_stat), &RefStat, sizeof(RefStat), false);
+    UT_SetDataBuffer(UT_KEY(OCS_fstat), &RefStat, sizeof(RefStat), false);
 
     /* nominal 1 - full permissions with file owned by own uid/gid */
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_SUCCESS);
@@ -124,7 +129,7 @@ void Test_OS_FileChmod_Impl(void)
     /* nominal 3 - non-owned file */
     ++RefStat.st_uid;
     ++RefStat.st_gid;
-    UT_SetDataBuffer(UT_KEY(OCS_stat), &RefStat, sizeof(RefStat), false);
+    UT_SetDataBuffer(UT_KEY(OCS_fstat), &RefStat, sizeof(RefStat), false);
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_SUCCESS);
 }
 

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_stat.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_stat.h
@@ -64,6 +64,7 @@ extern int OCS_fchmod(int fd, OCS_mode_t mode);
 extern int OCS_chmod(const char *path, OCS_mode_t mode);
 extern int OCS_mkdir(const char *path, ...);
 extern int OCS_stat(const char *file, struct OCS_stat *buf);
+extern int OCS_fstat(int fd, struct OCS_stat *buf);
 
 /* ----------------------------------------- */
 /* prototypes normally declared in sys/statvfs.h */

--- a/src/unit-test-coverage/ut-stubs/override_inc/stat.h
+++ b/src/unit-test-coverage/ut-stubs/override_inc/stat.h
@@ -29,6 +29,7 @@
 /* ----------------------------------------- */
 
 #define stat   OCS_stat
+#define fstat  OCS_fstat
 #define fchmod OCS_fchmod
 #define chmod  OCS_chmod
 #define mkdir  OCS_mkdir

--- a/src/unit-test-coverage/ut-stubs/src/posix-stat-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/posix-stat-stubs.c
@@ -66,6 +66,20 @@ int OCS_stat(const char *file, struct OCS_stat *buf)
     return Status;
 }
 
+int OCS_fstat(int fd, struct OCS_stat *buf)
+{
+    int32 Status;
+
+    Status = UT_DEFAULT_IMPL(OCS_fstat);
+
+    if (Status == 0 && UT_Stub_CopyToLocal(UT_KEY(OCS_fstat), buf, sizeof(*buf)) < sizeof(*buf))
+    {
+        memset(buf, 0, sizeof(*buf));
+    }
+
+    return Status;
+}
+
 int OCS_statvfs(const char *file, struct OCS_statvfs *buf)
 {
     int32 Status;

--- a/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
@@ -121,7 +121,7 @@ void UT_os_count_sem_create_test()
     testDesc = "#4 Initial-count-too-high";
 
     /*
-     * FIXME: This test can only be done if the OS defines a specific "SEM_VALUE_MAX"
+     * This test can only be done if the OS defines a specific "SEM_VALUE_MAX"
      * The OSAL should define this for itself, but it currently does not.
      *  (This macro is not currently defined in RTEMS)
      */


### PR DESCRIPTION
**Describe the contribution**
- Turned all FIXME comments into issues (and removed FIXME)
- Fix #333: security/filename race issue resolved by opening file and acting on descriptor (had to add fstat stub)
- Fix #327: squashed the minor recommended bugs

**Testing performed**
Built and ran unit tests, passed.

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
#630, #632 - new issues from FIXME
#631 - uncovered missing functional test on OS_chmod
 
**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC