### PR TITLE
Fix #623, add debug messages for mutex double locks

### DIFF
--- a/src/os/shared/inc/os-shared-mutex.h
+++ b/src/os/shared/inc/os-shared-mutex.h
@@ -32,7 +32,8 @@
 
 typedef struct
 {
-    char obj_name[OS_MAX_API_NAME];
+   char      obj_name[OS_MAX_API_NAME];
+   osal_id_t last_owner;
 } OS_mutex_internal_record_t;
 
 /*


### PR DESCRIPTION
**Describe the contribution**

If `OS_DEBUG` is enabled, this adds a message if mutex give/take actions occur outside the expected sequence.  In particular,
this warns if a task takes a mutex more than once.

Fixes #623 

**Testing performed**
Build and sanity test CFE with debug events enabled, confirm normal boot and operation.
Send "remove packet" request to TO_LAB.

Confirm warning is generated as follows (this is a known issue in CFE doing multiple locks):

    OS_MutSemTake():216:WARNING: Task 65547 taking mutex 327685 while owned by task 65547

**Expected behavior changes**
If debugging is enabled this now informs the user (via the debug console) if a lock is taken more than once.
It will also warn if a lock is given by a different task than what originally took it.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
