### PR TITLE
Fix #637, fix OS_ModuleUnload for static modules

### DIFF
--- a/src/os/shared/inc/os-shared-module.h
+++ b/src/os/shared/inc/os-shared-module.h
@@ -30,12 +30,20 @@
 
 #include <os-shared-globaldefs.h>
 
+typedef enum
+{
+    OS_MODULE_TYPE_UNKNOWN = 0, /**< Default/unspecified (reserved value) */
+    OS_MODULE_TYPE_DYNAMIC = 1, /**< Module is dynamically loaded via the OS loader */
+    OS_MODULE_TYPE_STATIC  = 2  /**< Module is statically linked and is a placeholder */
+} OS_module_type_t;
+
 typedef struct
 {
-    char    module_name[OS_MAX_API_NAME];
-    char    file_name[OS_MAX_PATH_LEN];
-    uint32  flags;
-    cpuaddr entry_point;
+    char             module_name[OS_MAX_API_NAME];
+    char             file_name[OS_MAX_PATH_LEN];
+    OS_module_type_t module_type;
+    uint32           flags;
+    cpuaddr          entry_point;
 } OS_module_internal_record_t;
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Ensure that the handle is not NULL before invoking `dlclose()`.  In particular the handle will be NULL for static modules.

Fixes #637 

**Testing performed**
Build and sanity test CFE with apps linked statically.

**Expected behavior changes**
- Shutdown after CTRL+C occurs normally (no segfault)
- Also confirmed that specifying an incorrect entry point symbol in startup script also benign.  (because a bad entry point also causes module to be "unloaded" as part of cleanup, which triggered the bug too)

**System(s) tested on**
Ubuntu 20.04 
i686-rtems4.11 / pc686 via QEMU

**Additional context**
This issue only affects statically linked apps, which "go through the motions" of module loading for consistency in operation, but do not actually load a module - because its already linked.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
