### PR TITLE
Fix #641, add OS_ModuleLoad flags

### DIFF
--- a/src/os/inc/osapi-os-loader.h
+++ b/src/os/inc/osapi-os-loader.h
@@ -34,6 +34,44 @@
 ** Defines
 */
 
+/**
+ * @brief Requests OS_ModuleLoad() to add the symbols to the global symbol table
+ *
+ * When supplied as the "flags" argument to OS_ModuleLoad(), this indicates
+ * that the symbols in the loaded module should be added to the global symbol
+ * table.  This will make symbols in this library available for use when
+ * resolving symbols in future module loads.
+ *
+ * This is the default mode of operation for OS_ModuleLoad().
+ *
+ * @note On some operating systems, use of this option may make it difficult
+ * to unload the module in the future, if the symbols are in use by other entities.
+ *
+ */
+#define OS_MODULE_FLAG_GLOBAL_SYMBOLS       0x00
+
+/**
+ * @brief Requests OS_ModuleLoad() to keep the symbols local/private to this module
+ *
+ * When supplied as the "flags" argument to OS_ModuleLoad(), this indicates
+ * that the symbols in the loaded module should NOT be added to the global
+ * symbol table.  This means the symbols in the loaded library will not available
+ * to for use by other modules.
+ *
+ * Use this option is recommended for cases where no other entities will need
+ * to reference symbols within this module.  This helps ensure that the module
+ * can be more safely unloaded in the future, by preventing other modules from
+ * binding to it.  It also helps reduce the likelihood of symbol name conflicts
+ * among modules.
+ *
+ * @note To look up symbols within a module loaded with this flag, use
+ * OS_SymbolLookupInModule() instead of OS_SymbolLookup().  Also note that
+ * references obtained using this method are not tracked by the OS; the
+ * application must ensure that all references obtained in this manner have
+ * been cleaned up/released before unloading the module.
+ */
+#define OS_MODULE_FLAG_LOCAL_SYMBOLS        0x01
+
 /*
 ** Typedefs
 */
@@ -107,6 +145,25 @@ int32 OS_SymbolLookup(cpuaddr *symbol_address, const char *symbol_name);
 
 /*-------------------------------------------------------------------------------------*/
 /**
+ * @brief Find the Address of a Symbol within a module
+ *
+ * This is similar to OS_SymbolLookup() but for a specific module ID.
+ * This should be used to look up a symbol in a module that has been
+ * loaded with the #OS_MODULE_FLAG_LOCAL_SYMBOLS flag.
+ *
+ * @param[in]  module_id      Module ID that should contain the symbol
+ * @param[out] symbol_address Set to the address of the symbol
+ * @param[in]  symbol_name    Name of the symbol to look up
+ *
+ * @return Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
+ * @retval #OS_ERROR if the symbol could not be found
+ * @retval #OS_INVALID_POINTER if one of the pointers passed in are NULL
+ */
+int32 OS_ModuleSymbolLookup(osal_id_t module_id, cpuaddr *SymbolAddress, const char *SymbolName);
+
+/*-------------------------------------------------------------------------------------*/
+/**
  * @brief Dumps the system symbol table to a file
  *
  * Dumps the system symbol table to the specified filename
@@ -138,7 +195,7 @@ int32 OS_SymbolTableDump(const char *filename, uint32 size_limit);
  * @retval #OS_ERR_NO_FREE_IDS if the module table is full
  * @retval #OS_ERR_NAME_TAKEN if the name is in use
  */
-int32 OS_ModuleLoad(osal_id_t *module_id, const char *module_name, const char *filename);
+int32 OS_ModuleLoad(osal_id_t *module_id, const char *module_name, const char *filename, uint32 flags);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/portable/os-impl-no-symtab.c
+++ b/src/os/portable/os-impl-no-symtab.c
@@ -32,17 +32,31 @@
 
 /*----------------------------------------------------------------
  *
- * Function: OS_SymbolLookup_Impl
+ * Function: OS_GlobalSymbolLookup_Impl
  *
  *  Purpose: Implemented per internal OSAL API
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
+int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 
-} /* end OS_SymbolLookup_Impl */
+} /* end OS_GlobalSymbolLookup_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_ModuleSymbolLookup_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_ModuleSymbolLookup_Impl */
 
 /*----------------------------------------------------------------
  *

--- a/src/os/portable/os-impl-posix-dl-symtab.c
+++ b/src/os/portable/os-impl-posix-dl-symtab.c
@@ -60,12 +60,16 @@
  * Otherwise, check if the C library provides an "RTLD_DEFAULT" symbol -
  * This symbol is not POSIX standard but many implementations do provide it.
  *
- * Lastly, if nothing no special handle that indicates the global symbol
- * table is defined, then OS_GlobalSymbolLookup_Impl() will return
- * OS_ERR_NOT_IMPLEMENTED rather than relying on undefined behavior.
+ * Lastly, if nothing else works, use NULL.  This is technically undefined
+ * behavior per POSIX, but most implementations do seem to interpret this
+ * as referring to the complete process (base executable + all loaded modules).
  */
-#if !defined(OSAL_DLSYM_GLOBAL_HANDLE) && defined(RTLD_DEFAULT)
-#define OSAL_DLSYM_GLOBAL_HANDLE RTLD_DEFAULT
+#ifndef OSAL_DLSYM_DEFAULT_HANDLE
+#ifdef RTLD_DEFAULT
+#define OSAL_DLSYM_DEFAULT_HANDLE RTLD_DEFAULT
+#else
+#define OSAL_DLSYM_DEFAULT_HANDLE NULL
+#endif
 #endif
 
 /****************************************************************************************
@@ -139,11 +143,7 @@ int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
 {
     int32 status;
 
-#ifdef OSAL_DLSYM_DEFAULT_HANDLE
     status = OS_GenericSymbolLookup_Impl(OSAL_DLSYM_DEFAULT_HANDLE, SymbolAddress, SymbolName);
-#else
-    status = OS_ERR_NOT_IMPLEMENTED;
-#endif
 
     return status;
 

--- a/src/os/shared/inc/os-shared-module.h
+++ b/src/os/shared/inc/os-shared-module.h
@@ -86,14 +86,24 @@ int32 OS_ModuleUnload_Impl(uint32 module_id);
 int32 OS_ModuleGetInfo_Impl(uint32 module_id, OS_module_prop_t *module_prop);
 
 /*----------------------------------------------------------------
-   Function: OS_SymbolLookup_Impl
+   Function: OS_GlobalSymbolLookup_Impl
 
-    Purpose: Find the Address of a Symbol
+    Purpose: Find the Address of a Symbol in the global symbol table.
              The address of the symbol will be stored in the pointer that is passed in.
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName);
+int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName);
+
+/*----------------------------------------------------------------
+   Function: OS_SymbolLookup_Impl
+
+    Purpose: Find the Address of a Symbol within a specific module.
+             The address of the symbol will be stored in the pointer that is passed in.
+
+    Returns: OS_SUCCESS on success, or relevant error code
+ ------------------------------------------------------------------*/
+int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName);
 
 /*----------------------------------------------------------------
    Function: OS_SymbolTableDump_Impl
@@ -109,6 +119,6 @@ int32 OS_SymbolTableDump_Impl(const char *filename, uint32 size_limit);
  * These need to be exposed for unit testing
  */
 int32 OS_ModuleLoad_Static(const char *ModuleName);
-int32 OS_SymbolLookup_Static(cpuaddr *SymbolAddress, const char *SymbolName);
+int32 OS_SymbolLookup_Static(cpuaddr *SymbolAddress, const char *SymbolName, const char *ModuleName);
 
 #endif /* INCLUDE_OS_SHARED_MODULE_H_ */

--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -64,13 +64,13 @@ extern SYMTAB_ID sysSymTbl;
 
 /*----------------------------------------------------------------
  *
- * Function: OS_SymbolLookup_Impl
+ * Function: OS_GenericSymbolLookup_Impl
  *
  *  Purpose: Implemented per internal OSAL API
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
+int32 OS_GenericSymbolLookup_Impl(SYMTAB_ID SymTab, cpuaddr *SymbolAddress, const char *SymbolName)
 {
     STATUS      vxStatus;
     SYMBOL_DESC SymDesc;
@@ -94,7 +94,7 @@ int32 OS_SymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
     SymDesc.mask = SYM_FIND_BY_NAME;
     SymDesc.name = (char *)SymbolName;
 
-    vxStatus       = symFind(sysSymTbl, &SymDesc);
+    vxStatus       = symFind(SymTab, &SymDesc);
     *SymbolAddress = (cpuaddr)SymDesc.value;
 
     if (vxStatus == ERROR)
@@ -104,7 +104,43 @@ int32 OS_SymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
 
     return (OS_SUCCESS);
 
-} /* end OS_SymbolLookup_Impl */
+} /* end OS_GenericSymbolLookup_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_GlobalSymbolLookup_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
+{
+    return OS_GenericSymbolLookup_Impl(sysSymTbl, SymbolAddress, SymbolName);
+} /* end OS_GlobalSymbolLookup_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_ModuleSymbolLookup_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName)
+{
+    /*
+     * NOTE: this is currently exactly the same as OS_GlobalSymbolLookup_Impl().
+     *
+     * Ideally this should get a SYMTAB_ID from the MODULE_ID and search only
+     * for the symbols provided by that module - but it is not clear if vxWorks
+     * offers this capability.
+     */
+    return OS_GenericSymbolLookup_Impl(sysSymTbl, SymbolAddress, SymbolName);
+} /* end OS_ModuleSymbolLookup_Impl */
+
+
 
 /*----------------------------------------------------------------
  *

--- a/src/unit-test-coverage/shared/adaptors/inc/ut-adaptor-module.h
+++ b/src/unit-test-coverage/shared/adaptors/inc/ut-adaptor-module.h
@@ -49,7 +49,7 @@ void Osapi_Internal_ResetState(void);
 /* A dummy function for the static symbol lookup test.  Not called */
 void Test_DummyFunc(void);
 
-int32 Osapi_Call_SymbolLookup_Static(cpuaddr *SymbolAddress, const char *SymbolName);
+int32 Osapi_Call_SymbolLookup_Static(cpuaddr *SymbolAddress, const char *SymbolName, const char *ModuleName);
 int32 Osapi_Call_ModuleLoad_Static(const char *ModuleName);
 
 #endif /* INCLUDE_UT_ADAPTOR_MODULE_H_ */

--- a/src/unit-test-coverage/shared/adaptors/src/ut-adaptor-module.c
+++ b/src/unit-test-coverage/shared/adaptors/src/ut-adaptor-module.c
@@ -28,9 +28,9 @@
 #include "ut-adaptor-module.h"
 #include "os-shared-module.h"
 
-int32 Osapi_Call_SymbolLookup_Static(cpuaddr *SymbolAddress, const char *SymbolName)
+int32 Osapi_Call_SymbolLookup_Static(cpuaddr *SymbolAddress, const char *SymbolName, const char *ModuleName)
 {
-    return OS_SymbolLookup_Static(SymbolAddress, SymbolName);
+    return OS_SymbolLookup_Static(SymbolAddress, SymbolName, ModuleName);
 }
 
 int32 Osapi_Call_ModuleLoad_Static(const char *ModuleName)

--- a/src/unit-test-coverage/shared/src/coveragetest-module.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-module.c
@@ -68,7 +68,7 @@ void Test_OS_ModuleLoad(void)
      */
     int32     expected = OS_SUCCESS;
     osal_id_t objid;
-    int32     actual = OS_ModuleLoad(&objid, "UT", "File");
+    int32     actual = OS_ModuleLoad(&objid, "UT", "File", OS_MODULE_FLAG_GLOBAL_SYMBOLS);
 
     UtAssert_True(actual == expected, "OS_ModuleLoad() (%ld) == OS_SUCCESS", (long)actual);
     actual = UT_GetStubCount(UT_KEY(OS_ModuleLoad_Impl));
@@ -76,25 +76,32 @@ void Test_OS_ModuleLoad(void)
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
     /* for a static module, it should also return a valid objid, but should NOT invoke OS_ModuleLoad_Impl */
-    actual = OS_ModuleLoad(&objid, "UTS", "File2");
+    actual = OS_ModuleLoad(&objid, "UTS", "File2", OS_MODULE_FLAG_GLOBAL_SYMBOLS);
     UtAssert_True(actual == expected, "OS_ModuleLoad() (%ld) == OS_SUCCESS", (long)actual);
     actual = UT_GetStubCount(UT_KEY(OS_ModuleLoad_Impl));
     UtAssert_True(actual == 1, "OS_ModuleLoad_Impl() called (%ld) == 1", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
+    /* a dynamic module with local symbols */
+    actual = OS_ModuleLoad(&objid, "UT", "File3", OS_MODULE_FLAG_LOCAL_SYMBOLS);
+    UtAssert_True(actual == expected, "OS_ModuleLoad() (%ld) == OS_SUCCESS", (long)actual);
+    actual = UT_GetStubCount(UT_KEY(OS_ModuleLoad_Impl));
+    UtAssert_True(actual == 2, "OS_ModuleLoad_Impl() called (%ld) == 2", (long)actual);
+    OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
+
     /* error cases */
-    actual   = OS_ModuleLoad(NULL, NULL, NULL);
+    actual   = OS_ModuleLoad(NULL, NULL, NULL, OS_MODULE_FLAG_GLOBAL_SYMBOLS);
     expected = OS_INVALID_POINTER;
     UtAssert_True(actual == expected, "OS_ModuleLoad() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_API_NAME);
-    actual   = OS_ModuleLoad(&objid, "UTS", "File2");
+    actual   = OS_ModuleLoad(&objid, "UTS", "File2", OS_MODULE_FLAG_GLOBAL_SYMBOLS);
     expected = OS_ERR_NAME_TOO_LONG;
     UtAssert_True(actual == expected, "OS_ModuleLoad() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
     UT_ResetState(UT_KEY(OCS_strlen));
 
     UT_SetForceFail(UT_KEY(OS_TranslatePath), OS_ERROR);
-    actual   = OS_ModuleLoad(&objid, "UT", "FileBad");
+    actual   = OS_ModuleLoad(&objid, "UT", "FileBad", OS_MODULE_FLAG_GLOBAL_SYMBOLS);
     expected = OS_ERROR;
     UtAssert_True(actual == expected, "OS_ModuleLoad() (%ld) == OS_ERROR", (long)actual);
 }
@@ -127,8 +134,8 @@ void Test_OS_SymbolLookup(void)
     actual = OS_SymbolLookup(&symaddr, "uttestsym0");
     UtAssert_True(actual == expected, "OS_SymbolLookup(name=%s) (%ld) == OS_SUCCESS", "uttestsym0", (long)actual);
 
-    UT_ResetState(UT_KEY(OS_SymbolLookup_Impl));
-    UT_SetForceFail(UT_KEY(OS_SymbolLookup_Impl), OS_ERROR);
+    UT_ResetState(UT_KEY(OS_GlobalSymbolLookup_Impl));
+    UT_SetForceFail(UT_KEY(OS_GlobalSymbolLookup_Impl), OS_ERROR);
 
     /* this lookup should always fail */
     symaddr  = 0;
@@ -167,8 +174,14 @@ void Test_OS_StaticSymbolLookup(void)
     cpuaddr addr;
 
     /* nominal */
-    actual = OS_SymbolLookup_Static(&addr, "UT_staticsym");
-    UtAssert_True(actual == expected, "OS_SymbolLookup_Static(name=%s) (%ld) == OS_SUCCESS", "Test_Func1",
+    actual = OS_SymbolLookup_Static(&addr, "UT_staticsym", NULL);
+    UtAssert_True(actual == expected, "OS_SymbolLookup_Static(name=%s, NULL) (%ld) == OS_SUCCESS", "Test_Func1",
+                  (long)actual);
+    UtAssert_True(addr == (cpuaddr)&Test_DummyFunc, "OS_SymbolLookup_Static(address=%lx) == %lx", (unsigned long)addr,
+                  (unsigned long)&Test_DummyFunc);
+
+    actual = OS_SymbolLookup_Static(&addr, "UT_staticsym", "UTS");
+    UtAssert_True(actual == expected, "OS_SymbolLookup_Static(name=%s, UTS) (%ld) == OS_SUCCESS", "Test_Func1",
                   (long)actual);
     UtAssert_True(addr == (cpuaddr)&Test_DummyFunc, "OS_SymbolLookup_Static(address=%lx) == %lx", (unsigned long)addr,
                   (unsigned long)&Test_DummyFunc);
@@ -177,7 +190,14 @@ void Test_OS_StaticSymbolLookup(void)
     UtAssert_True(actual == expected, "OS_ModuleLoad_Static(name=%s) (%ld) == OS_SUCCESS", "UT", (long)actual);
 
     expected = OS_ERROR;
-    actual   = OS_SymbolLookup_Static(&addr, "Invalid");
+    actual = OS_SymbolLookup_Static(&addr, "UT_staticsym", "NoModuleMatch");
+    UtAssert_True(actual == expected, "OS_SymbolLookup_Static(name=%s, NoModuleMatch) (%ld) == OS_ERROR", "Test_Func1",
+                  (long)actual);
+    UtAssert_True(addr == (cpuaddr)&Test_DummyFunc, "OS_SymbolLookup_Static(address=%lx) == %lx", (unsigned long)addr,
+                  (unsigned long)&Test_DummyFunc);
+
+    expected = OS_ERROR;
+    actual   = OS_SymbolLookup_Static(&addr, "Invalid", NULL);
     UtAssert_True(actual == expected, "OS_SymbolLookup_Static(name=%s) (%ld) == OS_ERROR", "Invalid", (long)actual);
 
     expected = OS_ERR_NAME_NOT_FOUND;

--- a/src/unit-test-coverage/ut-stubs/src/osapi-loader-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-loader-impl-stubs.c
@@ -39,5 +39,6 @@
 UT_DEFAULT_STUB(OS_ModuleLoad_Impl, (uint32 module_id, const char *translated_path))
 UT_DEFAULT_STUB(OS_ModuleUnload_Impl, (uint32 module_id))
 UT_DEFAULT_STUB(OS_ModuleGetInfo_Impl, (uint32 module_id, OS_module_prop_t *module_prop))
-UT_DEFAULT_STUB(OS_SymbolLookup_Impl, (cpuaddr * SymbolAddress, const char *SymbolName))
+UT_DEFAULT_STUB(OS_GlobalSymbolLookup_Impl, (cpuaddr * SymbolAddress, const char *SymbolName))
+UT_DEFAULT_STUB(OS_ModuleSymbolLookup_Impl, (uint32 module_id, cpuaddr * SymbolAddress, const char *SymbolName))
 UT_DEFAULT_STUB(OS_SymbolTableDump_Impl, (const char *filename, uint32 size_limit))

--- a/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
@@ -33,16 +33,31 @@
 #include <OCS_fcntl.h>
 #include <OCS_symLib.h>
 
-void Test_OS_SymbolLookup_Impl(void)
+void Test_OS_GlobalSymbolLookup_Impl(void)
 {
     /* Test Case For:
-     * int32 OS_SymbolLookup_Impl( cpuaddr *SymbolAddress, const char *SymbolName )
+     * int32 OS_GlobalSymbolLookup_Impl( cpuaddr *SymbolAddress, const char *SymbolName )
      */
     cpuaddr SymAddr;
-    OSAPI_TEST_FUNCTION_RC(OS_SymbolLookup_Impl(&SymAddr, "symname"), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_SymbolLookup_Impl(NULL, NULL), OS_INVALID_POINTER);
+
+    OSAPI_TEST_FUNCTION_RC(OS_GlobalSymbolLookup_Impl(&SymAddr, "symname"), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_GlobalSymbolLookup_Impl(NULL, NULL), OS_INVALID_POINTER);
     UT_SetForceFail(UT_KEY(OCS_symFind), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_SymbolLookup_Impl(&SymAddr, "symname"), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GlobalSymbolLookup_Impl(&SymAddr, "symname"), OS_ERROR);
+
+}
+
+void Test_OS_ModuleSymbolLookup_Impl(void)
+{
+    /* Test Case For:
+     * int32 OS_ModuleSymbolLookup_Impl( uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName )
+     */
+    cpuaddr SymAddr;
+
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(0, &SymAddr, "symname"), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(0, NULL, NULL), OS_INVALID_POINTER);
+    UT_SetForceFail(UT_KEY(OCS_symFind), OCS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(0, &SymAddr, "symname"), OS_ERROR);
 }
 
 void Test_OS_SymTableIterator_Impl(void)
@@ -101,6 +116,7 @@ void Osapi_Test_Teardown(void) {}
 void UtTest_Setup(void)
 {
     ADD_TEST(OS_SymTableIterator_Impl);
-    ADD_TEST(OS_SymbolLookup_Impl);
+    ADD_TEST(OS_GlobalSymbolLookup_Impl);
+    ADD_TEST(OS_ModuleSymbolLookup_Impl);
     ADD_TEST(OS_SymbolTableDump_Impl);
 }

--- a/src/unit-tests/osloader-test/ut_osloader_module_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_module_test.c
@@ -79,7 +79,7 @@ void UT_os_module_load_test()
     /*-----------------------------------------------------*/
     testDesc = "API Not implemented";
 
-    res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1);
+    res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
@@ -89,7 +89,7 @@ void UT_os_module_load_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg-1";
 
-    res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1);
+    res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -98,7 +98,7 @@ void UT_os_module_load_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Null-pointer-arg-2";
 
-    res = OS_ModuleLoad(&module_id, 0, UT_OS_GENERIC_MODULE_NAME1);
+    res = OS_ModuleLoad(&module_id, 0, UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -107,7 +107,7 @@ void UT_os_module_load_test()
     /*-----------------------------------------------------*/
     testDesc = "#3 Null-pointer-arg-3";
 
-    res = OS_ModuleLoad(&module_id, "TestModule", 0);
+    res = OS_ModuleLoad(&module_id, "TestModule", 0, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -121,7 +121,7 @@ void UT_os_module_load_test()
     {
         snprintf(module_name, sizeof(module_name), UT_OS_GENERIC_MODULE_NAME_TEMPLATE, i);
         snprintf(module_file_name, sizeof(module_file_name), UT_OS_GENERIC_MODULE_FILE_TEMPLATE, i);
-        res = OS_ModuleLoad(&module_id, module_name, module_file_name);
+        res = OS_ModuleLoad(&module_id, module_name, module_file_name, OS_MODULE_FLAG_LOCAL_SYMBOLS);
         if (res != OS_SUCCESS)
         {
             testDesc = "#4 No-free-IDs - Module Load failed";
@@ -133,7 +133,7 @@ void UT_os_module_load_test()
 
     if (test_setup_invalid == 0)
     {
-        res = OS_ModuleLoad(&module_id, "OneTooMany", UT_OS_GENERIC_MODULE_NAME2);
+        res = OS_ModuleLoad(&module_id, "OneTooMany", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
         if (res == OS_ERR_NO_FREE_IDS)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -146,7 +146,7 @@ void UT_os_module_load_test()
     testDesc = "#5 Duplicate-name";
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id2, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2);
+    res = OS_ModuleLoad(&module_id2, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res != OS_SUCCESS)
     {
         testDesc = "#5 Duplicate-name - Module Load failed";
@@ -154,7 +154,7 @@ void UT_os_module_load_test()
     }
     else
     {
-        res = OS_ModuleLoad(&module_id, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2);
+        res = OS_ModuleLoad(&module_id, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
         if (res == OS_ERR_NAME_TAKEN)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -172,7 +172,7 @@ void UT_os_module_load_test()
     /*-----------------------------------------------------*/
     testDesc = "#7 Nominal";
 
-    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2);
+    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res == OS_SUCCESS)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -227,7 +227,7 @@ void UT_os_module_unload_test()
     testDesc = "#3 Nominal";
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2);
+    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Module Load failed";
@@ -293,7 +293,7 @@ void UT_os_module_info_test()
     testDesc = "#3 Nominal";
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2);
+    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Module Load failed";

--- a/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
@@ -109,10 +109,10 @@ void UT_os_symbol_lookup_test()
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    testDesc = "#4 Nominal, Global Symbols";
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2);
+    res = OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_GLOBAL_SYMBOLS);
     if (res != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT("#4 Nominal - Module Load failed", UTASSERT_CASETYPE_TSF);
@@ -122,6 +122,8 @@ void UT_os_symbol_lookup_test()
         res = OS_SymbolLookup(&symbol_addr, "module1");
         if (res == OS_SUCCESS)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
+        else if (res == OS_ERR_NOT_IMPLEMENTED)
+            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
         else
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
 
@@ -132,6 +134,85 @@ void UT_os_symbol_lookup_test()
 UT_os_symbol_lookup_test_exit_tag:
     return;
 }
+
+/*--------------------------------------------------------------------------------*
+** Syntax: OS_ModuleSymbolLookup
+** Purpose: Returns the memory address of a symbol
+** Parameters: To-be-filled-in
+** Returns: OS_INVALID_POINTER if any of the pointers passed in is null
+**          OS_ERROR if the symbol name is not found
+**          OS_SUCCESS if succeeded
+**--------------------------------------------------------------------------------*/
+
+void UT_os_module_symbol_lookup_test()
+{
+    int32       res = 0;
+    const char *testDesc;
+    cpuaddr     symbol_addr;
+    osal_id_t   module_id;
+
+    /*-----------------------------------------------------*/
+    testDesc = "API Not implemented";
+
+    res = OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, "main");
+    if (res == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
+        goto UT_os_module_symbol_lookup_test_exit_tag;
+    }
+
+    /*-----------------------------------------------------*/
+    testDesc = "#1 Invalid-pointer-arg-1";
+
+    res = OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, 0, "main");
+    if (res == OS_INVALID_POINTER)
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
+    else
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+
+    /*-----------------------------------------------------*/
+    testDesc = "#2 Invalid-pointer-arg-2";
+
+    res = OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, 0);
+    if (res == OS_INVALID_POINTER)
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
+    else
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+
+    /*-----------------------------------------------------*/
+    /* Setup for remainder of tests */
+    res = OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
+    if (res != OS_SUCCESS)
+    {
+        UT_OS_TEST_RESULT("Module Load failed", UTASSERT_CASETYPE_TSF);
+        goto UT_os_module_symbol_lookup_test_exit_tag;
+    }
+
+    /*-----------------------------------------------------*/
+    testDesc = "#3 Symbol-not-found";
+
+    res = OS_ModuleSymbolLookup(module_id, &symbol_addr, "ThisSymbolIsNotFound");
+    if (res == OS_ERROR)
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
+    else
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+
+    /*-----------------------------------------------------*/
+    testDesc = "#4 Nominal, Local Symbols";
+
+    res = OS_ModuleSymbolLookup(module_id, &symbol_addr, "module1");
+    if (res == OS_SUCCESS)
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
+    else
+        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+
+    /* Reset test environment */
+    res = OS_ModuleUnload(module_id);
+
+UT_os_module_symbol_lookup_test_exit_tag:
+    return;
+}
+
 
 /*--------------------------------------------------------------------------------*
 ** Syntax: OS_SymbolTableDump

--- a/src/unit-tests/osloader-test/ut_osloader_symtable_test.h
+++ b/src/unit-tests/osloader-test/ut_osloader_symtable_test.h
@@ -54,6 +54,7 @@
 **--------------------------------------------------------------------------------*/
 
 void UT_os_symbol_lookup_test(void);
+void UT_os_module_symbol_lookup_test(void);
 void UT_os_symbol_table_dump_test(void);
 
 /*--------------------------------------------------------------------------------*/

--- a/src/unit-tests/osloader-test/ut_osloader_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_test.c
@@ -82,6 +82,7 @@ void UtTest_Setup(void)
     UtTest_Add(UT_os_module_unload_test, NULL, NULL, "OS_ModuleUnload");
     UtTest_Add(UT_os_module_info_test, NULL, NULL, "OS_ModuleInfo");
 
+    UtTest_Add(UT_os_module_symbol_lookup_test, NULL, NULL, "OS_ModuleSymbolLookup");
     UtTest_Add(UT_os_symbol_lookup_test, NULL, NULL, "OS_SymbolLookup");
     UtTest_Add(UT_os_symbol_table_dump_test, NULL, NULL, "OS_SymbolTableDump");
 }

--- a/src/ut-stubs/osapi-utstub-module.c
+++ b/src/ut-stubs/osapi-utstub-module.c
@@ -80,11 +80,12 @@ int32 dummy_function(void)
 **        Returns either a user-defined status flag or OS_SUCCESS.
 **
 ******************************************************************************/
-int32 OS_ModuleLoad(osal_id_t *module_id, const char *module_name, const char *filename)
+int32 OS_ModuleLoad(osal_id_t *module_id, const char *module_name, const char *filename, uint32 flags)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_ModuleLoad), module_id);
     UT_Stub_RegisterContext(UT_KEY(OS_ModuleLoad), module_name);
     UT_Stub_RegisterContext(UT_KEY(OS_ModuleLoad), filename);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_ModuleLoad), flags);
 
     int32 status;
 
@@ -214,6 +215,39 @@ int32 OS_SymbolLookup(cpuaddr *symbol_address, const char *symbol_name)
         *symbol_address = 0xDEADBEEFU;
     }
     else if (UT_Stub_CopyToLocal(UT_KEY(OS_SymbolLookup), symbol_address, sizeof(*symbol_address)) <
+             sizeof(*symbol_address))
+    {
+        /* return the dummy function when test didn't register anything else */
+        *symbol_address = (cpuaddr)&dummy_function;
+    }
+
+    return status;
+}
+
+/*****************************************************************************
+ *
+ * Stub function for OS_SymbolTableDump()
+ *
+ *****************************************************************************/
+int32 OS_ModuleSymbolLookup(osal_id_t module_id, cpuaddr *symbol_address, const char *symbol_name)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_ModuleSymbolLookup), module_id);
+    UT_Stub_RegisterContext(UT_KEY(OS_ModuleSymbolLookup), symbol_address);
+    UT_Stub_RegisterContext(UT_KEY(OS_ModuleSymbolLookup), symbol_name);
+
+    int32 status;
+
+    /*
+     * Register the context so a hook can do something with the parameters
+     */
+
+    status = UT_DEFAULT_IMPL(OS_ModuleSymbolLookup);
+
+    if (status != OS_SUCCESS)
+    {
+        *symbol_address = 0xDEADBEEFU;
+    }
+    else if (UT_Stub_CopyToLocal(UT_KEY(OS_ModuleSymbolLookup), symbol_address, sizeof(*symbol_address)) <
              sizeof(*symbol_address))
     {
         /* return the dummy function when test didn't register anything else */


### PR DESCRIPTION
**Describe the contribution**
Add a "flags" parameter to OS_ModuleLoad() and use this to indicate the desired symbol visibility - either GLOBAL (0, the default, and matches current behavior) or LOCAL, which means symbols are hidden from other modules.

This is intended as a "hint" to OSAL as to how the module will be used - LOCAL prevents other modules from binding to symbols in this module, thereby ensuring/preserving the ability to unload in the future.  CFE should use LOCAL flag for apps, and GLOBAL flags for libraries, which are typically not ever unloaded.

Fixes #641

**Testing performed**
Build and run unit test
Sanity check CFE (update/patch required update to CFE to add flags parameter on API call)

**Expected behavior changes**
No impact to behavior if flags are passed as 0.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Related to nasa/cfe#952

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
