### PR TITLE
Fix #586, Add one shot timer functional test

### DIFF
--- a/src/tests/timer-test/timer-test.c
+++ b/src/tests/timer-test/timer-test.c
@@ -33,7 +33,7 @@
 #include "uttest.h"
 #include "utbsp.h"
 
-#define NUMBER_OF_TIMERS 4
+#define NUMBER_OF_TIMERS 5
 
 #define TASK_1_ID         1
 #define TASK_1_STACK_SIZE 4096
@@ -45,8 +45,8 @@ void TimerTestCheck(void);
 
 OS_time_t StartTime;
 OS_time_t EndTime;
-uint32    TimerStart[NUMBER_OF_TIMERS]    = {1000, 2000000, 3000000, 4000000};
-uint32    TimerInterval[NUMBER_OF_TIMERS] = {500000, 400000, 800000, 600000};
+uint32    TimerStart[NUMBER_OF_TIMERS]    = {1000, 2000000, 3000000, 4000000, 1000000};
+uint32    TimerInterval[NUMBER_OF_TIMERS] = {500000, 400000, 800000, 600000, 0};
 
 uint32 TimerTestTaskStack[TASK_1_STACK_SIZE];
 int32  timer_counter[NUMBER_OF_TIMERS];
@@ -111,12 +111,12 @@ void TimerTestSetup(void)
 void TimerTestTask(void)
 {
 
-    int          i = 0;
-    int32        TimerStatus[NUMBER_OF_TIMERS];
-    osal_index_t TableId;
-    osal_id_t    TimerID[NUMBER_OF_TIMERS];
-    char         TimerName[NUMBER_OF_TIMERS][20] = {"TIMER1", "TIMER2", "TIMER3", "TIMER4"};
-    uint32       ClockAccuracy;
+    int             i = 0;
+    int32           TimerStatus[NUMBER_OF_TIMERS];
+    osal_index_t    TableId;
+    osal_id_t       TimerID[NUMBER_OF_TIMERS];
+    char            TimerName[NUMBER_OF_TIMERS][20] = {"TIMER1", "TIMER2", "TIMER3", "TIMER4", "TIMER5"};
+    uint32          ClockAccuracy;
 
     for (i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++)
     {
@@ -202,18 +202,29 @@ void TimerTestCheck(void)
     /* Make sure the ratio of the timers are OK */
     for (i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++)
     {
-        /*
-         * Expect one tick after the start time (i.e. first tick)
-         * Plus one tick for every interval that occurred during the test
-         */
-        expected = 1 + (microsecs - TimerStart[i]) / TimerInterval[i];
-        UtAssert_True(expected > 0, "Expected ticks = %u", (unsigned int)expected);
+        if (TimerInterval[i] == 0)
+        {
+            /*
+             * When the Timer Interval is 0, it's a one shot so expect eaxctly 1 tick
+             */
+            expected = 1;
+            UtAssert_True(timer_counter[i] == (expected), "Timer %d count = %d", (int)i, (int)(expected));
+        }
+        else
+        {
+            /*
+             * Expect one tick after the start time (i.e. first tick)
+             * Plus one tick for every interval that occurred during the test
+             */
+            expected = 1 + (microsecs - TimerStart[i]) / TimerInterval[i];
+            UtAssert_True(expected > 0, "Expected ticks = %u", (unsigned int)expected);
 
-        /*
-         * Since all these counts are affected by test system load,
-         * allow for some fudge factor before declaring failure
-         */
-        UtAssert_True(timer_counter[i] >= (expected - 3), "Timer %d count >= %d", (int)i, (int)(expected - 3));
-        UtAssert_True(timer_counter[i] <= (expected + 3), "Timer %d count <= %d", (int)i, (int)(expected + 3));
+            /*
+             * Since all these counts are affected by test system load,
+             * allow for some fudge factor before declaring failure
+             */
+            UtAssert_True(timer_counter[i] >= (expected - 3), "Timer %d count >= %d", (int)i, (int)(expected - 3));
+            UtAssert_True(timer_counter[i] <= (expected + 3), "Timer %d count <= %d", (int)i, (int)(expected + 3));
+        }
     }
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #586, added a one shot timer. 

Added a 5th timer to functional test to test the one shot (zero-length time interval) case.

**Testing performed**
Build and run unit test.

**Expected behavior changes**
No behavior change 

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
