### PR TITLE
Fix #635, Reduce use of uint32, add more OSAL typedefs

### DIFF
--- a/src/bsp/generic-linux/src/bsp_console.c
+++ b/src/bsp/generic-linux/src/bsp_console.c
@@ -72,7 +72,7 @@ static void OS_BSP_ExecTput(const char *cap, const char *param)
    OS_BSP_ConsoleOutput_Impl
    See full description in header
  ------------------------------------------------------------------*/
-void OS_BSP_ConsoleOutput_Impl(const char *Str, uint32 DataLen)
+void OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen)
 {
     ssize_t WriteLen;
 

--- a/src/bsp/generic-linux/src/bsp_start.c
+++ b/src/bsp/generic-linux/src/bsp_start.c
@@ -69,7 +69,7 @@ void OS_BSP_Initialize(void)
         {
             if (fgets(buffer, sizeof(buffer), fp) != NULL)
             {
-                OS_BSP_Global.MaxQueueDepth = strtoul(buffer, NULL, 10);
+                OS_BSP_Global.MaxQueueDepth = OSAL_BLOCKCOUNT_C(strtoul(buffer, NULL, 10));
                 BSP_DEBUG("Maximum user msg queue depth = %u\n", (unsigned int)OS_BSP_Global.MaxQueueDepth);
             }
             fclose(fp);

--- a/src/bsp/generic-vxworks/src/bsp_console.c
+++ b/src/bsp/generic-vxworks/src/bsp_console.c
@@ -40,7 +40,7 @@
    OS_BSP_ConsoleOutput_Impl
    See full description in header
  ------------------------------------------------------------------*/
-void OS_BSP_ConsoleOutput_Impl(const char *Str, uint32 DataLen)
+void OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen)
 {
     while (DataLen > 0)
     {

--- a/src/bsp/shared/inc/bsp-impl.h
+++ b/src/bsp/shared/inc/bsp-impl.h
@@ -90,10 +90,10 @@
 */
 typedef struct
 {
-    uint32 ArgC;          /* number of boot/startup parameters in ArgV */
-    char **ArgV;          /* strings for boot/startup parameters */
-    int32  AppStatus;     /* value which can be returned to the OS (0=nominal) */
-    uint32 MaxQueueDepth; /* Queue depth limit supported by BSP (0=no limit) */
+    uint32            ArgC;          /* number of boot/startup parameters in ArgV */
+    char **           ArgV;          /* strings for boot/startup parameters */
+    int32             AppStatus;     /* value which can be returned to the OS (0=nominal) */
+    osal_blockcount_t MaxQueueDepth; /* Queue depth limit supported by BSP (0=no limit) */
 } OS_BSP_GlobalData_t;
 
 /*
@@ -118,7 +118,7 @@ extern OS_BSP_GlobalData_t OS_BSP_Global;
 
        Note: This should write the string as-is without buffering.
  ------------------------------------------------------------------*/
-void OS_BSP_ConsoleOutput_Impl(const char *Str, uint32 DataLen);
+void OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen);
 
 /*----------------------------------------------------------------
    Function: OS_BSP_ConsoleSetMode_Impl

--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -101,6 +101,28 @@ extern "C"
      */
     typedef uint32_t osal_id_t;
 
+    /**
+     * A type used to represent a number of blocks or buffers
+     *
+     * This is used with file system and queue implementations.
+     */
+    typedef size_t osal_blockcount_t;
+
+    /**
+     * A type used to represent an index into a table structure
+     *
+     * This is used when referring directly to a table index as
+     * opposed to an object ID.  It is primarily intended for
+     * internal use, but is also output from public APIs such as
+     * OS_ObjectIdToArrayIndex().
+     */
+    typedef uint32 osal_index_t;
+
+    /**
+     * A type used to represent the runtime type or category of an OSAL object
+     */
+    typedef uint32 osal_objtype_t;
+
 #ifndef NULL /* pointer to nothing */
 #define NULL ((void *)0)
 #endif
@@ -149,5 +171,19 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+/*
+ * Type macros for literals
+ *
+ * These macros enforce that a literal or other value is
+ * interpreted as the intended type.  Although implicit
+ * conversions between these types are often possible, using
+ * this makes it explicit in the code where a type conversion
+ * is expected.
+ */
+#define OSAL_SIZE_C(X)       ((size_t) {X})
+#define OSAL_BLOCKCOUNT_C(X) ((osal_blockcount_t) {X})
+#define OSAL_INDEX_C(X)      ((osal_index_t) {X})
+#define OSAL_OBJTYPE_C(X)    ((osal_objtype_t) {X})
 
 #endif /* _common_types_ */

--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -181,9 +181,9 @@ extern "C"
  * this makes it explicit in the code where a type conversion
  * is expected.
  */
-#define OSAL_SIZE_C(X)       ((size_t) {X})
-#define OSAL_BLOCKCOUNT_C(X) ((osal_blockcount_t) {X})
-#define OSAL_INDEX_C(X)      ((osal_index_t) {X})
-#define OSAL_OBJTYPE_C(X)    ((osal_objtype_t) {X})
+#define OSAL_SIZE_C(X)       ((size_t)(X))
+#define OSAL_BLOCKCOUNT_C(X) ((osal_blockcount_t)(X))
+#define OSAL_INDEX_C(X)      ((osal_index_t)(X))
+#define OSAL_OBJTYPE_C(X)    ((osal_objtype_t)(X))
 
 #endif /* _common_types_ */

--- a/src/os/inc/osapi-os-filesys.h
+++ b/src/os/inc/osapi-os-filesys.h
@@ -112,7 +112,7 @@ typedef struct
 {
     uint32 FileModeBits;
     int32  FileTime;
-    uint32 FileSize;
+    size_t FileSize;
 } os_fstat_t;
 
 /**
@@ -285,7 +285,7 @@ int32 OS_close(osal_id_t filedes);
  * @retval #OS_ERROR if OS call failed
  * @retval #OS_ERR_INVALID_ID if the file descriptor passed in is invalid
  */
-int32 OS_read(osal_id_t filedes, void *buffer, uint32 nbytes);
+int32 OS_read(osal_id_t filedes, void *buffer, size_t nbytes);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -306,7 +306,7 @@ int32 OS_read(osal_id_t filedes, void *buffer, uint32 nbytes);
  * @retval #OS_ERROR if OS call failed
  * @retval #OS_ERR_INVALID_ID if the file descriptor passed in is invalid
  */
-int32 OS_write(osal_id_t filedes, const void *buffer, uint32 nbytes);
+int32 OS_write(osal_id_t filedes, const void *buffer, size_t nbytes);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -337,7 +337,7 @@ int32 OS_write(osal_id_t filedes, const void *buffer, uint32 nbytes);
  * @return Byte count on success, zero for timeout, or appropriate error code,
  *         see @ref OSReturnCodes
  */
-int32 OS_TimedRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout);
+int32 OS_TimedRead(osal_id_t filedes, void *buffer, size_t nbytes, int32 timeout);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -368,7 +368,7 @@ int32 OS_TimedRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout
  * @return Byte count on success, zero for timeout, or appropriate error code,
  *         see @ref OSReturnCodes
  */
-int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, uint32 nbytes, int32 timeout);
+int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, size_t nbytes, int32 timeout);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -715,7 +715,7 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
  * @retval #OS_FS_ERR_DEVICE_NOT_FREE if the volume table is full
  * @retval #OS_SUCCESS on creating the disk
  */
-int32 OS_mkfs(char *address, const char *devname, const char *volname, uint32 blocksize, uint32 numblocks);
+int32 OS_mkfs(char *address, const char *devname, const char *volname, size_t blocksize, osal_blockcount_t numblocks);
 /*-------------------------------------------------------------------------------------*/
 /**
  * @brief Mounts a file system
@@ -754,7 +754,7 @@ int32 OS_mount(const char *devname, const char *mountpoint);
  * @retval #OS_FS_ERR_DEVICE_NOT_FREE if the volume table is full
  * @retval #OS_FS_ERR_DRIVE_NOT_CREATED on error
  */
-int32 OS_initfs(char *address, const char *devname, const char *volname, uint32 blocksize, uint32 numblocks);
+int32 OS_initfs(char *address, const char *devname, const char *volname, size_t blocksize, osal_blockcount_t numblocks);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/inc/osapi-os-loader.h
+++ b/src/os/inc/osapi-os-loader.h
@@ -176,7 +176,7 @@ int32 OS_ModuleSymbolLookup(osal_id_t module_id, cpuaddr *symbol_address, const 
  * @retval #OS_ERR_NOT_IMPLEMENTED @copybrief OS_ERR_NOT_IMPLEMENTED
  * @retval #OS_ERROR if the symbol table could not be read or dumped
  */
-int32 OS_SymbolTableDump(const char *filename, uint32 size_limit);
+int32 OS_SymbolTableDump(const char *filename, size_t size_limit);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/inc/osapi-os-net.h
+++ b/src/os/inc/osapi-os-net.h
@@ -102,7 +102,7 @@ typedef union
  */
 typedef struct
 {
-    uint32            ActualLength; /**< @brief Length of the actual address data */
+    size_t            ActualLength; /**< @brief Length of the actual address data */
     OS_SockAddrData_t AddrData;     /**< @brief Abstract Address data */
 } OS_SockAddr_t;
 
@@ -162,7 +162,7 @@ int32 OS_SocketAddrInit(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain);
  *
  * @return Execution status, see @ref OSReturnCodes
  */
-int32 OS_SocketAddrToString(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr);
+int32 OS_SocketAddrToString(char *buffer, size_t buflen, const OS_SockAddr_t *Addr);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -317,7 +317,7 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
  *
  * @return Count of actual bytes received or error status, see @ref OSReturnCodes
  */
-int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout);
+int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -334,7 +334,7 @@ int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockA
  *
  * @return Count of actual bytes sent or error status, see @ref OSReturnCodes
  */
-int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr);
+int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -400,7 +400,7 @@ int32 OS_NetworkGetID(void);
  *
  * @return Execution status, see @ref OSReturnCodes
  */
-int32 OS_NetworkGetHostName(char *host_name, uint32 name_len);
+int32 OS_NetworkGetHostName(char *host_name, size_t name_len);
 /**@}*/
 
 #endif

--- a/src/os/inc/osapi-os-timer.h
+++ b/src/os/inc/osapi-os-timer.h
@@ -33,8 +33,8 @@
 /*
 ** Typedefs
 */
-typedef void (*OS_TimerCallback_t)(osal_id_t timer_id); /**< @brief Timer callback */
-typedef uint32 (*OS_TimerSync_t)(uint32 timer_id);      /**< @brief Timer sync */
+typedef void (*OS_TimerCallback_t)(osal_id_t timer_id);  /**< @brief Timer callback */
+typedef uint32 (*OS_TimerSync_t)(osal_index_t timer_id); /**< @brief Timer sync */
 
 /** @brief Timer properties */
 typedef struct

--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -74,12 +74,12 @@
  *-----------------------------------------------------------------*/
 static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
 {
-    uint32 offset;
-    uint32 bit;
-    uint32 id;
-    uint8  objids;
-    int    osfd;
-    int    maxfd;
+    size_t       offset;
+    size_t       bit;
+    osal_index_t id;
+    uint8        objids;
+    int          osfd;
+    int          maxfd;
 
     maxfd = -1;
     for (offset = 0; offset < sizeof(OSAL_set->object_ids); ++offset)
@@ -122,11 +122,11 @@ static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
  *-----------------------------------------------------------------*/
 static void OS_FdSet_ConvertOut_Impl(fd_set *output, OS_FdSet *Input)
 {
-    uint32 offset;
-    uint32 bit;
-    uint32 id;
-    uint8  objids;
-    int    osfd;
+    size_t       offset;
+    size_t       bit;
+    osal_index_t id;
+    uint8        objids;
+    int          osfd;
 
     for (offset = 0; offset < sizeof(Input->object_ids); ++offset)
     {
@@ -249,7 +249,7 @@ static int32 OS_DoSelect(int maxfd, fd_set *rd_set, fd_set *wr_set, int32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SelectSingle_Impl(uint32 stream_id, uint32 *SelectFlags, int32 msecs)
+int32 OS_SelectSingle_Impl(osal_index_t stream_id, uint32 *SelectFlags, int32 msecs)
 {
     int32  return_code;
     fd_set wr_set;

--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -90,7 +90,7 @@ static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
         {
             if (objids & 0x01)
             {
-                id   = (offset * 8) + bit;
+                id   = OSAL_INDEX_C((offset * 8) + bit);
                 osfd = OS_impl_filehandle_table[id].fd;
                 if (osfd >= 0 && OS_impl_filehandle_table[id].selectable)
                 {
@@ -136,7 +136,7 @@ static void OS_FdSet_ConvertOut_Impl(fd_set *output, OS_FdSet *Input)
         {
             if (objids & 0x01)
             {
-                id   = (offset * 8) + bit;
+                id   = OSAL_INDEX_C((offset * 8) + bit);
                 osfd = OS_impl_filehandle_table[id].fd;
                 if (osfd < 0 || !FD_ISSET(osfd, output))
                 {

--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -84,7 +84,7 @@ typedef union
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketOpen_Impl(uint32 sock_id)
+int32 OS_SocketOpen_Impl(osal_index_t sock_id)
 {
     int os_domain;
     int os_type;
@@ -175,7 +175,7 @@ int32 OS_SocketOpen_Impl(uint32 sock_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr)
+int32 OS_SocketBind_Impl(osal_index_t sock_id, const OS_SockAddr_t *Addr)
 {
     int                    os_result;
     socklen_t              addrlen;
@@ -231,7 +231,7 @@ int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 timeout)
+int32 OS_SocketConnect_Impl(osal_index_t sock_id, const OS_SockAddr_t *Addr, int32 timeout)
 {
     int32                  return_code;
     int                    os_status;
@@ -309,7 +309,7 @@ int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 tim
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Addr, int32 timeout)
+int32 OS_SocketAccept_Impl(osal_index_t sock_id, osal_index_t connsock_id, OS_SockAddr_t *Addr, int32 timeout)
 {
     int32     return_code;
     uint32    operation;
@@ -370,7 +370,8 @@ int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Ad
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
+int32 OS_SocketRecvFrom_Impl(osal_index_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr,
+                             int32 timeout)
 {
     int32            return_code;
     int              os_result;
@@ -458,7 +459,7 @@ int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_Soc
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr)
+int32 OS_SocketSendTo_Impl(osal_index_t sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr)
 {
     int                    os_result;
     socklen_t              addrlen;
@@ -503,7 +504,7 @@ int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, uint32 buflen, co
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketGetInfo_Impl(uint32 sock_id, OS_socket_prop_t *sock_prop)
+int32 OS_SocketGetInfo_Impl(osal_index_t sock_id, OS_socket_prop_t *sock_prop)
 {
     return OS_SUCCESS;
 } /* end OS_SocketGetInfo_Impl */
@@ -539,7 +540,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
 #endif
         default:
             sa_family = 0;
-            addrlen = 0;
+            addrlen   = 0;
             break;
     }
 
@@ -548,7 +549,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
         return OS_ERR_NOT_IMPLEMENTED;
     }
 
-    Addr->ActualLength           = addrlen;
+    Addr->ActualLength           = OSAL_SIZE_C(addrlen);
     Accessor->sockaddr.sa_family = sa_family;
 
     return OS_SUCCESS;
@@ -562,7 +563,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketAddrToString_Impl(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr)
+int32 OS_SocketAddrToString_Impl(char *buffer, size_t buflen, const OS_SockAddr_t *Addr)
 {
     const void *                  addrbuffer;
     const OS_SockAddr_Accessor_t *Accessor;

--- a/src/os/portable/os-impl-console-bsp.c
+++ b/src/os/portable/os-impl-console-bsp.c
@@ -52,11 +52,11 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_ConsoleOutput_Impl(uint32 local_id)
+void OS_ConsoleOutput_Impl(osal_index_t local_id)
 {
-    uint32                        StartPos;
-    uint32                        EndPos;
-    long                          WriteSize;
+    size_t                        StartPos;
+    size_t                        EndPos;
+    size_t                        WriteSize;
     OS_console_internal_record_t *console;
 
     console  = &OS_console_table[local_id];

--- a/src/os/portable/os-impl-no-loader.c
+++ b/src/os/portable/os-impl-no-loader.c
@@ -38,7 +38,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
+int32 OS_ModuleLoad_Impl(osal_index_t module_id, const char *translated_path)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 
@@ -52,7 +52,7 @@ int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleUnload_Impl(uint32 module_id)
+int32 OS_ModuleUnload_Impl(osal_index_t module_id)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 
@@ -66,7 +66,7 @@ int32 OS_ModuleUnload_Impl(uint32 module_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleGetInfo_Impl(uint32 module_id, OS_module_prop_t *module_prop)
+int32 OS_ModuleGetInfo_Impl(osal_index_t module_id, OS_module_prop_t *module_prop)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 

--- a/src/os/portable/os-impl-no-network.c
+++ b/src/os/portable/os-impl-no-network.c
@@ -56,7 +56,7 @@ int32 OS_NetworkGetID_Impl(int32 *IdBuf)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_NetworkGetHostName_Impl(char *host_name, uint32 name_len)
+int32 OS_NetworkGetHostName_Impl(char *host_name, size_t name_len)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 } /* end OS_NetworkGetHostName_Impl */

--- a/src/os/portable/os-impl-no-shell.c
+++ b/src/os/portable/os-impl-no-shell.c
@@ -34,7 +34,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char *Cmd)
+int32 OS_ShellOutputToFile_Impl(osal_index_t file_id, const char *Cmd)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 }

--- a/src/os/portable/os-impl-no-sockets.c
+++ b/src/os/portable/os-impl-no-sockets.c
@@ -101,7 +101,7 @@ int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Ad
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
+int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 } /* end OS_SocketRecvFrom_Impl */
@@ -114,7 +114,7 @@ int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_Soc
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr)
+int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 } /* end OS_SocketSendTo_Impl */

--- a/src/os/portable/os-impl-no-symtab.c
+++ b/src/os/portable/os-impl-no-symtab.c
@@ -66,7 +66,7 @@ int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const 
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SymbolTableDump_Impl(const char *filename, uint32 SizeLimit)
+int32 OS_SymbolTableDump_Impl(const char *filename, size_t SizeLimit)
 {
     return (OS_ERR_NOT_IMPLEMENTED);
 

--- a/src/os/portable/os-impl-posix-dirs.c
+++ b/src/os/portable/os-impl-posix-dirs.c
@@ -104,7 +104,7 @@ int32 OS_DirCreate_Impl(const char *local_path, uint32 access)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
+int32 OS_DirOpen_Impl(osal_index_t local_id, const char *local_path)
 {
     DIR *dp = opendir(local_path);
     if (dp == NULL)
@@ -123,7 +123,7 @@ int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirClose_Impl(uint32 local_id)
+int32 OS_DirClose_Impl(osal_index_t local_id)
 {
     closedir(OS_impl_dir_table[local_id].dp);
     OS_impl_dir_table[local_id].dp = NULL;
@@ -138,7 +138,7 @@ int32 OS_DirClose_Impl(uint32 local_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
+int32 OS_DirRead_Impl(osal_index_t local_id, os_dirent_t *dirent)
 {
     struct dirent *de;
 
@@ -171,7 +171,7 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirRewind_Impl(uint32 local_id)
+int32 OS_DirRewind_Impl(osal_index_t local_id)
 {
     rewinddir(OS_impl_dir_table[local_id].dp);
     return OS_SUCCESS;

--- a/src/os/portable/os-impl-posix-dl-loader.c
+++ b/src/os/portable/os-impl-posix-dl-loader.c
@@ -61,10 +61,10 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
+int32 OS_ModuleLoad_Impl(osal_index_t module_id, const char *translated_path)
 {
     int32 status = OS_ERROR;
-    int dl_mode;
+    int   dl_mode;
 
     /*
      * RTLD_NOW should instruct dlopen() to resolve all the symbols in the
@@ -117,7 +117,7 @@ int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleUnload_Impl(uint32 module_id)
+int32 OS_ModuleUnload_Impl(osal_index_t module_id)
 {
     int32 status = OS_ERROR;
 
@@ -147,7 +147,7 @@ int32 OS_ModuleUnload_Impl(uint32 module_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleGetInfo_Impl(uint32 module_id, OS_module_prop_t *module_prop)
+int32 OS_ModuleGetInfo_Impl(osal_index_t module_id, OS_module_prop_t *module_prop)
 {
     /*
      * Limiting strictly to POSIX-defined API means there is no defined

--- a/src/os/portable/os-impl-posix-dl-symtab.c
+++ b/src/os/portable/os-impl-posix-dl-symtab.c
@@ -87,7 +87,7 @@
 int32 OS_GenericSymbolLookup_Impl(void *dl_handle, cpuaddr *SymbolAddress, const char *SymbolName)
 {
     const char *dlError; /*  Pointer to error string   */
-    void       *Function;
+    void *      Function;
     int32       status;
 
     status = OS_ERROR;
@@ -157,7 +157,7 @@ int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName)
+int32 OS_ModuleSymbolLookup_Impl(osal_index_t local_id, cpuaddr *SymbolAddress, const char *SymbolName)
 {
     int32 status;
 
@@ -177,7 +177,7 @@ int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const 
  *  POSIX DL does not provide
  *
  *-----------------------------------------------------------------*/
-int32 OS_SymbolTableDump_Impl(const char *filename, uint32 SizeLimit)
+int32 OS_SymbolTableDump_Impl(const char *filename, size_t SizeLimit)
 {
     /*
      * Limiting strictly to POSIX-defined API means there is no defined

--- a/src/os/portable/os-impl-posix-files.c
+++ b/src/os/portable/os-impl-posix-files.c
@@ -63,7 +63,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int32 access)
+int32 OS_FileOpen_Impl(osal_index_t local_id, const char *local_path, int32 flags, int32 access)
 {
     int os_perm;
     int os_mode;

--- a/src/os/portable/os-impl-posix-io.c
+++ b/src/os/portable/os-impl-posix-io.c
@@ -66,7 +66,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_GenericClose_Impl(uint32 local_id)
+int32 OS_GenericClose_Impl(osal_index_t local_id)
 {
     int result;
 
@@ -98,7 +98,7 @@ int32 OS_GenericClose_Impl(uint32 local_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_GenericSeek_Impl(uint32 local_id, int32 offset, uint32 whence)
+int32 OS_GenericSeek_Impl(osal_index_t local_id, int32 offset, uint32 whence)
 {
     int   where;
     int32 result;
@@ -153,7 +153,7 @@ int32 OS_GenericSeek_Impl(uint32 local_id, int32 offset, uint32 whence)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_GenericRead_Impl(uint32 local_id, void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_GenericRead_Impl(osal_index_t local_id, void *buffer, size_t nbytes, int32 timeout)
 {
     int32  return_code;
     int    os_result;
@@ -204,7 +204,7 @@ int32 OS_GenericRead_Impl(uint32 local_id, void *buffer, uint32 nbytes, int32 ti
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_GenericWrite_Impl(uint32 local_id, const void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_GenericWrite_Impl(osal_index_t local_id, const void *buffer, size_t nbytes, int32 timeout)
 {
     int32  return_code;
     int    os_result;

--- a/src/os/portable/os-impl-posix-network.c
+++ b/src/os/portable/os-impl-posix-network.c
@@ -58,7 +58,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_NetworkGetHostName_Impl(char *host_name, uint32 name_len)
+int32 OS_NetworkGetHostName_Impl(char *host_name, size_t name_len)
 {
     int32 return_code;
 

--- a/src/os/posix/inc/os-impl-io.h
+++ b/src/os/posix/inc/os-impl-io.h
@@ -39,13 +39,13 @@ typedef struct
 {
     int  fd;
     bool selectable;
-} OS_Posix_file_internal_record_t;
+} OS_impl_file_internal_record_t;
 
 /*
  * The global file handle table.
  *
  * This is shared by all OSAL entities that perform low-level I/O.
  */
-extern OS_Posix_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+extern OS_impl_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
 
 #endif /* INCLUDE_OS_IMPL_IO_H_ */

--- a/src/os/posix/inc/os-posix.h
+++ b/src/os/posix/inc/os-posix.h
@@ -74,7 +74,7 @@ typedef struct
 typedef struct
 {
     bool                   EnableTaskPriorities;
-    uint32                 TruncateQueueDepth;
+    osal_blockcount_t      TruncateQueueDepth;
     uint32                 ClockAccuracyNsec;
     pthread_key_t          ThreadKey;
     sigset_t               MaximumSigMask;
@@ -105,10 +105,10 @@ int32 OS_Posix_StreamAPI_Impl_Init(void);
 int32 OS_Posix_DirAPI_Impl_Init(void);
 int32 OS_Posix_FileSysAPI_Impl_Init(void);
 
-int32 OS_Posix_TableMutex_Init(uint32 idtype);
+int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype);
 
-int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t stacksz, PthreadFuncPtr_t entry,
-                                       void *entry_arg);
+int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority, size_t stacksz,
+                                       PthreadFuncPtr_t entry, void *entry_arg);
 void  OS_Posix_CompAbsDelayTime(uint32 msecs, struct timespec *tm);
 
 #endif /* INCLUDE_OS_POSIX_H_ */

--- a/src/os/posix/src/os-impl-binsem.c
+++ b/src/os/posix/src/os-impl-binsem.c
@@ -118,7 +118,7 @@ int32 OS_Posix_BinSemAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 initial_value, uint32 options)
+int32 OS_BinSemCreate_Impl(osal_index_t sem_id, uint32 initial_value, uint32 options)
 {
     int                               ret;
     int                               attr_created;
@@ -240,7 +240,7 @@ int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 initial_value, uint32 options)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemDelete_Impl(uint32 sem_id)
+int32 OS_BinSemDelete_Impl(osal_index_t sem_id)
 {
     OS_impl_binsem_internal_record_t *sem;
     int32                             return_code;
@@ -279,7 +279,7 @@ int32 OS_BinSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemGive_Impl(uint32 sem_id)
+int32 OS_BinSemGive_Impl(osal_index_t sem_id)
 {
     OS_impl_binsem_internal_record_t *sem;
 
@@ -324,7 +324,7 @@ int32 OS_BinSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemFlush_Impl(uint32 sem_id)
+int32 OS_BinSemFlush_Impl(osal_index_t sem_id)
 {
     OS_impl_binsem_internal_record_t *sem;
 
@@ -441,7 +441,7 @@ static int32 OS_GenericBinSemTake_Impl(OS_impl_binsem_internal_record_t *sem, co
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemTake_Impl(uint32 sem_id)
+int32 OS_BinSemTake_Impl(osal_index_t sem_id)
 {
     return (OS_GenericBinSemTake_Impl(&OS_impl_bin_sem_table[sem_id], NULL));
 } /* end OS_BinSemTake_Impl */
@@ -454,7 +454,7 @@ int32 OS_BinSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
+int32 OS_BinSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs)
 {
     struct timespec ts;
 
@@ -474,7 +474,7 @@ int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemGetInfo_Impl(uint32 sem_id, OS_bin_sem_prop_t *sem_prop)
+int32 OS_BinSemGetInfo_Impl(osal_index_t sem_id, OS_bin_sem_prop_t *sem_prop)
 {
     /* put the info into the stucture */
     sem_prop->value = OS_impl_bin_sem_table[sem_id].current_value;

--- a/src/os/posix/src/os-impl-common.c
+++ b/src/os/posix/src/os-impl-common.c
@@ -52,7 +52,7 @@ POSIX_GlobalVars_t POSIX_GlobalVars = {0};
 
    returns: OS_SUCCESS or OS_ERROR
 ---------------------------------------------------------------------------------------*/
-int32 OS_API_Impl_Init(uint32 idtype)
+int32 OS_API_Impl_Init(osal_objtype_t idtype)
 {
     int32 return_code;
 

--- a/src/os/posix/src/os-impl-console.c
+++ b/src/os/posix/src/os-impl-console.c
@@ -59,7 +59,7 @@ OS_impl_console_internal_record_t OS_impl_console_table[OS_MAX_CONSOLES];
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_ConsoleWakeup_Impl(uint32 local_id)
+void OS_ConsoleWakeup_Impl(osal_index_t local_id)
 {
     OS_impl_console_internal_record_t *local = &OS_impl_console_table[local_id];
 
@@ -89,10 +89,10 @@ static void *OS_ConsoleTask_Entry(void *arg)
     OS_impl_console_internal_record_t *local;
 
     local_arg.opaque_arg = arg;
-    local                = &OS_impl_console_table[local_arg.value];
+    local                = &OS_impl_console_table[local_arg.idx];
     while (true)
     {
-        OS_ConsoleOutput_Impl(local_arg.value);
+        OS_ConsoleOutput_Impl(local_arg.idx);
         sem_wait(&local->data_sem);
     }
     return NULL;
@@ -106,7 +106,7 @@ static void *OS_ConsoleTask_Entry(void *arg)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ConsoleCreate_Impl(uint32 local_id)
+int32 OS_ConsoleCreate_Impl(osal_index_t local_id)
 {
     OS_impl_console_internal_record_t *local = &OS_impl_console_table[local_id];
     pthread_t                          consoletask;
@@ -126,8 +126,8 @@ int32 OS_ConsoleCreate_Impl(uint32 local_id)
             }
             else
             {
-                local_arg.value = local_id;
-                return_code     = OS_Posix_InternalTaskCreate_Impl(&consoletask, OS_CONSOLE_TASK_PRIORITY, 0,
+                local_arg.idx = local_id;
+                return_code   = OS_Posix_InternalTaskCreate_Impl(&consoletask, OS_CONSOLE_TASK_PRIORITY, 0,
                                                                OS_ConsoleTask_Entry, local_arg.opaque_arg);
 
                 if (return_code != OS_SUCCESS)

--- a/src/os/posix/src/os-impl-countsem.c
+++ b/src/os/posix/src/os-impl-countsem.c
@@ -74,7 +74,7 @@ int32 OS_Posix_CountSemAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options)
+int32 OS_CountSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options)
 {
     if (sem_initial_value > SEM_VALUE_MAX)
     {
@@ -98,7 +98,7 @@ int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 opt
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemDelete_Impl(uint32 sem_id)
+int32 OS_CountSemDelete_Impl(osal_index_t sem_id)
 {
     if (sem_destroy(&OS_impl_count_sem_table[sem_id].id) < 0)
     {
@@ -117,7 +117,7 @@ int32 OS_CountSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemGive_Impl(uint32 sem_id)
+int32 OS_CountSemGive_Impl(osal_index_t sem_id)
 {
     if (sem_post(&OS_impl_count_sem_table[sem_id].id) < 0)
     {
@@ -136,7 +136,7 @@ int32 OS_CountSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemTake_Impl(uint32 sem_id)
+int32 OS_CountSemTake_Impl(osal_index_t sem_id)
 {
     if (sem_wait(&OS_impl_count_sem_table[sem_id].id) < 0)
     {
@@ -154,7 +154,7 @@ int32 OS_CountSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
+int32 OS_CountSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs)
 {
     struct timespec ts;
     int             result;
@@ -189,7 +189,7 @@ int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemGetInfo_Impl(uint32 sem_id, OS_count_sem_prop_t *count_prop)
+int32 OS_CountSemGetInfo_Impl(osal_index_t sem_id, OS_count_sem_prop_t *count_prop)
 {
     int sval;
 

--- a/src/os/posix/src/os-impl-files.c
+++ b/src/os/posix/src/os-impl-files.c
@@ -48,7 +48,7 @@
  *
  * This is shared by all OSAL entities that perform low-level I/O.
  */
-OS_Posix_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+OS_impl_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
 
 /*
  * These two constants (EUID and EGID) are local cache of the
@@ -85,7 +85,7 @@ const int OS_IMPL_REGULAR_FILE_FLAGS = O_NONBLOCK;
  ---------------------------------------------------------------------------------------*/
 int32 OS_Posix_StreamAPI_Impl_Init(void)
 {
-    uint32 local_id;
+    osal_index_t local_id;
 
     /*
      * init all filehandles to -1, which is always invalid.

--- a/src/os/posix/src/os-impl-filesys.c
+++ b/src/os/posix/src/os-impl-filesys.c
@@ -82,7 +82,7 @@ int32 OS_Posix_FileSysAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStartVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysStartVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     struct stat                   stat_buf;
@@ -184,7 +184,7 @@ int32 OS_FileSysStartVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStopVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysStopVolume_Impl(osal_index_t filesys_id)
 {
     /*
      * This is a no-op.
@@ -207,7 +207,7 @@ int32 OS_FileSysStopVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysFormatVolume_Impl(osal_index_t filesys_id)
 {
     /*
      * In theory, this should wipe any existing files in the ramdisk,
@@ -230,7 +230,7 @@ int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysMountVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysMountVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     struct stat                   stat_buf;
@@ -282,7 +282,7 @@ int32 OS_FileSysMountVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysUnmountVolume_Impl(osal_index_t filesys_id)
 {
     /*
      * NOTE: Mounting/Unmounting on POSIX is not implemented.
@@ -303,7 +303,7 @@ int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
+int32 OS_FileSysStatVolume_Impl(osal_index_t filesys_id, OS_statvfs_t *result)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     struct statvfs                stat_buf;
@@ -313,9 +313,9 @@ int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
         return OS_ERROR;
     }
 
-    result->block_size   = stat_buf.f_bsize;
-    result->blocks_free  = stat_buf.f_bfree;
-    result->total_blocks = stat_buf.f_blocks;
+    result->block_size   = OSAL_SIZE_C(stat_buf.f_bsize);
+    result->blocks_free  = OSAL_BLOCKCOUNT_C(stat_buf.f_bfree);
+    result->total_blocks = OSAL_BLOCKCOUNT_C(stat_buf.f_blocks);
 
     return (OS_SUCCESS);
 } /* end OS_FileSysStatVolume_Impl */
@@ -328,7 +328,7 @@ int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysCheckVolume_Impl(uint32 filesys_id, bool repair)
+int32 OS_FileSysCheckVolume_Impl(osal_index_t filesys_id, bool repair)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 } /* end OS_FileSysCheckVolume_Impl */

--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -83,7 +83,7 @@ enum
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(uint32 idtype)
+int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
 {
     POSIX_GlobalLock_t *mut;
     sigset_t            previous;
@@ -119,7 +119,7 @@ int32 OS_Lock_Global_Impl(uint32 idtype)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(uint32 idtype)
+int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
 {
     POSIX_GlobalLock_t *mut;
     sigset_t            previous;
@@ -158,7 +158,7 @@ int32 OS_Unlock_Global_Impl(uint32 idtype)
 
    returns: OS_SUCCESS or OS_ERROR
 ---------------------------------------------------------------------------------------*/
-int32 OS_Posix_TableMutex_Init(uint32 idtype)
+int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
 {
     int                 ret;
     int32               return_code = OS_SUCCESS;

--- a/src/os/posix/src/os-impl-mutex.c
+++ b/src/os/posix/src/os-impl-mutex.c
@@ -61,7 +61,7 @@ int32 OS_Posix_MutexAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options)
+int32 OS_MutSemCreate_Impl(osal_index_t sem_id, uint32 options)
 {
     int                 return_code;
     pthread_mutexattr_t mutex_attr;
@@ -121,7 +121,7 @@ int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemDelete_Impl(uint32 sem_id)
+int32 OS_MutSemDelete_Impl(osal_index_t sem_id)
 {
     int status;
 
@@ -144,7 +144,7 @@ int32 OS_MutSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemGive_Impl(uint32 sem_id)
+int32 OS_MutSemGive_Impl(osal_index_t sem_id)
 {
     int status;
 
@@ -168,7 +168,7 @@ int32 OS_MutSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemTake_Impl(uint32 sem_id)
+int32 OS_MutSemTake_Impl(osal_index_t sem_id)
 {
     int status;
 
@@ -192,7 +192,7 @@ int32 OS_MutSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemGetInfo_Impl(uint32 sem_id, OS_mut_sem_prop_t *mut_prop)
+int32 OS_MutSemGetInfo_Impl(osal_index_t sem_id, OS_mut_sem_prop_t *mut_prop)
 {
     return OS_SUCCESS;
 

--- a/src/os/posix/src/os-impl-queues.c
+++ b/src/os/posix/src/os-impl-queues.c
@@ -67,7 +67,7 @@ int32 OS_Posix_QueueAPI_Impl_Init(void)
     /*
      * Initialize this to zero to indicate no limit
      */
-    POSIX_GlobalVars.TruncateQueueDepth = 0;
+    POSIX_GlobalVars.TruncateQueueDepth = OSAL_BLOCKCOUNT_C(0);
 #endif
 
     return OS_SUCCESS;
@@ -81,7 +81,7 @@ int32 OS_Posix_QueueAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags)
+int32 OS_QueueCreate_Impl(osal_index_t queue_id, uint32 flags)
 {
     int            return_code;
     mqd_t          queueDesc;
@@ -159,7 +159,7 @@ int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueDelete_Impl(uint32 queue_id)
+int32 OS_QueueDelete_Impl(osal_index_t queue_id)
 {
     int32 return_code;
 
@@ -185,7 +185,7 @@ int32 OS_QueueDelete_Impl(uint32 queue_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+int32 OS_QueueGet_Impl(osal_index_t queue_id, void *data, size_t size, size_t *size_copied, int32 timeout)
 {
     int32           return_code;
     ssize_t         sizeCopied;
@@ -240,7 +240,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
     /* Figure out the return code */
     if (sizeCopied == -1)
     {
-        *size_copied = 0;
+        *size_copied = OSAL_SIZE_C(0);
 
         /* Map the system errno to the most appropriate OSAL return code */
         if (errno == EMSGSIZE)
@@ -266,7 +266,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
     }
     else
     {
-        *size_copied = sizeCopied;
+        *size_copied = OSAL_SIZE_C(sizeCopied);
         return_code  = OS_SUCCESS;
     }
 
@@ -281,7 +281,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 flags)
+int32 OS_QueuePut_Impl(osal_index_t queue_id, const void *data, size_t size, uint32 flags)
 {
     int32           return_code;
     int             result;

--- a/src/os/posix/src/os-impl-shell.c
+++ b/src/os/posix/src/os-impl-shell.c
@@ -57,7 +57,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char *Cmd)
+int32 OS_ShellOutputToFile_Impl(osal_index_t file_id, const char *Cmd)
 {
     pid_t       cpid;
     uint32      local_id;

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -61,7 +61,7 @@ OS_impl_task_internal_record_t OS_impl_task_table[OS_MAX_TASKS];
  * to be within the range of [0,OS_MAX_TASK_PRIORITY]
  *
 ----------------------------------------------------------------------------*/
-static int OS_PriorityRemap(uint32 InputPri)
+static int OS_PriorityRemap(osal_priority_t InputPri)
 {
     int OutputPri;
 
@@ -429,8 +429,8 @@ int32 OS_Posix_TaskAPI_Impl_Init(void)
  *  Purpose: Local helper routine, not part of OSAL API.
  *
  *-----------------------------------------------------------------*/
-int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t stacksz, PthreadFuncPtr_t entry,
-                                       void *entry_arg)
+int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority, size_t stacksz,
+                                       PthreadFuncPtr_t entry, void *entry_arg)
 {
     int                return_code = 0;
     pthread_attr_t     custom_attr;
@@ -564,7 +564,7 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, uint32 priority, size_t 
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags)
+int32 OS_TaskCreate_Impl(osal_index_t task_id, uint32 flags)
 {
     OS_U32ValueWrapper_t arg;
     int32                return_code;
@@ -587,7 +587,7 @@ int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskMatch_Impl(uint32 task_id)
+int32 OS_TaskMatch_Impl(osal_index_t task_id)
 {
     if (pthread_equal(pthread_self(), OS_impl_task_table[task_id].id) == 0)
     {
@@ -605,7 +605,7 @@ int32 OS_TaskMatch_Impl(uint32 task_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskDelete_Impl(uint32 task_id)
+int32 OS_TaskDelete_Impl(osal_index_t task_id)
 {
     /*
     ** Try to delete the task
@@ -678,7 +678,7 @@ int32 OS_TaskDelay_Impl(uint32 millisecond)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskSetPriority_Impl(uint32 task_id, uint32 new_priority)
+int32 OS_TaskSetPriority_Impl(osal_index_t task_id, osal_priority_t new_priority)
 {
     int os_priority;
     int ret;
@@ -758,7 +758,7 @@ osal_id_t OS_TaskGetId_Impl(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskGetInfo_Impl(uint32 task_id, OS_task_prop_t *task_prop)
+int32 OS_TaskGetInfo_Impl(osal_index_t task_id, OS_task_prop_t *task_prop)
 {
     return OS_SUCCESS;
 } /* end OS_TaskGetInfo_Impl */
@@ -771,7 +771,7 @@ int32 OS_TaskGetInfo_Impl(uint32 task_id, OS_task_prop_t *task_prop)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+bool OS_TaskIdMatchSystemData_Impl(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     const pthread_t *target = (const pthread_t *)ref;
 
@@ -786,7 +786,7 @@ bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_r
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, size_t sysdata_size)
 {
     if (sysdata == NULL || sysdata_size != sizeof(pthread_t))
     {

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -480,7 +480,7 @@ int32 OS_TimeBaseCreate_Impl(osal_index_t timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, int32 start_time, int32 interval_time)
+int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, uint32 start_time, uint32 interval_time)
 {
     OS_impl_timebase_internal_record_t *local;
     struct itimerspec                   timeout;

--- a/src/os/rtems/inc/os-rtems.h
+++ b/src/os/rtems/inc/os-rtems.h
@@ -84,6 +84,6 @@ int32 OS_Rtems_StreamAPI_Impl_Init(void);
 int32 OS_Rtems_DirAPI_Impl_Init(void);
 int32 OS_Rtems_FileSysAPI_Impl_Init(void);
 
-int32 OS_Rtems_TableMutex_Init(uint32 idtype);
+int32 OS_Rtems_TableMutex_Init(osal_objtype_t idtype);
 
 #endif /* INCLUDE_OS_RTEMS_H_ */

--- a/src/os/rtems/src/os-impl-binsem.c
+++ b/src/os/rtems/src/os-impl-binsem.c
@@ -87,7 +87,7 @@ int32 OS_Rtems_BinSemAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options)
+int32 OS_BinSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options)
 {
     rtems_status_code status;
     rtems_name        r_name;
@@ -128,7 +128,7 @@ int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 optio
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemDelete_Impl(uint32 sem_id)
+int32 OS_BinSemDelete_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -151,7 +151,7 @@ int32 OS_BinSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemGive_Impl(uint32 sem_id)
+int32 OS_BinSemGive_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -173,7 +173,7 @@ int32 OS_BinSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemFlush_Impl(uint32 sem_id)
+int32 OS_BinSemFlush_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -197,7 +197,7 @@ int32 OS_BinSemFlush_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemTake_Impl(uint32 sem_id)
+int32 OS_BinSemTake_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -228,7 +228,7 @@ int32 OS_BinSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
+int32 OS_BinSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs)
 {
     rtems_status_code status;
     int               TimeInTicks;
@@ -264,7 +264,7 @@ int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemGetInfo_Impl(uint32 sem_id, OS_bin_sem_prop_t *bin_prop)
+int32 OS_BinSemGetInfo_Impl(osal_index_t sem_id, OS_bin_sem_prop_t *bin_prop)
 {
     /* RTEMS has no API for obtaining the current value of a semaphore */
     return OS_SUCCESS;

--- a/src/os/rtems/src/os-impl-common.c
+++ b/src/os/rtems/src/os-impl-common.c
@@ -52,7 +52,7 @@ RTEMS_GlobalVars_t RTEMS_GlobalVars = {0};
 
    returns: OS_SUCCESS or OS_ERROR
 ---------------------------------------------------------------------------------------*/
-int32 OS_API_Impl_Init(uint32 idtype)
+int32 OS_API_Impl_Init(osal_objtype_t idtype)
 {
     int32 return_code;
 

--- a/src/os/rtems/src/os-impl-console.c
+++ b/src/os/rtems/src/os-impl-console.c
@@ -86,7 +86,7 @@ OS_impl_console_internal_record_t OS_impl_console_table[OS_MAX_CONSOLES];
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_ConsoleWakeup_Impl(uint32 local_id)
+void OS_ConsoleWakeup_Impl(osal_index_t local_id)
 {
     OS_impl_console_internal_record_t *local = &OS_impl_console_table[local_id];
 
@@ -130,7 +130,7 @@ static void OS_ConsoleTask_Entry(rtems_task_argument arg)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ConsoleCreate_Impl(uint32 local_id)
+int32 OS_ConsoleCreate_Impl(osal_index_t local_id)
 {
     OS_impl_console_internal_record_t *local = &OS_impl_console_table[local_id];
     int32                              return_code;

--- a/src/os/rtems/src/os-impl-countsem.c
+++ b/src/os/rtems/src/os-impl-countsem.c
@@ -84,7 +84,7 @@ int32 OS_Rtems_CountSemAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options)
+int32 OS_CountSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options)
 {
     rtems_status_code status;
     rtems_name        r_name;
@@ -125,7 +125,7 @@ int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 opt
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemDelete_Impl(uint32 sem_id)
+int32 OS_CountSemDelete_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -148,7 +148,7 @@ int32 OS_CountSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemGive_Impl(uint32 sem_id)
+int32 OS_CountSemGive_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -171,7 +171,7 @@ int32 OS_CountSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemTake_Impl(uint32 sem_id)
+int32 OS_CountSemTake_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -194,7 +194,7 @@ int32 OS_CountSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
+int32 OS_CountSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs)
 {
     rtems_status_code status;
     int               TimeInTicks;
@@ -228,7 +228,7 @@ int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemGetInfo_Impl(uint32 sem_id, OS_count_sem_prop_t *count_prop)
+int32 OS_CountSemGetInfo_Impl(osal_index_t sem_id, OS_count_sem_prop_t *count_prop)
 {
     /* RTEMS does not provide an API to get the value */
     return OS_SUCCESS;

--- a/src/os/rtems/src/os-impl-filesys.c
+++ b/src/os/rtems/src/os-impl-filesys.c
@@ -104,7 +104,7 @@ int32 OS_Rtems_FileSysAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStartVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysStartVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *     local = &OS_filesys_table[filesys_id];
     OS_impl_filesys_internal_record_t *impl  = &OS_impl_filesys_table[filesys_id];
@@ -205,7 +205,7 @@ int32 OS_FileSysStartVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStopVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysStopVolume_Impl(osal_index_t filesys_id)
 {
     OS_impl_filesys_internal_record_t *impl = &OS_impl_filesys_table[filesys_id];
 
@@ -229,7 +229,7 @@ int32 OS_FileSysStopVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysFormatVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *     local = &OS_filesys_table[filesys_id];
     OS_impl_filesys_internal_record_t *impl  = &OS_impl_filesys_table[filesys_id];
@@ -291,7 +291,7 @@ int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysMountVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysMountVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *     local = &OS_filesys_table[filesys_id];
     OS_impl_filesys_internal_record_t *impl  = &OS_impl_filesys_table[filesys_id];
@@ -345,7 +345,7 @@ int32 OS_FileSysMountVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysUnmountVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
 
@@ -373,7 +373,7 @@ int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
+int32 OS_FileSysStatVolume_Impl(osal_index_t filesys_id, OS_statvfs_t *result)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     struct statvfs                stat_buf;
@@ -415,7 +415,7 @@ int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysCheckVolume_Impl(uint32 filesys_id, bool repair)
+int32 OS_FileSysCheckVolume_Impl(osal_index_t filesys_id, bool repair)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 } /* end OS_FileSysCheckVolume_Impl */

--- a/src/os/rtems/src/os-impl-idmap.c
+++ b/src/os/rtems/src/os-impl-idmap.c
@@ -86,7 +86,7 @@ enum
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(uint32 idtype)
+int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
 {
     rtems_id *mut;
 
@@ -120,7 +120,7 @@ int32 OS_Lock_Global_Impl(uint32 idtype)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(uint32 idtype)
+int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
 {
     rtems_id *mut;
 
@@ -158,7 +158,7 @@ int32 OS_Unlock_Global_Impl(uint32 idtype)
 
    returns: OS_SUCCESS or OS_ERROR
 ---------------------------------------------------------------------------------------*/
-int32 OS_Rtems_TableMutex_Init(uint32 idtype)
+int32 OS_Rtems_TableMutex_Init(osal_objtype_t idtype)
 {
     int32             return_code = OS_SUCCESS;
     rtems_status_code rtems_sc;

--- a/src/os/rtems/src/os-impl-loader.c
+++ b/src/os/rtems/src/os-impl-loader.c
@@ -104,7 +104,7 @@ static bool OS_rtems_rtl_check_unresolved(rtems_rtl_unresolv_rec_t *rec, void *d
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
+int32 OS_ModuleLoad_Impl(osal_index_t module_id, const char *translated_path)
 {
     int32 status = OS_ERROR;
     int   unresolved;
@@ -177,7 +177,7 @@ int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleUnload_Impl(uint32 module_id)
+int32 OS_ModuleUnload_Impl(osal_index_t module_id)
 {
     int32 status = OS_ERROR;
 
@@ -207,7 +207,7 @@ int32 OS_ModuleUnload_Impl(uint32 module_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleGetInfo_Impl(uint32 module_id, OS_module_prop_t *module_prop)
+int32 OS_ModuleGetInfo_Impl(osal_index_t module_id, OS_module_prop_t *module_prop)
 {
     /*
     ** RTEMS does not specify a way to get these values

--- a/src/os/rtems/src/os-impl-mutex.c
+++ b/src/os/rtems/src/os-impl-mutex.c
@@ -85,7 +85,7 @@ int32 OS_Rtems_MutexAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options)
+int32 OS_MutSemCreate_Impl(osal_index_t sem_id, uint32 options)
 {
     rtems_status_code status;
     rtems_name        r_name;
@@ -114,7 +114,7 @@ int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemDelete_Impl(uint32 sem_id)
+int32 OS_MutSemDelete_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -138,7 +138,7 @@ int32 OS_MutSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemGive_Impl(uint32 sem_id)
+int32 OS_MutSemGive_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -163,7 +163,7 @@ int32 OS_MutSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemTake_Impl(uint32 sem_id)
+int32 OS_MutSemTake_Impl(osal_index_t sem_id)
 {
     rtems_status_code status;
 
@@ -187,7 +187,7 @@ int32 OS_MutSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemGetInfo_Impl(uint32 sem_id, OS_mut_sem_prop_t *mut_prop)
+int32 OS_MutSemGetInfo_Impl(osal_index_t sem_id, OS_mut_sem_prop_t *mut_prop)
 {
     /* RTEMS provides no additional info */
     return OS_SUCCESS;

--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -78,7 +78,7 @@ int32 OS_Rtems_QueueAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags)
+int32 OS_QueueCreate_Impl(osal_index_t queue_id, uint32 flags)
 {
     rtems_status_code status;
     rtems_name        r_name;
@@ -125,7 +125,7 @@ int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueDelete_Impl(uint32 queue_id)
+int32 OS_QueueDelete_Impl(osal_index_t queue_id)
 {
     rtems_status_code status;
 
@@ -149,7 +149,7 @@ int32 OS_QueueDelete_Impl(uint32 queue_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+int32 OS_QueueGet_Impl(osal_index_t queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
 {
     int32             return_code;
     rtems_status_code status;
@@ -243,7 +243,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 flags)
+int32 OS_QueuePut_Impl(osal_index_t queue_id, const void *data, uint32 size, uint32 flags)
 {
     rtems_status_code status;
     rtems_id          rtems_queue_id;
@@ -287,7 +287,7 @@ int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 fl
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGetInfo_Impl(uint32 queue_id, OS_queue_prop_t *queue_prop)
+int32 OS_QueueGetInfo_Impl(osal_index_t queue_id, OS_queue_prop_t *queue_prop)
 {
     /* No extra info for queues in the OS implementation */
     return OS_SUCCESS;

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -90,7 +90,7 @@ int32 OS_Rtems_TaskAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags)
+int32 OS_TaskCreate_Impl(osal_index_t task_id, uint32 flags)
 {
     rtems_status_code status;
     rtems_name        r_name;
@@ -151,7 +151,7 @@ int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskDelete_Impl(uint32 task_id)
+int32 OS_TaskDelete_Impl(osal_index_t task_id)
 {
     /*
     ** Try to delete the task
@@ -221,7 +221,7 @@ int32 OS_TaskDelay_Impl(uint32 milli_second)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskSetPriority_Impl(uint32 task_id, uint32 new_priority)
+int32 OS_TaskSetPriority_Impl(osal_index_t task_id, osal_priority_t new_priority)
 {
     rtems_task_priority old_pri;
     rtems_status_code   status;
@@ -246,7 +246,7 @@ int32 OS_TaskSetPriority_Impl(uint32 task_id, uint32 new_priority)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskMatch_Impl(uint32 task_id)
+int32 OS_TaskMatch_Impl(osal_index_t task_id)
 {
     /*
     ** Get RTEMS Task Id
@@ -329,7 +329,7 @@ osal_id_t OS_TaskGetId_Impl(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskGetInfo_Impl(uint32 task_id, OS_task_prop_t *task_prop)
+int32 OS_TaskGetInfo_Impl(osal_index_t task_id, OS_task_prop_t *task_prop)
 {
     return OS_SUCCESS;
 
@@ -360,7 +360,7 @@ int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+bool OS_TaskIdMatchSystemData_Impl(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     const rtems_id *target = (const rtems_id *)ref;
 

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -410,7 +410,7 @@ int32 OS_TimeBaseCreate_Impl(osal_index_t timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, int32 start_time, int32 interval_time)
+int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, uint32 start_time, uint32 interval_time)
 {
     OS_U32ValueWrapper_t                user_data;
     OS_impl_timebase_internal_record_t *local;

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -89,7 +89,7 @@ OS_impl_timebase_internal_record_t OS_impl_timebase_table[OS_MAX_TIMEBASES];
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_TimeBaseLock_Impl(uint32 local_id)
+void OS_TimeBaseLock_Impl(osal_index_t local_id)
 {
     rtems_semaphore_obtain(OS_impl_timebase_table[local_id].handler_mutex, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
 } /* end OS_TimeBaseLock_Impl */
@@ -102,7 +102,7 @@ void OS_TimeBaseLock_Impl(uint32 local_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_TimeBaseUnlock_Impl(uint32 local_id)
+void OS_TimeBaseUnlock_Impl(osal_index_t local_id)
 {
     rtems_semaphore_release(OS_impl_timebase_table[local_id].handler_mutex);
 } /* end OS_TimeBaseUnlock_Impl */
@@ -119,7 +119,7 @@ void OS_TimeBaseUnlock_Impl(uint32 local_id)
 static rtems_timer_service_routine OS_TimeBase_ISR(rtems_id rtems_timer_id, void *arg)
 {
     OS_U32ValueWrapper_t                user_data;
-    uint32                              local_id;
+    osal_index_t                        local_id;
     OS_impl_timebase_internal_record_t *local;
 
     user_data.opaque_arg = arg;
@@ -154,7 +154,7 @@ static rtems_timer_service_routine OS_TimeBase_ISR(rtems_id rtems_timer_id, void
  *           Pends on the semaphore for the next timer tick
  *
  *-----------------------------------------------------------------*/
-static uint32 OS_TimeBase_WaitImpl(uint32 local_id)
+static uint32 OS_TimeBase_WaitImpl(osal_index_t local_id)
 {
     OS_impl_timebase_internal_record_t *local;
     uint32                              tick_time;
@@ -280,7 +280,7 @@ void OS_UsecsToTicks(uint32 usecs, rtems_interval *ticks)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
+int32 OS_TimeBaseCreate_Impl(osal_index_t timer_id)
 {
     int32                               return_code;
     rtems_status_code                   rtems_sc;
@@ -410,7 +410,7 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(uint32 timer_id, int32 start_time, int32 interval_time)
+int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, int32 start_time, int32 interval_time)
 {
     OS_U32ValueWrapper_t                user_data;
     OS_impl_timebase_internal_record_t *local;
@@ -512,7 +512,7 @@ int32 OS_TimeBaseSet_Impl(uint32 timer_id, int32 start_time, int32 interval_time
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseDelete_Impl(uint32 timer_id)
+int32 OS_TimeBaseDelete_Impl(osal_index_t timer_id)
 {
     rtems_status_code                   rtems_sc;
     OS_impl_timebase_internal_record_t *local;
@@ -576,7 +576,7 @@ int32 OS_TimeBaseDelete_Impl(uint32 timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseGetInfo_Impl(uint32 timer_id, OS_timebase_prop_t *timer_prop)
+int32 OS_TimeBaseGetInfo_Impl(osal_index_t timer_id, OS_timebase_prop_t *timer_prop)
 {
     return OS_SUCCESS;
 

--- a/src/os/shared/inc/os-shared-binsem.h
+++ b/src/os/shared/inc/os-shared-binsem.h
@@ -62,7 +62,7 @@ int32 OS_BinSemAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options);
+int32 OS_BinSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options);
 
 /*----------------------------------------------------------------
    Function: OS_BinSemFlush_Impl
@@ -72,7 +72,7 @@ int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 optio
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_BinSemFlush_Impl(uint32 sem_id);
+int32 OS_BinSemFlush_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_BinSemGive_Impl
@@ -81,7 +81,7 @@ int32 OS_BinSemFlush_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_BinSemGive_Impl(uint32 sem_id);
+int32 OS_BinSemGive_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_BinSemTake_Impl
@@ -91,7 +91,7 @@ int32 OS_BinSemGive_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_BinSemTake_Impl(uint32 sem_id);
+int32 OS_BinSemTake_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_BinSemTimedWait_Impl
@@ -101,7 +101,7 @@ int32 OS_BinSemTake_Impl(uint32 sem_id);
     Returns: OS_SUCCESS on success, or relevant error code
              OS_SEM_TIMEOUT must be returned if the time limit was reached
  ------------------------------------------------------------------*/
-int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs);
+int32 OS_BinSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs);
 
 /*----------------------------------------------------------------
    Function: OS_BinSemDelete_Impl
@@ -110,7 +110,7 @@ int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_BinSemDelete_Impl(uint32 sem_id);
+int32 OS_BinSemDelete_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_BinSemGetInfo_Impl
@@ -119,6 +119,6 @@ int32 OS_BinSemDelete_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_BinSemGetInfo_Impl(uint32 sem_id, OS_bin_sem_prop_t *bin_prop);
+int32 OS_BinSemGetInfo_Impl(osal_index_t sem_id, OS_bin_sem_prop_t *bin_prop);
 
 #endif /* INCLUDE_OS_SHARED_BINSEM_H_ */

--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -87,7 +87,7 @@ int32 OS_NotifyEvent(OS_Event_t event, osal_id_t object_id, void *data);
 
    returns: OS_SUCCESS on success, or relevant error code
 ---------------------------------------------------------------------------------------*/
-int32 OS_API_Impl_Init(uint32 idtype);
+int32 OS_API_Impl_Init(osal_objtype_t idtype);
 
 /*
  * This functions implement a the OS-specific portion

--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -52,8 +52,8 @@ struct OS_shared_global_vars
      */
     volatile bool   PrintfEnabled;
     volatile uint32 ShutdownFlag;
-    int32           MicroSecPerTick;
-    int32           TicksPerSecond;
+    uint32          MicroSecPerTick;
+    uint32          TicksPerSecond;
 
     /*
      * The event handler is an application-defined callback

--- a/src/os/shared/inc/os-shared-countsem.h
+++ b/src/os/shared/inc/os-shared-countsem.h
@@ -62,7 +62,7 @@ int32 OS_CountSemAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options);
+int32 OS_CountSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options);
 
 /*----------------------------------------------------------------
    Function: OS_CountSemGive_Impl
@@ -71,7 +71,7 @@ int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 opt
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_CountSemGive_Impl(uint32 sem_id);
+int32 OS_CountSemGive_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_CountSemTake_Impl
@@ -81,7 +81,7 @@ int32 OS_CountSemGive_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_CountSemTake_Impl(uint32 sem_id);
+int32 OS_CountSemTake_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_CountSemTimedWait_Impl
@@ -91,7 +91,7 @@ int32 OS_CountSemTake_Impl(uint32 sem_id);
     Returns: OS_SUCCESS on success, or relevant error code
              OS_SEM_TIMEOUT must be returned if the time limit was reached
  ------------------------------------------------------------------*/
-int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs);
+int32 OS_CountSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs);
 
 /*----------------------------------------------------------------
    Function: OS_CountSemDelete_Impl
@@ -100,7 +100,7 @@ int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_CountSemDelete_Impl(uint32 sem_id);
+int32 OS_CountSemDelete_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_CountSemGetInfo_Impl
@@ -109,6 +109,6 @@ int32 OS_CountSemDelete_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_CountSemGetInfo_Impl(uint32 sem_id, OS_count_sem_prop_t *count_prop);
+int32 OS_CountSemGetInfo_Impl(osal_index_t sem_id, OS_count_sem_prop_t *count_prop);
 
 #endif /* INCLUDE_OS_SHARED_COUNTSEM_H_ */

--- a/src/os/shared/inc/os-shared-dir.h
+++ b/src/os/shared/inc/os-shared-dir.h
@@ -72,7 +72,7 @@ int32 OS_DirCreate_Impl(const char *local_path, uint32 access);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path);
+int32 OS_DirOpen_Impl(osal_index_t local_id, const char *local_path);
 
 /*----------------------------------------------------------------
    Function: OS_DirClose_Impl
@@ -81,7 +81,7 @@ int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_DirClose_Impl(uint32 local_id);
+int32 OS_DirClose_Impl(osal_index_t local_id);
 
 /*----------------------------------------------------------------
    Function: OS_DirRead_Impl
@@ -90,7 +90,7 @@ int32 OS_DirClose_Impl(uint32 local_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent);
+int32 OS_DirRead_Impl(osal_index_t local_id, os_dirent_t *dirent);
 
 /*----------------------------------------------------------------
    Function: OS_DirRewind_Impl
@@ -99,7 +99,7 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_DirRewind_Impl(uint32 local_id);
+int32 OS_DirRewind_Impl(osal_index_t local_id);
 
 /*----------------------------------------------------------------
    Function: OS_DirRemove_Impl

--- a/src/os/shared/inc/os-shared-file.h
+++ b/src/os/shared/inc/os-shared-file.h
@@ -78,7 +78,7 @@ int32 OS_FileAPI_Init(void);
 
     Returns: File position (non-negative) on success, or relevant error code (negative)
  ------------------------------------------------------------------*/
-int32 OS_GenericSeek_Impl(uint32 local_id, int32 offset, uint32 whence);
+int32 OS_GenericSeek_Impl(osal_index_t local_id, int32 offset, uint32 whence);
 
 /*----------------------------------------------------------------
    Function: OS_GenericRead_Impl
@@ -88,7 +88,7 @@ int32 OS_GenericSeek_Impl(uint32 local_id, int32 offset, uint32 whence);
 
     Returns: Number of bytes read (non-negative) on success, or relevant error code (negative)
  ------------------------------------------------------------------*/
-int32 OS_GenericRead_Impl(uint32 local_id, void *buffer, uint32 nbytes, int32 timeout);
+int32 OS_GenericRead_Impl(osal_index_t local_id, void *buffer, size_t nbytes, int32 timeout);
 
 /*----------------------------------------------------------------
    Function: OS_GenericWrite_Impl
@@ -98,7 +98,7 @@ int32 OS_GenericRead_Impl(uint32 local_id, void *buffer, uint32 nbytes, int32 ti
 
     Returns: Number of bytes written (non-negative) on success, or relevant error code (negative)
  ------------------------------------------------------------------*/
-int32 OS_GenericWrite_Impl(uint32 local_id, const void *buffer, uint32 nbytes, int32 timeout);
+int32 OS_GenericWrite_Impl(osal_index_t local_id, const void *buffer, size_t nbytes, int32 timeout);
 
 /*----------------------------------------------------------------
    Function: OS_GenericClose_Impl
@@ -108,7 +108,7 @@ int32 OS_GenericWrite_Impl(uint32 local_id, const void *buffer, uint32 nbytes, i
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_GenericClose_Impl(uint32 local_id);
+int32 OS_GenericClose_Impl(osal_index_t local_id);
 
 /*----------------------------------------------------------------
    Function: OS_FileOpen_Impl
@@ -118,7 +118,7 @@ int32 OS_GenericClose_Impl(uint32 local_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int32 access);
+int32 OS_FileOpen_Impl(osal_index_t local_id, const char *local_path, int32 flags, int32 access);
 
 /*----------------------------------------------------------------
    Function: OS_ShellOutputToFile_Impl
@@ -127,7 +127,7 @@ int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ShellOutputToFile_Impl(uint32 stream_id, const char *Cmd);
+int32 OS_ShellOutputToFile_Impl(osal_index_t stream_id, const char *Cmd);
 
 /****************************************************************************************
                              Filename-based Operations

--- a/src/os/shared/inc/os-shared-filesys.h
+++ b/src/os/shared/inc/os-shared-filesys.h
@@ -94,9 +94,9 @@ enum
  */
 typedef struct
 {
-    uint32 block_size;
-    uint64 total_blocks;
-    uint64 blocks_free;
+    size_t            block_size;
+    osal_blockcount_t total_blocks;
+    osal_blockcount_t blocks_free;
 } OS_statvfs_t;
 
 typedef struct
@@ -107,11 +107,11 @@ typedef struct
                                                    operating system */
     char virtual_mountpt[OS_MAX_PATH_LEN]; /**< The name/prefix in the OSAL Virtual File system exposed to applications
                                             */
-    char * address;
-    uint32 blocksize;
-    uint32 numblocks;
-    uint8  flags;
-    uint8  fstype;
+    char *            address;
+    size_t            blocksize;
+    osal_blockcount_t numblocks;
+    uint8             flags;
+    uint8             fstype;
 } OS_filesys_internal_record_t;
 
 /*
@@ -140,7 +140,7 @@ int32 OS_FileSysAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysStartVolume_Impl(uint32 filesys_id);
+int32 OS_FileSysStartVolume_Impl(osal_index_t filesys_id);
 
 /*----------------------------------------------------------------
    Function: OS_FileSysStopVolume_Impl
@@ -149,7 +149,7 @@ int32 OS_FileSysStartVolume_Impl(uint32 filesys_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysStopVolume_Impl(uint32 filesys_id);
+int32 OS_FileSysStopVolume_Impl(osal_index_t filesys_id);
 
 /*----------------------------------------------------------------
    Function: OS_FileSysFormatVolume_Impl
@@ -158,7 +158,7 @@ int32 OS_FileSysStopVolume_Impl(uint32 filesys_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id);
+int32 OS_FileSysFormatVolume_Impl(osal_index_t filesys_id);
 
 /*----------------------------------------------------------------
    Function: OS_FileSysCheckVolume_Impl
@@ -167,7 +167,7 @@ int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysCheckVolume_Impl(uint32 filesys_id, bool repair);
+int32 OS_FileSysCheckVolume_Impl(osal_index_t filesys_id, bool repair);
 
 /*----------------------------------------------------------------
    Function: OS_FileSysStatVolume_Impl
@@ -176,7 +176,7 @@ int32 OS_FileSysCheckVolume_Impl(uint32 filesys_id, bool repair);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result);
+int32 OS_FileSysStatVolume_Impl(osal_index_t filesys_id, OS_statvfs_t *result);
 
 /*----------------------------------------------------------------
    Function: OS_FileSysMountVolume_Impl
@@ -185,7 +185,7 @@ int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysMountVolume_Impl(uint32 filesys_id);
+int32 OS_FileSysMountVolume_Impl(osal_index_t filesys_id);
 
 /*----------------------------------------------------------------
    Function: OS_FileSysUnmountVolume_Impl
@@ -194,7 +194,7 @@ int32 OS_FileSysMountVolume_Impl(uint32 filesys_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id);
+int32 OS_FileSysUnmountVolume_Impl(osal_index_t filesys_id);
 
 /*
  * Internal helper functions
@@ -202,8 +202,8 @@ int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id);
  * Not normally invoked outside this unit, except for unit testing
  */
 
-bool  OS_FileSys_FindVirtMountPoint(void *ref, uint32 local_id, const OS_common_record_t *obj);
-int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fsvolname, uint32 blocksize,
-                            uint32 numblocks, bool should_format);
+bool  OS_FileSys_FindVirtMountPoint(void *ref, osal_index_t local_id, const OS_common_record_t *obj);
+int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fsvolname, size_t blocksize,
+                            osal_blockcount_t numblocks, bool should_format);
 
 #endif /* INCLUDE_OS_SHARED_FILESYS_H_ */

--- a/src/os/shared/inc/os-shared-globaldefs.h
+++ b/src/os/shared/inc/os-shared-globaldefs.h
@@ -61,7 +61,7 @@ typedef union
     OS_TimerCallback_t timer_callback_func;
     osal_task_entry    entry_func;
     osal_id_t          id;
-    uint32             value;
+    osal_index_t       idx;
 } OS_U32ValueWrapper_t;
 
 /*

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -65,7 +65,7 @@ typedef enum
  *
  * Returns true if the id/obj matches the reference, false otherwise.
  */
-typedef bool (*OS_ObjectMatchFunc_t)(void *ref, uint32 local_id, const OS_common_record_t *obj);
+typedef bool (*OS_ObjectMatchFunc_t)(void *ref, osal_index_t local_id, const OS_common_record_t *obj);
 
 /*
  * Global instantiations
@@ -109,7 +109,7 @@ int32 OS_ObjectIdInit(void);
 
    Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-void OS_Lock_Global(uint32 idtype);
+void OS_Lock_Global(osal_objtype_t idtype);
 
 /*----------------------------------------------------------------
    Function: OS_Lock_Global
@@ -118,7 +118,7 @@ void OS_Lock_Global(uint32 idtype);
 
    Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(uint32 idtype);
+int32 OS_Lock_Global_Impl(osal_objtype_t idtype);
 
 /*----------------------------------------------------------------
    Function: OS_Unlock_Global
@@ -127,7 +127,7 @@ int32 OS_Lock_Global_Impl(uint32 idtype);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-void OS_Unlock_Global(uint32 idtype);
+void OS_Unlock_Global(osal_objtype_t idtype);
 
 /*----------------------------------------------------------------
    Function: OS_Unlock_Global
@@ -136,7 +136,7 @@ void OS_Unlock_Global(uint32 idtype);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(uint32 idtype);
+int32 OS_Unlock_Global_Impl(osal_objtype_t idtype);
 
 /*
    Function prototypes for routines implemented in common layers but private to OSAL
@@ -161,7 +161,7 @@ static inline uint32 OS_ObjectIdToSerialNumber_Impl(osal_id_t id)
 
     Purpose: Obtain the object type component of a generic OSAL Object ID
  ------------------------------------------------------------------*/
-static inline uint32 OS_ObjectIdToType_Impl(osal_id_t id)
+static inline osal_objtype_t OS_ObjectIdToType_Impl(osal_id_t id)
 {
     return (OS_ObjectIdToInteger(id) >> OS_OBJECT_TYPE_SHIFT);
 }
@@ -171,7 +171,7 @@ static inline uint32 OS_ObjectIdToType_Impl(osal_id_t id)
 
     Purpose: Convert an object serial number and resource type into an external 32-bit OSAL ID
  ------------------------------------------------------------------*/
-static inline void OS_ObjectIdCompose_Impl(uint32 idtype, uint32 idserial, osal_id_t *result)
+static inline void OS_ObjectIdCompose_Impl(osal_objtype_t idtype, uint32 idserial, osal_id_t *result)
 {
     *result = OS_ObjectIdFromInteger((idtype << OS_OBJECT_TYPE_SHIFT) | idserial);
 }
@@ -183,7 +183,7 @@ static inline void OS_ObjectIdCompose_Impl(uint32 idtype, uint32 idserial, osal_
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-uint32 OS_GetMaxForObjectType(uint32 idtype);
+uint32 OS_GetMaxForObjectType(osal_objtype_t idtype);
 
 /*----------------------------------------------------------------
    Function: OS_GetBaseForObjectType
@@ -192,7 +192,7 @@ uint32 OS_GetMaxForObjectType(uint32 idtype);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-uint32 OS_GetBaseForObjectType(uint32 idtype);
+uint32 OS_GetBaseForObjectType(osal_objtype_t idtype);
 
 /*----------------------------------------------------------------
    Function: OS_ObjectIdFindByName
@@ -201,7 +201,7 @@ uint32 OS_GetBaseForObjectType(uint32 idtype);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdFindByName(uint32 idtype, const char *name, osal_id_t *object_id);
+int32 OS_ObjectIdFindByName(osal_objtype_t idtype, const char *name, osal_id_t *object_id);
 
 /*----------------------------------------------------------------
    Function: OS_ObjectIdGetBySearch
@@ -212,7 +212,7 @@ int32 OS_ObjectIdFindByName(uint32 idtype, const char *name, osal_id_t *object_i
 
    Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
+int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
                              OS_common_record_t **record);
 
 /*----------------------------------------------------------------
@@ -223,7 +223,8 @@ int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectM
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, uint32 idtype, const char *name, OS_common_record_t **record);
+int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, osal_objtype_t idtype, const char *name,
+                           OS_common_record_t **record);
 
 /*----------------------------------------------------------------
    Function: OS_ObjectIdGetById
@@ -233,7 +234,7 @@ int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, uint32 idtype, const char *
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t id, uint32 *array_index,
+int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, osal_objtype_t idtype, osal_id_t id, osal_index_t *array_index,
                          OS_common_record_t **record);
 
 /*----------------------------------------------------------------
@@ -246,7 +247,8 @@ int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t id, 
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_index, OS_common_record_t **record);
+int32 OS_ObjectIdAllocateNew(osal_objtype_t idtype, const char *name, osal_index_t *array_index,
+                             OS_common_record_t **record);
 
 /*----------------------------------------------------------------
    Function: OS_ObjectIdFinalizeNew
@@ -287,10 +289,11 @@ int32 OS_ObjectIdRefcountDecr(OS_common_record_t *record);
  * These are not normally called outside this unit, but need
  * to be exposed for unit testing.
  */
-bool  OS_ObjectNameMatch(void *ref, uint32 local_id, const OS_common_record_t *obj);
-void  OS_ObjectIdInitiateLock(OS_lock_mode_t lock_mode, uint32 idtype);
-int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t reference_id, OS_common_record_t *obj);
-int32 OS_ObjectIdSearch(uint32 idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg, OS_common_record_t **record);
-int32 OS_ObjectIdFindNext(uint32 idtype, uint32 *array_index, OS_common_record_t **record);
+bool  OS_ObjectNameMatch(void *ref, osal_index_t local_id, const OS_common_record_t *obj);
+void  OS_ObjectIdInitiateLock(OS_lock_mode_t lock_mode, osal_objtype_t idtype);
+int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, osal_objtype_t idtype, osal_id_t reference_id,
+                             OS_common_record_t *obj);
+int32 OS_ObjectIdSearch(osal_objtype_t idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg, OS_common_record_t **record);
+int32 OS_ObjectIdFindNext(osal_objtype_t idtype, osal_index_t *array_index, OS_common_record_t **record);
 
 #endif /* INCLUDE_OS_SHARED_IDMAP_H_ */

--- a/src/os/shared/inc/os-shared-module.h
+++ b/src/os/shared/inc/os-shared-module.h
@@ -72,7 +72,7 @@ int32 OS_ModuleAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path);
+int32 OS_ModuleLoad_Impl(osal_index_t module_id, const char *translated_path);
 
 /*----------------------------------------------------------------
 
@@ -82,7 +82,7 @@ int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ModuleUnload_Impl(uint32 module_id);
+int32 OS_ModuleUnload_Impl(osal_index_t module_id);
 
 /*----------------------------------------------------------------
    Function: OS_ModuleGetInfo_Impl
@@ -91,7 +91,7 @@ int32 OS_ModuleUnload_Impl(uint32 module_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ModuleGetInfo_Impl(uint32 module_id, OS_module_prop_t *module_prop);
+int32 OS_ModuleGetInfo_Impl(osal_index_t module_id, OS_module_prop_t *module_prop);
 
 /*----------------------------------------------------------------
    Function: OS_GlobalSymbolLookup_Impl
@@ -111,7 +111,7 @@ int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName);
+int32 OS_ModuleSymbolLookup_Impl(osal_index_t local_id, cpuaddr *SymbolAddress, const char *SymbolName);
 
 /*----------------------------------------------------------------
    Function: OS_SymbolTableDump_Impl
@@ -120,7 +120,7 @@ int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const 
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SymbolTableDump_Impl(const char *filename, uint32 size_limit);
+int32 OS_SymbolTableDump_Impl(const char *filename, size_t size_limit);
 
 /*
  * Helper functions within the shared layer that are not normally invoked outside the local module

--- a/src/os/shared/inc/os-shared-mutex.h
+++ b/src/os/shared/inc/os-shared-mutex.h
@@ -58,7 +58,7 @@ int32 OS_MutexAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options);
+int32 OS_MutSemCreate_Impl(osal_index_t sem_id, uint32 options);
 
 /*----------------------------------------------------------------
    Function: OS_MutSemGive_Impl
@@ -67,7 +67,7 @@ int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_MutSemGive_Impl(uint32 sem_id);
+int32 OS_MutSemGive_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_MutSemTake_Impl
@@ -76,7 +76,7 @@ int32 OS_MutSemGive_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_MutSemTake_Impl(uint32 sem_id);
+int32 OS_MutSemTake_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_MutSemDelete_Impl
@@ -85,7 +85,7 @@ int32 OS_MutSemTake_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_MutSemDelete_Impl(uint32 sem_id);
+int32 OS_MutSemDelete_Impl(osal_index_t sem_id);
 
 /*----------------------------------------------------------------
    Function: OS_MutSemGetInfo_Impl
@@ -94,6 +94,6 @@ int32 OS_MutSemDelete_Impl(uint32 sem_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_MutSemGetInfo_Impl(uint32 sem_id, OS_mut_sem_prop_t *mut_prop);
+int32 OS_MutSemGetInfo_Impl(osal_index_t sem_id, OS_mut_sem_prop_t *mut_prop);
 
 #endif /* INCLUDE_OS_SHARED_MUTEX_H_ */

--- a/src/os/shared/inc/os-shared-network.h
+++ b/src/os/shared/inc/os-shared-network.h
@@ -51,7 +51,7 @@ int32 OS_NetworkAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_NetworkGetHostName_Impl(char *host_name, uint32 name_len);
+int32 OS_NetworkGetHostName_Impl(char *host_name, size_t name_len);
 
 /*----------------------------------------------------------------
    Function: OS_NetworkGetID_Impl

--- a/src/os/shared/inc/os-shared-printf.h
+++ b/src/os/shared/inc/os-shared-printf.h
@@ -45,9 +45,9 @@ typedef struct
     char device_name[OS_MAX_API_NAME];
 
     char *          BufBase;        /**< Start of the buffer memory */
-    uint32          BufSize;        /**< Total size of the buffer */
-    volatile uint32 ReadPos;        /**< Offset of next byte to read */
-    volatile uint32 WritePos;       /**< Offset of next byte to write */
+    size_t          BufSize;        /**< Total size of the buffer */
+    volatile size_t ReadPos;        /**< Offset of next byte to read */
+    volatile size_t WritePos;       /**< Offset of next byte to write */
     uint32          OverflowEvents; /**< Number of lines dropped due to overflow */
 
 } OS_console_internal_record_t;
@@ -73,7 +73,7 @@ int32 OS_ConsoleAPI_Init(void);
     Purpose: Prepare a console device for use
              For Async devices, this sets up the background writer task
  ------------------------------------------------------------------*/
-int32 OS_ConsoleCreate_Impl(uint32 local_id);
+int32 OS_ConsoleCreate_Impl(osal_index_t local_id);
 
 /*----------------------------------------------------------------
    Function: OS_ConsoleOutput_Impl
@@ -85,7 +85,7 @@ int32 OS_ConsoleCreate_Impl(uint32 local_id);
 
    The data is already formatted, this just writes the characters.
  ------------------------------------------------------------------*/
-void OS_ConsoleOutput_Impl(uint32 local_id);
+void OS_ConsoleOutput_Impl(osal_index_t local_id);
 
 /*----------------------------------------------------------------
    Function: OS_ConsoleOutput_Impl
@@ -100,6 +100,6 @@ void OS_ConsoleOutput_Impl(uint32 local_id);
    service, this should wakeup the actual console servicing
    thread.
  ------------------------------------------------------------------*/
-void OS_ConsoleWakeup_Impl(uint32 local_id);
+void OS_ConsoleWakeup_Impl(osal_index_t local_id);
 
 #endif /* INCLUDE_OS_SHARED_PRINTF_H_ */

--- a/src/os/shared/inc/os-shared-queue.h
+++ b/src/os/shared/inc/os-shared-queue.h
@@ -32,9 +32,9 @@
 
 typedef struct
 {
-    char   queue_name[OS_MAX_API_NAME];
-    uint32 max_size;
-    uint32 max_depth;
+    char              queue_name[OS_MAX_API_NAME];
+    size_t            max_size;
+    osal_blockcount_t max_depth;
 } OS_queue_internal_record_t;
 
 /*
@@ -63,7 +63,7 @@ int32 OS_QueueAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags);
+int32 OS_QueueCreate_Impl(osal_index_t queue_id, uint32 flags);
 
 /*----------------------------------------------------------------
    Function: OS_QueueDelete_Impl
@@ -72,7 +72,7 @@ int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_QueueDelete_Impl(uint32 queue_id);
+int32 OS_QueueDelete_Impl(osal_index_t queue_id);
 
 /*----------------------------------------------------------------
    Function: OS_QueueGet_Impl
@@ -85,7 +85,7 @@ int32 OS_QueueDelete_Impl(uint32 queue_id);
              OS_QUEUE_EMPTY must be returned if the queue is empty when polled (OS_CHECK)
              OS_QUEUE_INVALID_SIZE must be returned if the supplied buffer is too small
  ------------------------------------------------------------------*/
-int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout);
+int32 OS_QueueGet_Impl(osal_index_t queue_id, void *data, size_t size, size_t *size_copied, int32 timeout);
 
 /*----------------------------------------------------------------
    Function: OS_QueuePut_Impl
@@ -95,7 +95,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
     Returns: OS_SUCCESS on success, or relevant error code
              OS_QUEUE_FULL must be returned if the queue is full.
  ------------------------------------------------------------------*/
-int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 flags);
+int32 OS_QueuePut_Impl(osal_index_t queue_id, const void *data, size_t size, uint32 flags);
 
 /*----------------------------------------------------------------
    Function: OS_QueueGetInfo_Impl
@@ -104,6 +104,6 @@ int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 fl
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_QueueGetInfo_Impl(uint32 queue_id, OS_queue_prop_t *queue_prop);
+int32 OS_QueueGetInfo_Impl(osal_index_t queue_id, OS_queue_prop_t *queue_prop);
 
 #endif /* INCLUDE_OS_SHARED_QUEUE_H_ */

--- a/src/os/shared/inc/os-shared-select.h
+++ b/src/os/shared/inc/os-shared-select.h
@@ -50,7 +50,7 @@
     Returns: OS_SUCCESS on success, or relevant error code
              OS_ERR_OPERATION_NOT_SUPPORTED if the specified file handle does not support select
  ------------------------------------------------------------------*/
-int32 OS_SelectSingle_Impl(uint32 stream_id, uint32 *SelectFlags, int32 msecs);
+int32 OS_SelectSingle_Impl(osal_index_t stream_id, uint32 *SelectFlags, int32 msecs);
 
 /*----------------------------------------------------------------
 

--- a/src/os/shared/inc/os-shared-shell.h
+++ b/src/os/shared/inc/os-shared-shell.h
@@ -41,6 +41,6 @@
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ShellOutputToFile_Impl(uint32 stream_id, const char *Cmd);
+int32 OS_ShellOutputToFile_Impl(osal_index_t stream_id, const char *Cmd);
 
 #endif /* INCLUDE_OS_SHARED_SHELL_H_ */

--- a/src/os/shared/inc/os-shared-sockets.h
+++ b/src/os/shared/inc/os-shared-sockets.h
@@ -50,7 +50,7 @@ int32 OS_SocketAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketOpen_Impl(uint32 sock_id);
+int32 OS_SocketOpen_Impl(osal_index_t sock_id);
 
 /*----------------------------------------------------------------
    Function: OS_SocketBind_Impl
@@ -59,7 +59,7 @@ int32 OS_SocketOpen_Impl(uint32 sock_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr);
+int32 OS_SocketBind_Impl(osal_index_t sock_id, const OS_SockAddr_t *Addr);
 
 /*----------------------------------------------------------------
    Function: OS_SocketAccept_Impl
@@ -70,7 +70,7 @@ int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Addr, int32 timeout);
+int32 OS_SocketAccept_Impl(osal_index_t sock_id, osal_index_t connsock_id, OS_SockAddr_t *Addr, int32 timeout);
 
 /*----------------------------------------------------------------
    Function: OS_SocketConnect_Impl
@@ -80,7 +80,7 @@ int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Ad
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 timeout);
+int32 OS_SocketConnect_Impl(osal_index_t sock_id, const OS_SockAddr_t *Addr, int32 timeout);
 
 /*----------------------------------------------------------------
    Function: OS_SocketRecvFrom_Impl
@@ -93,7 +93,8 @@ int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 tim
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout);
+int32 OS_SocketRecvFrom_Impl(osal_index_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr,
+                             int32 timeout);
 
 /*----------------------------------------------------------------
    Function: OS_SocketSendTo_Impl
@@ -104,7 +105,7 @@ int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, uint32 buflen, OS_Soc
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr);
+int32 OS_SocketSendTo_Impl(osal_index_t sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr);
 
 /*----------------------------------------------------------------
 
@@ -114,7 +115,7 @@ int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, uint32 buflen, co
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketGetInfo_Impl(uint32 sock_id, OS_socket_prop_t *sock_prop);
+int32 OS_SocketGetInfo_Impl(osal_index_t sock_id, OS_socket_prop_t *sock_prop);
 
 /*----------------------------------------------------------------
 
@@ -134,7 +135,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketAddrToString_Impl(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr);
+int32 OS_SocketAddrToString_Impl(char *buffer, size_t buflen, const OS_SockAddr_t *Addr);
 
 /*----------------------------------------------------------------
    Function: OS_SocketAddrFromString_Impl
@@ -174,6 +175,6 @@ int32 OS_SocketAddrSetPort_Impl(OS_SockAddr_t *Addr, uint16 PortNum);
  * Internal helper functions
  * Not normally called outside the local unit, except during unit test
  */
-void OS_CreateSocketName(uint32 local_id, const OS_SockAddr_t *Addr, const char *parent_name);
+void OS_CreateSocketName(osal_index_t local_id, const OS_SockAddr_t *Addr, const char *parent_name);
 
 #endif /* INCLUDE_OS_SHARED_SOCKETS_H_ */

--- a/src/os/shared/inc/os-shared-task.h
+++ b/src/os/shared/inc/os-shared-task.h
@@ -34,12 +34,12 @@
 typedef struct
 {
     char            task_name[OS_MAX_API_NAME];
-    uint32          stack_size;
-    uint32          priority;
+    size_t          stack_size;
+    osal_priority_t priority;
     osal_task_entry entry_function_pointer;
     osal_task_entry delete_hook_pointer;
     void *          entry_arg;
-    uint32 *        stack_pointer;
+    osal_stackptr_t stack_pointer;
 } OS_task_internal_record_t;
 
 /*
@@ -81,7 +81,7 @@ void OS_TaskEntryPoint(osal_id_t global_task_id);
 
     Returns: OS_SUCCESS on match, any other code on non-match
  ------------------------------------------------------------------*/
-int32 OS_TaskMatch_Impl(uint32 task_id);
+int32 OS_TaskMatch_Impl(osal_index_t task_id);
 
 /*----------------------------------------------------------------
 
@@ -92,7 +92,7 @@ int32 OS_TaskMatch_Impl(uint32 task_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags);
+int32 OS_TaskCreate_Impl(osal_index_t task_id, uint32 flags);
 
 /*----------------------------------------------------------------
    Function: OS_TaskDelete_Impl
@@ -101,7 +101,7 @@ int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TaskDelete_Impl(uint32 task_id);
+int32 OS_TaskDelete_Impl(osal_index_t task_id);
 
 /*----------------------------------------------------------------
    Function: OS_TaskExit_Impl
@@ -128,7 +128,7 @@ int32 OS_TaskDelay_Impl(uint32 millisecond);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TaskSetPriority_Impl(uint32 task_id, uint32 new_priority);
+int32 OS_TaskSetPriority_Impl(osal_index_t task_id, osal_priority_t new_priority);
 
 /*----------------------------------------------------------------
    Function: OS_TaskGetId_Impl
@@ -146,7 +146,7 @@ osal_id_t OS_TaskGetId_Impl(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TaskGetInfo_Impl(uint32 task_id, OS_task_prop_t *task_prop);
+int32 OS_TaskGetInfo_Impl(osal_index_t task_id, OS_task_prop_t *task_prop);
 
 /*----------------------------------------------------------------
 
@@ -169,7 +169,7 @@ int32 OS_TaskRegister_Impl(osal_id_t global_task_id);
              Compatible with the "OS_ObjectIdFindBySearch" routine
 
  ------------------------------------------------------------------*/
-bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj);
+bool OS_TaskIdMatchSystemData_Impl(void *ref, osal_index_t local_id, const OS_common_record_t *obj);
 
 /*----------------------------------------------------------------
 
@@ -179,6 +179,6 @@ bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_r
              compatible/reasonable for the underlying OS.
 
  ------------------------------------------------------------------*/
-int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size);
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, size_t sysdata_size);
 
 #endif /* INCLUDE_OS_SHARED_TASK_H_ */

--- a/src/os/shared/inc/os-shared-time.h
+++ b/src/os/shared/inc/os-shared-time.h
@@ -36,9 +36,9 @@ typedef struct
 {
     char             timer_name[OS_MAX_API_NAME];
     uint32           flags;
-    uint32           timebase_ref;
-    uint32           prev_ref;
-    uint32           next_ref;
+    osal_index_t     timebase_ref;
+    osal_index_t     prev_ref;
+    osal_index_t     next_ref;
     uint32           backlog_resets;
     int32            wait_time;
     int32            interval_time;

--- a/src/os/shared/inc/os-shared-timebase.h
+++ b/src/os/shared/inc/os-shared-timebase.h
@@ -82,7 +82,7 @@ int32 OS_TimeBaseCreate_Impl(osal_index_t timebase_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(osal_index_t timebase_id, int32 start_time, int32 interval_time);
+int32 OS_TimeBaseSet_Impl(osal_index_t timebase_id, uint32 start_time, uint32 interval_time);
 
 /*----------------------------------------------------------------
    Function: OS_TimeBaseDelete_Impl

--- a/src/os/shared/inc/os-shared-timebase.h
+++ b/src/os/shared/inc/os-shared-timebase.h
@@ -73,7 +73,7 @@ int32 OS_TimeBaseAPI_Init(void);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TimeBaseCreate_Impl(uint32 timebase_id);
+int32 OS_TimeBaseCreate_Impl(osal_index_t timebase_id);
 
 /*----------------------------------------------------------------
    Function: OS_TimeBaseSet_Impl
@@ -82,7 +82,7 @@ int32 OS_TimeBaseCreate_Impl(uint32 timebase_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(uint32 timebase_id, int32 start_time, int32 interval_time);
+int32 OS_TimeBaseSet_Impl(osal_index_t timebase_id, int32 start_time, int32 interval_time);
 
 /*----------------------------------------------------------------
    Function: OS_TimeBaseDelete_Impl
@@ -91,7 +91,7 @@ int32 OS_TimeBaseSet_Impl(uint32 timebase_id, int32 start_time, int32 interval_t
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TimeBaseDelete_Impl(uint32 timebase_id);
+int32 OS_TimeBaseDelete_Impl(osal_index_t timebase_id);
 
 /****************************************************************************************
                                 INTERNAL FUNCTIONS
@@ -103,7 +103,7 @@ int32 OS_TimeBaseDelete_Impl(uint32 timebase_id);
     Purpose: Get exclusive access to the given timebase
              Add/remove of application callbacks is prevented
  ------------------------------------------------------------------*/
-void OS_TimeBaseLock_Impl(uint32 timebase_id);
+void OS_TimeBaseLock_Impl(osal_index_t timebase_id);
 
 /*----------------------------------------------------------------
    Function: OS_TimeBaseLock_Impl
@@ -111,7 +111,7 @@ void OS_TimeBaseLock_Impl(uint32 timebase_id);
     Purpose: Release exclusive access to the given timebase
              Add/remove of application callbacks is allowed
  ------------------------------------------------------------------*/
-void OS_TimeBaseUnlock_Impl(uint32 timebase_id);
+void OS_TimeBaseUnlock_Impl(osal_index_t timebase_id);
 
 /*----------------------------------------------------------------
    Function: OS_TimeBaseGetInfo_Impl
@@ -120,7 +120,7 @@ void OS_TimeBaseUnlock_Impl(uint32 timebase_id);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_TimeBaseGetInfo_Impl(uint32 timer_id, OS_timebase_prop_t *timer_prop);
+int32 OS_TimeBaseGetInfo_Impl(osal_index_t timer_id, OS_timebase_prop_t *timer_prop);
 
 /*----------------------------------------------------------------
    Function: OS_TimeBase_CallbackThread

--- a/src/os/shared/src/osapi-binsem.c
+++ b/src/os/shared/src/osapi-binsem.c
@@ -98,7 +98,7 @@ int32 OS_BinSemCreate(osal_id_t *sem_id, const char *sem_name, uint32 sem_initia
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check for NULL pointers */
     if (sem_id == NULL || sem_name == NULL)
@@ -141,7 +141,7 @@ int32 OS_BinSemCreate(osal_id_t *sem_id, const char *sem_name, uint32 sem_initia
 int32 OS_BinSemDelete(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_EXCLUSIVE, LOCAL_OBJID_TYPE, sem_id, &local_id, &record);
@@ -168,7 +168,7 @@ int32 OS_BinSemDelete(osal_id_t sem_id)
 int32 OS_BinSemGive(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -193,7 +193,7 @@ int32 OS_BinSemGive(osal_id_t sem_id)
 int32 OS_BinSemFlush(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -217,7 +217,7 @@ int32 OS_BinSemFlush(osal_id_t sem_id)
 int32 OS_BinSemTake(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -241,7 +241,7 @@ int32 OS_BinSemTake(osal_id_t sem_id)
 int32 OS_BinSemTimedWait(osal_id_t sem_id, uint32 msecs)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -287,7 +287,7 @@ int32 OS_BinSemGetIdByName(osal_id_t *sem_id, const char *sem_name)
 int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check parameters */

--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -108,9 +108,9 @@ int32 OS_NotifyEvent(OS_Event_t event, osal_id_t object_id, void *data)
  *-----------------------------------------------------------------*/
 int32 OS_API_Init(void)
 {
-    int32  return_code = OS_SUCCESS;
-    uint32 idtype;
-    uint32 microSecPerSec;
+    int32          return_code = OS_SUCCESS;
+    osal_objtype_t idtype;
+    uint32         microSecPerSec;
 
     if (OS_SharedGlobalVars.Initialized != false)
     {

--- a/src/os/shared/src/osapi-countsem.c
+++ b/src/os/shared/src/osapi-countsem.c
@@ -90,7 +90,7 @@ int32 OS_CountSemCreate(osal_id_t *sem_id, const char *sem_name, uint32 sem_init
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check for NULL pointers */
     if (sem_id == NULL || sem_name == NULL)
@@ -133,7 +133,7 @@ int32 OS_CountSemCreate(osal_id_t *sem_id, const char *sem_name, uint32 sem_init
 int32 OS_CountSemDelete(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_EXCLUSIVE, LOCAL_OBJID_TYPE, sem_id, &local_id, &record);
@@ -160,7 +160,7 @@ int32 OS_CountSemDelete(osal_id_t sem_id)
 int32 OS_CountSemGive(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -185,7 +185,7 @@ int32 OS_CountSemGive(osal_id_t sem_id)
 int32 OS_CountSemTake(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -209,7 +209,7 @@ int32 OS_CountSemTake(osal_id_t sem_id)
 int32 OS_CountSemTimedWait(osal_id_t sem_id, uint32 msecs)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -255,7 +255,7 @@ int32 OS_CountSemGetIdByName(osal_id_t *sem_id, const char *sem_name)
 int32 OS_CountSemGetInfo(osal_id_t sem_id, OS_count_sem_prop_t *count_prop)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check parameters */

--- a/src/os/shared/src/osapi-dir.c
+++ b/src/os/shared/src/osapi-dir.c
@@ -113,7 +113,7 @@ int32 OS_DirectoryOpen(osal_id_t *dir_id, const char *path)
 {
     char                local_path[OS_MAX_LOCAL_PATH_LEN];
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     if (dir_id == NULL || path == NULL)
@@ -154,7 +154,7 @@ int32 OS_DirectoryOpen(osal_id_t *dir_id, const char *path)
 int32 OS_DirectoryClose(osal_id_t dir_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Make sure the file descriptor is legit before using it */
@@ -181,7 +181,7 @@ int32 OS_DirectoryClose(osal_id_t dir_id)
 int32 OS_DirectoryRead(osal_id_t dir_id, os_dirent_t *dirent)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     if (dirent == NULL)
@@ -223,7 +223,7 @@ int32 OS_DirectoryRead(osal_id_t dir_id, os_dirent_t *dirent)
 int32 OS_DirectoryRewind(osal_id_t dir_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Make sure the file descriptor is legit before using it */

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -90,7 +90,7 @@ int32 OS_FileAPI_Init(void)
 int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access)
 {
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *record;
     char                local_path[OS_MAX_LOCAL_PATH_LEN];
 
@@ -228,7 +228,7 @@ int32 OS_open(const char *path, int32 access, uint32 mode)
 int32 OS_close(osal_id_t filedes)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Make sure the file descriptor is legit before using it */
@@ -253,10 +253,10 @@ int32 OS_close(osal_id_t filedes)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimedRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_TimedRead(osal_id_t filedes, void *buffer, size_t nbytes, int32 timeout)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -283,10 +283,10 @@ int32 OS_TimedRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, size_t nbytes, int32 timeout)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -313,7 +313,7 @@ int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, uint32 nbytes, int32 
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_read(osal_id_t filedes, void *buffer, uint32 nbytes)
+int32 OS_read(osal_id_t filedes, void *buffer, size_t nbytes)
 {
     return OS_TimedRead(filedes, buffer, nbytes, OS_PEND);
 } /* end OS_read */
@@ -326,7 +326,7 @@ int32 OS_read(osal_id_t filedes, void *buffer, uint32 nbytes)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_write(osal_id_t filedes, const void *buffer, uint32 nbytes)
+int32 OS_write(osal_id_t filedes, const void *buffer, size_t nbytes)
 {
     return OS_TimedWrite(filedes, buffer, nbytes, OS_PEND);
 } /* end OS_write */
@@ -394,7 +394,7 @@ int32 OS_stat(const char *path, os_fstat_t *filestats)
 int32 OS_lseek(osal_id_t filedes, int32 offset, uint32 whence)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Make sure the file descriptor is legit before using it */
@@ -441,10 +441,10 @@ int32 OS_remove(const char *path)
  *-----------------------------------------------------------------*/
 int32 OS_rename(const char *old, const char *new)
 {
-    int   i;
-    int32 return_code;
-    char  old_path[OS_MAX_LOCAL_PATH_LEN];
-    char  new_path[OS_MAX_LOCAL_PATH_LEN];
+    osal_index_t i;
+    int32        return_code;
+    char         old_path[OS_MAX_LOCAL_PATH_LEN];
+    char         new_path[OS_MAX_LOCAL_PATH_LEN];
 
     return_code = OS_TranslatePath(old, old_path);
     if (return_code == OS_SUCCESS)
@@ -583,7 +583,7 @@ int32 OS_mv(const char *src, const char *dest)
 int32 OS_FDGetInfo(osal_id_t filedes, OS_file_prop_t *fd_prop)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check parameters */
@@ -618,8 +618,8 @@ int32 OS_FDGetInfo(osal_id_t filedes, OS_file_prop_t *fd_prop)
  *-----------------------------------------------------------------*/
 int32 OS_FileOpenCheck(const char *Filename)
 {
-    int32  return_code;
-    uint32 i;
+    int32        return_code;
+    osal_index_t i;
 
     if (Filename == NULL)
     {
@@ -656,9 +656,9 @@ int32 OS_FileOpenCheck(const char *Filename)
  *-----------------------------------------------------------------*/
 int32 OS_CloseFileByName(const char *Filename)
 {
-    int32  return_code;
-    int32  close_code;
-    uint32 i;
+    int32        return_code;
+    int32        close_code;
+    osal_index_t i;
 
     if (Filename == NULL)
     {
@@ -703,9 +703,9 @@ int32 OS_CloseFileByName(const char *Filename)
  *-----------------------------------------------------------------*/
 int32 OS_CloseAllFiles(void)
 {
-    int32  return_code;
-    int32  close_code;
-    uint32 i;
+    int32        return_code;
+    int32        close_code;
+    osal_index_t i;
 
     return_code = OS_SUCCESS;
 

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -74,7 +74,7 @@ const char OS_FILESYS_RAMDISK_VOLNAME_PREFIX[] = "RAM";
  *  Returns: true if the entry matches, false if it does not match
  *
  *-----------------------------------------------------------------*/
-bool OS_FileSys_FindVirtMountPoint(void *ref, uint32 local_id, const OS_common_record_t *obj)
+bool OS_FileSys_FindVirtMountPoint(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     OS_filesys_internal_record_t *rec    = &OS_filesys_table[local_id];
     const char *                  target = (const char *)ref;
@@ -101,13 +101,13 @@ bool OS_FileSys_FindVirtMountPoint(void *ref, uint32 local_id, const OS_common_r
  *  Returns: OS_SUCCESS on creating the disk, or appropriate error code.
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fsvolname, uint32 blocksize,
-                            uint32 numblocks, bool should_format)
+int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fsvolname, size_t blocksize,
+                            osal_blockcount_t numblocks, bool should_format)
 {
     OS_common_record_t *          global;
     OS_filesys_internal_record_t *local;
     int32                         return_code;
-    uint32                        local_id;
+    osal_index_t                  local_id;
 
     /*
     ** Check parameters
@@ -229,7 +229,7 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
     OS_common_record_t *          global;
     OS_filesys_internal_record_t *local;
     int32                         return_code;
-    uint32                        local_id;
+    osal_index_t                  local_id;
     const char *                  dev_name;
 
     /*
@@ -316,7 +316,7 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_mkfs(char *address, const char *devname, const char *volname, uint32 blocksize, uint32 numblocks)
+int32 OS_mkfs(char *address, const char *devname, const char *volname, size_t blocksize, osal_blockcount_t numblocks)
 {
     int32 return_code;
 
@@ -349,7 +349,7 @@ int32 OS_mkfs(char *address, const char *devname, const char *volname, uint32 bl
 int32 OS_rmfs(const char *devname)
 {
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *global;
 
     if (devname == NULL)
@@ -402,7 +402,7 @@ int32 OS_rmfs(const char *devname)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_initfs(char *address, const char *devname, const char *volname, uint32 blocksize, uint32 numblocks)
+int32 OS_initfs(char *address, const char *devname, const char *volname, size_t blocksize, osal_blockcount_t numblocks)
 {
     int32 return_code;
 
@@ -435,7 +435,7 @@ int32 OS_initfs(char *address, const char *devname, const char *volname, uint32 
 int32 OS_mount(const char *devname, const char *mountpoint)
 {
     int32                         return_code;
-    uint32                        local_id;
+    osal_index_t                  local_id;
     OS_common_record_t *          global;
     OS_filesys_internal_record_t *local;
 
@@ -511,7 +511,7 @@ int32 OS_mount(const char *devname, const char *mountpoint)
 int32 OS_unmount(const char *mountpoint)
 {
     int32                         return_code;
-    uint32                        local_id;
+    osal_index_t                  local_id;
     OS_common_record_t *          global;
     OS_filesys_internal_record_t *local;
 
@@ -582,7 +582,7 @@ int32 OS_fsBlocksFree(const char *name)
 {
     int32               return_code;
     OS_statvfs_t        statfs;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *global;
 
     if (name == NULL)
@@ -633,7 +633,7 @@ int32 OS_fsBytesFree(const char *name, uint64 *bytes_free)
 {
     int32               return_code;
     OS_statvfs_t        statfs;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *global;
 
     if (name == NULL || bytes_free == NULL)
@@ -682,7 +682,7 @@ int32 OS_fsBytesFree(const char *name, uint64 *bytes_free)
  *-----------------------------------------------------------------*/
 int32 OS_chkfs(const char *name, bool repair)
 {
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
     OS_common_record_t *global;
 
@@ -729,7 +729,7 @@ int32 OS_chkfs(const char *name, bool repair)
  *-----------------------------------------------------------------*/
 int32 OS_FS_GetPhysDriveName(char *PhysDriveName, const char *MountPoint)
 {
-    uint32                        local_id;
+    osal_index_t                  local_id;
     int32                         return_code;
     OS_common_record_t *          global;
     OS_filesys_internal_record_t *local;
@@ -783,7 +783,7 @@ int32 OS_FS_GetPhysDriveName(char *PhysDriveName, const char *MountPoint)
  *-----------------------------------------------------------------*/
 int32 OS_GetFsInfo(os_fsinfo_t *filesys_info)
 {
-    int i;
+    osal_index_t idx;
 
     /*
     ** Check to see if the file pointers are NULL
@@ -800,9 +800,9 @@ int32 OS_GetFsInfo(os_fsinfo_t *filesys_info)
 
     OS_Lock_Global(OS_OBJECT_TYPE_OS_STREAM);
 
-    for (i = 0; i < OS_MAX_NUM_OPEN_FILES; i++)
+    for (idx = 0; idx < OS_MAX_NUM_OPEN_FILES; idx++)
     {
-        if (!OS_ObjectIdDefined(OS_global_stream_table[i].active_id))
+        if (!OS_ObjectIdDefined(OS_global_stream_table[idx].active_id))
         {
             filesys_info->FreeFds++;
         }
@@ -812,9 +812,9 @@ int32 OS_GetFsInfo(os_fsinfo_t *filesys_info)
 
     OS_Lock_Global(OS_OBJECT_TYPE_OS_FILESYS);
 
-    for (i = 0; i < OS_MAX_FILE_SYSTEMS; i++)
+    for (idx = 0; idx < OS_MAX_FILE_SYSTEMS; idx++)
     {
-        if (!OS_ObjectIdDefined(OS_global_filesys_table[i].active_id))
+        if (!OS_ObjectIdDefined(OS_global_filesys_table[idx].active_id))
         {
             filesys_info->FreeVolumes++;
         }
@@ -835,7 +835,7 @@ int32 OS_GetFsInfo(os_fsinfo_t *filesys_info)
  *-----------------------------------------------------------------*/
 int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
 {
-    uint32                        local_id;
+    osal_index_t                  local_id;
     int32                         return_code;
     const char *                  name_ptr;
     OS_common_record_t *          global;

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -132,7 +132,7 @@ int32 OS_ObjectIdInit(void)
  *  Purpose: Local helper routine, not part of OSAL API.
  *
  *-----------------------------------------------------------------*/
-uint32 OS_GetMaxForObjectType(uint32 idtype)
+uint32 OS_GetMaxForObjectType(osal_objtype_t idtype)
 {
     switch (idtype)
     {
@@ -172,7 +172,7 @@ uint32 OS_GetMaxForObjectType(uint32 idtype)
  *  Purpose: Local helper routine, not part of OSAL API.
  *
  *-----------------------------------------------------------------*/
-uint32 OS_GetBaseForObjectType(uint32 idtype)
+uint32 OS_GetBaseForObjectType(osal_objtype_t idtype)
 {
     switch (idtype)
     {
@@ -224,7 +224,7 @@ uint32 OS_GetBaseForObjectType(uint32 idtype)
  *  returns: true if match, false otherwise
  *
  *-----------------------------------------------------------------*/
-bool OS_ObjectNameMatch(void *ref, uint32 local_id, const OS_common_record_t *obj)
+bool OS_ObjectNameMatch(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     return (obj->name_entry != NULL && strcmp((const char *)ref, obj->name_entry) == 0);
 } /* end OS_ObjectNameMatch */
@@ -245,7 +245,7 @@ bool OS_ObjectNameMatch(void *ref, uint32 local_id, const OS_common_record_t *ob
  *   lock type requested (lock_mode).
  *
  *-----------------------------------------------------------------*/
-void OS_ObjectIdInitiateLock(OS_lock_mode_t lock_mode, uint32 idtype)
+void OS_ObjectIdInitiateLock(OS_lock_mode_t lock_mode, osal_objtype_t idtype)
 {
     if (lock_mode != OS_LOCK_MODE_NONE)
     {
@@ -291,7 +291,8 @@ void OS_ObjectIdInitiateLock(OS_lock_mode_t lock_mode, uint32 idtype)
  *         all lock modes other than OS_LOCK_MODE_NONE.
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t reference_id, OS_common_record_t *obj)
+int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, osal_objtype_t idtype, osal_id_t reference_id,
+                             OS_common_record_t *obj)
 {
     int32  return_code    = OS_ERROR;
     uint32 exclusive_bits = 0;
@@ -420,11 +421,11 @@ int32 OS_ObjectIdConvertLock(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t 
  *  returns: OS_ERR_NAME_NOT_FOUND if not found, OS_SUCCESS if match is found
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdSearch(uint32 idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg, OS_common_record_t **record)
+int32 OS_ObjectIdSearch(osal_objtype_t idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg, OS_common_record_t **record)
 {
     int32               return_code;
     uint32              obj_count;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *obj;
 
     return_code = OS_ERR_NAME_NOT_FOUND;
@@ -475,7 +476,7 @@ int32 OS_ObjectIdSearch(uint32 idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg
  *
  *  returns: OS_SUCCESS if an empty location was found.
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdFindNext(uint32 idtype, uint32 *array_index, OS_common_record_t **record)
+int32 OS_ObjectIdFindNext(osal_objtype_t idtype, osal_index_t *array_index, OS_common_record_t **record)
 {
     uint32              max_id;
     uint32              base_id;
@@ -537,7 +538,7 @@ int32 OS_ObjectIdFindNext(uint32 idtype, uint32 *array_index, OS_common_record_t
 
     if (array_index != NULL)
     {
-        *array_index = local_id;
+        *array_index = OSAL_INDEX_C(local_id);
     }
     if (record != NULL)
     {
@@ -561,7 +562,7 @@ int32 OS_ObjectIdFindNext(uint32 idtype, uint32 *array_index, OS_common_record_t
 
     Purpose: Locks the global table identified by "idtype"
  ------------------------------------------------------------------*/
-void OS_Lock_Global(uint32 idtype)
+void OS_Lock_Global(osal_objtype_t idtype)
 {
     int32               return_code;
     osal_id_t           self_task_id;
@@ -622,7 +623,7 @@ void OS_Lock_Global(uint32 idtype)
 
     Purpose: Unlocks the global table identified by "idtype"
  ------------------------------------------------------------------*/
-void OS_Unlock_Global(uint32 idtype)
+void OS_Unlock_Global(osal_objtype_t idtype)
 {
     int32               return_code;
     osal_id_t           self_task_id;
@@ -695,8 +696,8 @@ void OS_Unlock_Global(uint32 idtype)
  *-----------------------------------------------------------------*/
 int32 OS_ObjectIdFinalizeNew(int32 operation_status, OS_common_record_t *record, osal_id_t *outid)
 {
-    uint32    idtype = OS_ObjectIdToType_Impl(record->active_id);
-    osal_id_t callback_id;
+    osal_objtype_t idtype = OS_ObjectIdToType_Impl(record->active_id);
+    osal_id_t      callback_id;
 
     /* if operation was unsuccessful, then clear
      * the active_id field within the record, so
@@ -750,8 +751,8 @@ int32 OS_ObjectIdFinalizeNew(int32 operation_status, OS_common_record_t *record,
  ------------------------------------------------------------------*/
 int32 OS_ObjectIdFinalizeDelete(int32 operation_status, OS_common_record_t *record)
 {
-    uint32    idtype = OS_ObjectIdToType_Impl(record->active_id);
-    osal_id_t callback_id;
+    osal_objtype_t idtype = OS_ObjectIdToType_Impl(record->active_id);
+    osal_id_t      callback_id;
 
     /* Clear the OSAL ID if successful - this returns the record to the pool */
     if (operation_status == OS_SUCCESS)
@@ -790,7 +791,7 @@ int32 OS_ObjectIdFinalizeDelete(int32 operation_status, OS_common_record_t *reco
  *  returns: OS_ERR_NAME_NOT_FOUND if not found, OS_SUCCESS if match is found
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
+int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
                              OS_common_record_t **record)
 {
     int32               return_code;
@@ -836,7 +837,8 @@ int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectM
  *  returns: OS_ERR_NAME_NOT_FOUND if not found, OS_SUCCESS if match is found
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, uint32 idtype, const char *name, OS_common_record_t **record)
+int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, osal_objtype_t idtype, const char *name,
+                           OS_common_record_t **record)
 {
     return OS_ObjectIdGetBySearch(lock_mode, idtype, OS_ObjectNameMatch, (void *)name, record);
 
@@ -853,7 +855,7 @@ int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, uint32 idtype, const char *
  *  returns: OS_ERR_NAME_NOT_FOUND if not found, OS_SUCCESS if match is found
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdFindByName(uint32 idtype, const char *name, osal_id_t *object_id)
+int32 OS_ObjectIdFindByName(osal_objtype_t idtype, const char *name, osal_id_t *object_id)
 {
     int32               return_code;
     OS_common_record_t *global;
@@ -900,7 +902,7 @@ int32 OS_ObjectIdFindByName(uint32 idtype, const char *name, osal_id_t *object_i
  *           If this returns something other than OS_SUCCESS then the global is NOT locked.
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t id, uint32 *array_index,
+int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, osal_objtype_t idtype, osal_id_t id, osal_index_t *array_index,
                          OS_common_record_t **record)
 {
     int32 return_code;
@@ -955,8 +957,8 @@ int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, uint32 idtype, osal_id_t id, 
  *-----------------------------------------------------------------*/
 int32 OS_ObjectIdRefcountDecr(OS_common_record_t *record)
 {
-    int32  return_code;
-    uint32 idtype = OS_ObjectIdToType_Impl(record->active_id);
+    int32          return_code;
+    osal_objtype_t idtype = OS_ObjectIdToType_Impl(record->active_id);
 
     if (idtype == 0 || !OS_ObjectIdDefined(record->active_id))
     {
@@ -1012,7 +1014,8 @@ int32 OS_ObjectIdRefcountDecr(OS_common_record_t *record)
  *             manipulate the global lock at all.
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_index, OS_common_record_t **record)
+int32 OS_ObjectIdAllocateNew(osal_objtype_t idtype, const char *name, osal_index_t *array_index,
+                             OS_common_record_t **record)
 {
     int32 return_code;
 
@@ -1079,7 +1082,7 @@ int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_inde
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ConvertToArrayIndex(osal_id_t object_id, uint32 *ArrayIndex)
+int32 OS_ConvertToArrayIndex(osal_id_t object_id, osal_index_t *ArrayIndex)
 {
     /* just pass to the generic internal conversion routine */
     return OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_UNDEFINED, object_id, ArrayIndex);
@@ -1095,7 +1098,7 @@ int32 OS_ConvertToArrayIndex(osal_id_t object_id, uint32 *ArrayIndex)
  *-----------------------------------------------------------------*/
 void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg)
 {
-    uint32 idtype;
+    osal_objtype_t idtype;
 
     for (idtype = 0; idtype < OS_OBJECT_TYPE_USER; ++idtype)
     {
@@ -1111,11 +1114,12 @@ void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void 
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-void OS_ForEachObjectOfType(uint32 idtype, osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg)
+void OS_ForEachObjectOfType(osal_objtype_t idtype, osal_id_t creator_id, OS_ArgCallback_t callback_ptr,
+                            void *callback_arg)
 {
-    uint32    obj_index;
-    uint32    obj_max;
-    osal_id_t obj_id;
+    osal_index_t obj_index;
+    uint32       obj_max;
+    osal_id_t    obj_id;
 
     obj_max = OS_GetMaxForObjectType(idtype);
     if (obj_max > 0)
@@ -1170,7 +1174,7 @@ void OS_ForEachObjectOfType(uint32 idtype, osal_id_t creator_id, OS_ArgCallback_
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-uint32 OS_IdentifyObject(osal_id_t object_id)
+osal_objtype_t OS_IdentifyObject(osal_id_t object_id)
 {
     return OS_ObjectIdToType_Impl(object_id);
 } /* end OS_IdentifyObject */
@@ -1183,13 +1187,13 @@ uint32 OS_IdentifyObject(osal_id_t object_id)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_GetResourceName(osal_id_t object_id, char *buffer, uint32 buffer_size)
+int32 OS_GetResourceName(osal_id_t object_id, char *buffer, size_t buffer_size)
 {
-    uint32              idtype;
+    osal_objtype_t      idtype;
     OS_common_record_t *record;
     int32               return_code;
-    uint32              name_len;
-    uint32              local_id;
+    size_t              name_len;
+    osal_index_t        local_id;
 
     /* sanity check the passed-in buffer and size */
     if (buffer == NULL || buffer_size == 0)
@@ -1241,12 +1245,12 @@ int32 OS_GetResourceName(osal_id_t object_id, char *buffer, uint32 buffer_size)
  *           Otherwise OS_SUCCESS is returned.
  *
  *-----------------------------------------------------------------*/
-int32 OS_ObjectIdToArrayIndex(uint32 idtype, osal_id_t object_id, uint32 *ArrayIndex)
+int32 OS_ObjectIdToArrayIndex(osal_objtype_t idtype, osal_id_t object_id, osal_index_t *ArrayIndex)
 {
-    uint32 max_id;
-    uint32 obj_index;
-    uint32 actual_type;
-    int32  return_code;
+    uint32         max_id;
+    uint32         obj_index;
+    osal_objtype_t actual_type;
+    int32          return_code;
 
     obj_index   = OS_ObjectIdToSerialNumber_Impl(object_id);
     actual_type = OS_ObjectIdToType_Impl(object_id);
@@ -1269,7 +1273,7 @@ int32 OS_ObjectIdToArrayIndex(uint32 idtype, osal_id_t object_id, uint32 *ArrayI
         else
         {
             return_code = OS_SUCCESS;
-            *ArrayIndex = obj_index % max_id;
+            *ArrayIndex = OSAL_INDEX_C(obj_index % max_id);
         }
     }
 

--- a/src/os/shared/src/osapi-module.c
+++ b/src/os/shared/src/osapi-module.c
@@ -184,7 +184,7 @@ int32 OS_ModuleLoad(osal_id_t *module_id, const char *module_name, const char *f
     char                translated_path[OS_MAX_LOCAL_PATH_LEN];
     int32               return_code;
     int32               filename_status;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *record;
 
     /*
@@ -282,7 +282,7 @@ int32 OS_ModuleUnload(osal_id_t module_id)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_EXCLUSIVE, LOCAL_OBJID_TYPE, module_id, &local_id, &record);
     if (return_code == OS_SUCCESS)
@@ -316,7 +316,7 @@ int32 OS_ModuleInfo(osal_id_t module_id, OS_module_prop_t *module_prop)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check parameters */
     if (module_prop == NULL)
@@ -402,7 +402,7 @@ int32 OS_ModuleSymbolLookup(osal_id_t module_id, cpuaddr *symbol_address, const 
     int32               return_code;
     int32               staticsym_status;
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /*
     ** Check parameters
@@ -447,7 +447,7 @@ int32 OS_ModuleSymbolLookup(osal_id_t module_id, cpuaddr *symbol_address, const 
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SymbolTableDump(const char *filename, uint32 SizeLimit)
+int32 OS_SymbolTableDump(const char *filename, size_t SizeLimit)
 {
     int32 return_code;
     char  translated_path[OS_MAX_LOCAL_PATH_LEN];

--- a/src/os/shared/src/osapi-mutex.c
+++ b/src/os/shared/src/osapi-mutex.c
@@ -90,7 +90,7 @@ int32 OS_MutSemCreate(osal_id_t *sem_id, const char *sem_name, uint32 options)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check for NULL pointers */
     if (sem_id == NULL || sem_name == NULL)
@@ -133,7 +133,7 @@ int32 OS_MutSemCreate(osal_id_t *sem_id, const char *sem_name, uint32 options)
 int32 OS_MutSemDelete(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_EXCLUSIVE, LOCAL_OBJID_TYPE, sem_id, &local_id, &record);
@@ -160,7 +160,7 @@ int32 OS_MutSemDelete(osal_id_t sem_id)
 int32 OS_MutSemGive(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
     osal_id_t           self_task;
 
@@ -198,7 +198,7 @@ int32 OS_MutSemGive(osal_id_t sem_id)
 int32 OS_MutSemTake(osal_id_t sem_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
     osal_id_t           self_task;
 
@@ -262,7 +262,7 @@ int32 OS_MutSemGetInfo(osal_id_t sem_id, OS_mut_sem_prop_t *mut_prop)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check parameters */
     if (mut_prop == NULL)

--- a/src/os/shared/src/osapi-network.c
+++ b/src/os/shared/src/osapi-network.c
@@ -63,7 +63,7 @@ int32 OS_NetworkAPI_Init(void)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_NetworkGetHostName(char *host_name, uint32 name_len)
+int32 OS_NetworkGetHostName(char *host_name, size_t name_len)
 {
     uint32 return_code;
 

--- a/src/os/shared/src/osapi-printf.c
+++ b/src/os/shared/src/osapi-printf.c
@@ -78,7 +78,7 @@ int32 OS_ConsoleAPI_Init(void)
 {
     OS_console_internal_record_t *console;
     int32                         return_code;
-    uint32                        local_id;
+    osal_index_t                  local_id;
     OS_common_record_t *          record;
 
     memset(&OS_console_table, 0, sizeof(OS_console_table));
@@ -137,10 +137,10 @@ int32 OS_ConsoleAPI_Init(void)
  *    Either the entire string should be written, or none of it.
  *
  *-----------------------------------------------------------------*/
-static int32 OS_Console_CopyOut(OS_console_internal_record_t *console, const char *Str, uint32 *NextWritePos)
+static int32 OS_Console_CopyOut(OS_console_internal_record_t *console, const char *Str, size_t *NextWritePos)
 {
     const char *pmsg;
-    uint32      WriteOffset;
+    size_t      WriteOffset;
     int32       return_code;
 
     return_code = OS_ERROR;
@@ -193,9 +193,9 @@ int32 OS_ConsoleWrite(osal_id_t console_id, const char *Str)
 {
     int32                         return_code;
     OS_common_record_t *          record;
-    uint32                        local_id;
+    osal_index_t                  local_id;
     OS_console_internal_record_t *console;
-    uint32                        PendingWritePos;
+    size_t                        PendingWritePos;
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, OS_OBJECT_TYPE_OS_CONSOLE, console_id, &local_id, &record);
     if (return_code == OS_SUCCESS)

--- a/src/os/shared/src/osapi-queue.c
+++ b/src/os/shared/src/osapi-queue.c
@@ -87,11 +87,12 @@ int32 OS_QueueAPI_Init(void)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueCreate(osal_id_t *queue_id, const char *queue_name, uint32 queue_depth, uint32 data_size, uint32 flags)
+int32 OS_QueueCreate(osal_id_t *queue_id, const char *queue_name, osal_blockcount_t queue_depth, size_t data_size,
+                     uint32 flags)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     if (queue_name == NULL || queue_id == NULL)
     {
@@ -140,7 +141,7 @@ int32 OS_QueueCreate(osal_id_t *queue_id, const char *queue_name, uint32 queue_d
 int32 OS_QueueDelete(osal_id_t queue_id)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_EXCLUSIVE, LOCAL_OBJID_TYPE, queue_id, &local_id, &record);
@@ -164,10 +165,10 @@ int32 OS_QueueDelete(osal_id_t queue_id)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGet(osal_id_t queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+int32 OS_QueueGet(osal_id_t queue_id, void *data, size_t size, size_t *size_copied, int32 timeout)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -206,10 +207,10 @@ int32 OS_QueueGet(osal_id_t queue_id, void *data, uint32 size, uint32 *size_copi
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueuePut(osal_id_t queue_id, const void *data, uint32 size, uint32 flags)
+int32 OS_QueuePut(osal_id_t queue_id, const void *data, size_t size, uint32 flags)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -264,7 +265,7 @@ int32 OS_QueueGetInfo(osal_id_t queue_id, OS_queue_prop_t *queue_prop)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check parameters */
     if (queue_prop == NULL)

--- a/src/os/shared/src/osapi-select.c
+++ b/src/os/shared/src/osapi-select.c
@@ -61,7 +61,7 @@
 int32 OS_SelectSingle(osal_id_t objid, uint32 *StateFlags, int32 msecs)
 {
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
     OS_common_record_t *record;
 
     if (StateFlags == NULL)
@@ -126,8 +126,8 @@ int32 OS_SelectFdZero(OS_FdSet *Set)
  *-----------------------------------------------------------------*/
 int32 OS_SelectFdAdd(OS_FdSet *Set, osal_id_t objid)
 {
-    int32  return_code;
-    uint32 local_id;
+    int32        return_code;
+    osal_index_t local_id;
 
     if (Set == NULL)
         return OS_INVALID_POINTER;
@@ -151,8 +151,8 @@ int32 OS_SelectFdAdd(OS_FdSet *Set, osal_id_t objid)
  *-----------------------------------------------------------------*/
 int32 OS_SelectFdClear(OS_FdSet *Set, osal_id_t objid)
 {
-    int32  return_code;
-    uint32 local_id;
+    int32        return_code;
+    osal_index_t local_id;
 
     if (Set == NULL)
         return OS_INVALID_POINTER;
@@ -176,8 +176,8 @@ int32 OS_SelectFdClear(OS_FdSet *Set, osal_id_t objid)
  *-----------------------------------------------------------------*/
 bool OS_SelectFdIsSet(OS_FdSet *Set, osal_id_t objid)
 {
-    int32  return_code;
-    uint32 local_id;
+    int32        return_code;
+    osal_index_t local_id;
 
     if (Set == NULL)
         return false;

--- a/src/os/shared/src/osapi-shell.c
+++ b/src/os/shared/src/osapi-shell.c
@@ -53,7 +53,7 @@
 int32 OS_ShellOutputToFile(const char *Cmd, osal_id_t filedes)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -84,9 +84,9 @@ int32 OS_SocketAPI_Init(void)
  *  Purpose: Local helper routine, not part of OSAL API.
  *
  *-----------------------------------------------------------------*/
-void OS_CreateSocketName(uint32 local_id, const OS_SockAddr_t *Addr, const char *parent_name)
+void OS_CreateSocketName(osal_index_t local_id, const OS_SockAddr_t *Addr, const char *parent_name)
 {
-    int32                        len;
+    size_t                       len;
     uint16                       port;
     OS_stream_internal_record_t *sock = &OS_stream_table[local_id];
 
@@ -122,7 +122,7 @@ int32 OS_SocketOpen(osal_id_t *sock_id, OS_SocketDomain_t Domain, OS_SocketType_
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check for NULL pointers */
     if (sock_id == NULL)
@@ -160,7 +160,7 @@ int32 OS_SocketOpen(osal_id_t *sock_id, OS_SocketDomain_t Domain, OS_SocketType_
 int32 OS_SocketBind(osal_id_t sock_id, const OS_SockAddr_t *Addr)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -214,8 +214,8 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
 {
     OS_common_record_t *record;
     OS_common_record_t *connrecord;
-    uint32              local_id;
-    uint32              conn_id = 0;
+    osal_index_t        local_id;
+    osal_index_t        conn_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -232,6 +232,7 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
      * set to OS_SUCCESS when connrecord is also initialized)
      */
     connrecord = NULL;
+    conn_id    = OSAL_INDEX_C(0);
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_REFCOUNT, LOCAL_OBJID_TYPE, sock_id, &local_id, &record);
     if (return_code == OS_SUCCESS)
@@ -310,7 +311,7 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
 int32 OS_SocketConnect(osal_id_t sock_id, const OS_SockAddr_t *Addr, int32 Timeout)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -364,10 +365,10 @@ int32 OS_SocketConnect(osal_id_t sock_id, const OS_SockAddr_t *Addr, int32 Timeo
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
+int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -407,10 +408,10 @@ int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockA
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr)
+int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check Parameters */
@@ -470,7 +471,7 @@ int32 OS_SocketGetIdByName(osal_id_t *sock_id, const char *sock_name)
 int32 OS_SocketGetInfo(osal_id_t sock_id, OS_socket_prop_t *sock_prop)
 {
     OS_common_record_t *record;
-    uint32              local_id;
+    osal_index_t        local_id;
     int32               return_code;
 
     /* Check parameters */
@@ -520,7 +521,7 @@ int32 OS_SocketAddrInit(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SocketAddrToString(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr)
+int32 OS_SocketAddrToString(char *buffer, size_t buflen, const OS_SockAddr_t *Addr)
 {
     if (Addr == NULL || buffer == NULL || buflen == 0)
     {

--- a/src/os/shared/src/osapi-time.c
+++ b/src/os/shared/src/osapi-time.c
@@ -94,10 +94,11 @@ static int32 OS_DoTimerAdd(osal_id_t *timer_id, const char *timer_name, osal_id_
     OS_common_record_t *         record;
     OS_timecb_internal_record_t *local;
     int32                        return_code;
-    uint32                       local_id;
-    uint32                       timebase_local_id;
+    osal_objtype_t               objtype;
+    osal_index_t                 local_id;
+    osal_index_t                 timebase_local_id;
     osal_id_t                    cb_list;
-    uint32                       attach_id;
+    osal_index_t                 attach_id;
 
     /*
      ** Check Parameters
@@ -128,8 +129,8 @@ static int32 OS_DoTimerAdd(osal_id_t *timer_id, const char *timer_name, osal_id_
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -313,7 +314,8 @@ int32 OS_TimerSet(osal_id_t timer_id, uint32 start_time, uint32 interval_time)
     OS_common_record_t *         record;
     OS_timecb_internal_record_t *local;
     int32                        return_code;
-    uint32                       local_id;
+    osal_objtype_t               objtype;
+    osal_index_t                 local_id;
     osal_id_t                    dedicated_timebase_id;
 
     dedicated_timebase_id = OS_OBJECT_ID_UNDEFINED;
@@ -332,8 +334,8 @@ int32 OS_TimerSet(osal_id_t timer_id, uint32 start_time, uint32 interval_time)
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -393,7 +395,8 @@ int32 OS_TimerDelete(osal_id_t timer_id)
     OS_common_record_t *         record;
     OS_common_record_t *         timebase = NULL;
     int32                        return_code;
-    uint32                       local_id;
+    osal_objtype_t               objtype;
+    osal_index_t                 local_id;
     osal_id_t                    dedicated_timebase_id;
 
     dedicated_timebase_id = OS_OBJECT_ID_UNDEFINED;
@@ -402,8 +405,8 @@ int32 OS_TimerDelete(osal_id_t timer_id)
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -483,8 +486,8 @@ int32 OS_TimerDelete(osal_id_t timer_id)
  *-----------------------------------------------------------------*/
 int32 OS_TimerGetIdByName(osal_id_t *timer_id, const char *timer_name)
 {
-    int32  return_code;
-    uint32 local_id;
+    int32          return_code;
+    osal_objtype_t objtype;
 
     if (timer_id == NULL || timer_name == NULL)
     {
@@ -495,8 +498,8 @@ int32 OS_TimerGetIdByName(osal_id_t *timer_id, const char *timer_name)
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -518,7 +521,8 @@ int32 OS_TimerGetInfo(osal_id_t timer_id, OS_timer_prop_t *timer_prop)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
+    osal_objtype_t      objtype;
 
     /* Check parameters */
     if (timer_prop == NULL)
@@ -530,8 +534,8 @@ int32 OS_TimerGetInfo(osal_id_t timer_id, OS_timer_prop_t *timer_prop)
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }

--- a/src/os/shared/src/osapi-timebase.c
+++ b/src/os/shared/src/osapi-timebase.c
@@ -100,7 +100,8 @@ int32 OS_TimeBaseCreate(osal_id_t *timer_id, const char *timebase_name, OS_Timer
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_objtype_t      objtype;
+    osal_index_t        local_id;
 
     /*
      * Specifying a NULL sync function means the timebase is not externally synchronized.
@@ -128,8 +129,8 @@ int32 OS_TimeBaseCreate(osal_id_t *timer_id, const char *timebase_name, OS_Timer
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -175,7 +176,8 @@ int32 OS_TimeBaseSet(osal_id_t timer_id, uint32 start_time, uint32 interval_time
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_objtype_t      objtype;
+    osal_index_t        local_id;
 
     /*
      * Internally the implementation represents the interval as a
@@ -194,8 +196,8 @@ int32 OS_TimeBaseSet(osal_id_t timer_id, uint32 start_time, uint32 interval_time
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -235,14 +237,15 @@ int32 OS_TimeBaseDelete(osal_id_t timer_id)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_objtype_t      objtype;
+    osal_index_t        local_id;
 
     /*
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -269,8 +272,8 @@ int32 OS_TimeBaseDelete(osal_id_t timer_id)
  *-----------------------------------------------------------------*/
 int32 OS_TimeBaseGetIdByName(osal_id_t *timer_id, const char *timebase_name)
 {
-    int32  return_code;
-    uint32 local_id;
+    int32          return_code;
+    osal_objtype_t objtype;
 
     if (timer_id == NULL || timebase_name == NULL)
     {
@@ -281,8 +284,8 @@ int32 OS_TimeBaseGetIdByName(osal_id_t *timer_id, const char *timebase_name)
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -304,7 +307,8 @@ int32 OS_TimeBaseGetInfo(osal_id_t timebase_id, OS_timebase_prop_t *timebase_pro
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_objtype_t      objtype;
+    osal_index_t        local_id;
 
     /* Check parameters */
     if (timebase_prop == NULL)
@@ -316,8 +320,8 @@ int32 OS_TimeBaseGetInfo(osal_id_t timebase_id, OS_timebase_prop_t *timebase_pro
      * Check our context.  Not allowed to use the timer API from a timer callback.
      * Just interested in the object type returned.
      */
-    local_id = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
-    if (local_id == OS_OBJECT_TYPE_OS_TIMEBASE)
+    objtype = OS_ObjectIdToType_Impl(OS_TaskGetId_Impl());
+    if (objtype == OS_OBJECT_TYPE_OS_TIMEBASE)
     {
         return OS_ERR_INCORRECT_OBJ_STATE;
     }
@@ -353,7 +357,7 @@ int32 OS_TimeBaseGetFreeRun(osal_id_t timebase_id, uint32 *freerun_val)
 {
     OS_common_record_t *record;
     int32               return_code;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     /* Check parameters */
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, LOCAL_OBJID_TYPE, timebase_id, &local_id, &record);
@@ -390,9 +394,9 @@ void OS_TimeBase_CallbackThread(osal_id_t timebase_id)
     OS_timebase_internal_record_t *timebase;
     OS_timecb_internal_record_t *  timecb;
     OS_common_record_t *           record;
-    uint32                         local_id;
-    uint32                         timer_id;
-    uint32                         curr_cb_local_id;
+    osal_index_t                   local_id;
+    osal_index_t                   timer_id;
+    osal_index_t                   curr_cb_local_id;
     osal_id_t                      curr_cb_public_id;
     uint32                         tick_time;
     uint32                         spin_cycles;

--- a/src/os/vxworks/inc/os-impl-io.h
+++ b/src/os/vxworks/inc/os-impl-io.h
@@ -38,7 +38,7 @@ typedef struct
 {
     int  fd;
     bool selectable;
-} OS_VxWorks_filehandle_entry_t;
+} OS_impl_file_internal_record_t;
 
 /*
  * The global file handle table.
@@ -46,7 +46,7 @@ typedef struct
  * This table is shared across multiple units (files, sockets, etc) and they will share
  * the same file handle table from the basic file I/O.
  */
-extern OS_VxWorks_filehandle_entry_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+extern OS_impl_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
 
 /*
  * VxWorks needs to cast the argument to "write()" to avoid a warning.

--- a/src/os/vxworks/inc/os-impl-symtab.h
+++ b/src/os/vxworks/inc/os-impl-symtab.h
@@ -33,8 +33,8 @@
 
 typedef struct
 {
-    uint32 Sizelimit;
-    uint32 CurrSize;
+    size_t Sizelimit;
+    size_t CurrSize;
     int32  StatusCode;
     int    fd;
 } SymbolDumpState_t;

--- a/src/os/vxworks/inc/os-vxworks.h
+++ b/src/os/vxworks/inc/os-vxworks.h
@@ -92,14 +92,14 @@ int32 OS_VxWorks_DirAPI_Impl_Init(void);
 int OS_VxWorks_TaskEntry(int arg);
 int OS_VxWorks_ConsoleTask_Entry(int arg);
 
-uint32 OS_VxWorks_SigWait(uint32 local_id);
+uint32 OS_VxWorks_SigWait(osal_index_t local_id);
 int    OS_VxWorks_TimeBaseTask(int arg);
-void   OS_VxWorks_RegisterTimer(uint32 local_id);
+void   OS_VxWorks_RegisterTimer(osal_index_t local_id);
 void   OS_VxWorks_UsecToTimespec(uint32 usecs, struct timespec *time_spec);
 
 int32 OS_VxWorks_GenericSemTake(SEM_ID vxid, int sys_ticks);
 int32 OS_VxWorks_GenericSemGive(SEM_ID vxid);
 
-int32 OS_VxWorks_TableMutex_Init(uint32 idtype);
+int32 OS_VxWorks_TableMutex_Init(osal_objtype_t idtype);
 
 #endif /* INCLUDE_OS_VXWORKS_H_ */

--- a/src/os/vxworks/src/os-impl-binsem.c
+++ b/src/os/vxworks/src/os-impl-binsem.c
@@ -70,7 +70,7 @@ int32 OS_VxWorks_BinSemAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options)
+int32 OS_BinSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options)
 {
     SEM_ID tmp_sem_id;
 
@@ -98,7 +98,7 @@ int32 OS_BinSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 optio
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemDelete_Impl(uint32 sem_id)
+int32 OS_BinSemDelete_Impl(osal_index_t sem_id)
 {
     /*
      * As the memory for the sem is statically allocated, delete is a no-op.
@@ -116,7 +116,7 @@ int32 OS_BinSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemGive_Impl(uint32 sem_id)
+int32 OS_BinSemGive_Impl(osal_index_t sem_id)
 {
     /* Use common routine */
     return OS_VxWorks_GenericSemGive(OS_impl_bin_sem_table[sem_id].vxid);
@@ -130,7 +130,7 @@ int32 OS_BinSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemFlush_Impl(uint32 sem_id)
+int32 OS_BinSemFlush_Impl(osal_index_t sem_id)
 {
     /* Flush VxWorks Semaphore */
     if (semFlush(OS_impl_bin_sem_table[sem_id].vxid) != OK)
@@ -150,7 +150,7 @@ int32 OS_BinSemFlush_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemTake_Impl(uint32 sem_id)
+int32 OS_BinSemTake_Impl(osal_index_t sem_id)
 {
     /* Use common routine */
     return OS_VxWorks_GenericSemTake(OS_impl_bin_sem_table[sem_id].vxid, WAIT_FOREVER);
@@ -165,7 +165,7 @@ int32 OS_BinSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
+int32 OS_BinSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs)
 {
     int   ticks;
     int32 status;
@@ -188,7 +188,7 @@ int32 OS_BinSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_BinSemGetInfo_Impl(uint32 sem_id, OS_bin_sem_prop_t *bin_prop)
+int32 OS_BinSemGetInfo_Impl(osal_index_t sem_id, OS_bin_sem_prop_t *bin_prop)
 {
     /* VxWorks has no API for obtaining the current value of a semaphore */
     return OS_SUCCESS;

--- a/src/os/vxworks/src/os-impl-common.c
+++ b/src/os/vxworks/src/os-impl-common.c
@@ -60,7 +60,7 @@ static TASK_ID OS_idle_task_id;
  *           about objects
  *
  *-----------------------------------------------------------------*/
-int32 OS_API_Impl_Init(uint32 idtype)
+int32 OS_API_Impl_Init(osal_objtype_t idtype)
 {
     int32 return_code;
 

--- a/src/os/vxworks/src/os-impl-console.c
+++ b/src/os/vxworks/src/os-impl-console.c
@@ -66,7 +66,7 @@ OS_impl_console_internal_record_t OS_impl_console_table[OS_MAX_CONSOLES];
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_ConsoleWakeup_Impl(uint32 local_id)
+void OS_ConsoleWakeup_Impl(osal_index_t local_id)
 {
     OS_impl_console_internal_record_t *local = &OS_impl_console_table[local_id];
 
@@ -94,7 +94,7 @@ void OS_ConsoleWakeup_Impl(uint32 local_id)
  *-----------------------------------------------------------------*/
 int OS_VxWorks_ConsoleTask_Entry(int arg)
 {
-    uint32                             local_id = arg;
+    osal_index_t                       local_id = OSAL_INDEX_C(arg);
     OS_impl_console_internal_record_t *local;
 
     local = &OS_impl_console_table[local_id];
@@ -119,7 +119,7 @@ int OS_VxWorks_ConsoleTask_Entry(int arg)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ConsoleCreate_Impl(uint32 local_id)
+int32 OS_ConsoleCreate_Impl(osal_index_t local_id)
 {
     OS_impl_console_internal_record_t *local = &OS_impl_console_table[local_id];
     int32                              return_code;

--- a/src/os/vxworks/src/os-impl-countsem.c
+++ b/src/os/vxworks/src/os-impl-countsem.c
@@ -69,7 +69,7 @@ int32 OS_VxWorks_CountSemAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 options)
+int32 OS_CountSemCreate_Impl(osal_index_t sem_id, uint32 sem_initial_value, uint32 options)
 {
     SEM_ID tmp_sem_id;
 
@@ -97,7 +97,7 @@ int32 OS_CountSemCreate_Impl(uint32 sem_id, uint32 sem_initial_value, uint32 opt
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemDelete_Impl(uint32 sem_id)
+int32 OS_CountSemDelete_Impl(osal_index_t sem_id)
 {
     /*
      * As the memory for the sem is statically allocated, delete is a no-op.
@@ -115,7 +115,7 @@ int32 OS_CountSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemGive_Impl(uint32 sem_id)
+int32 OS_CountSemGive_Impl(osal_index_t sem_id)
 {
     /* Give VxWorks Semaphore */
     return OS_VxWorks_GenericSemGive(OS_impl_count_sem_table[sem_id].vxid);
@@ -129,7 +129,7 @@ int32 OS_CountSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemTake_Impl(uint32 sem_id)
+int32 OS_CountSemTake_Impl(osal_index_t sem_id)
 {
     return OS_VxWorks_GenericSemTake(OS_impl_count_sem_table[sem_id].vxid, WAIT_FOREVER);
 } /* end OS_CountSemTake_Impl */
@@ -142,7 +142,7 @@ int32 OS_CountSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
+int32 OS_CountSemTimedWait_Impl(osal_index_t sem_id, uint32 msecs)
 {
     int   ticks;
     int32 status;
@@ -165,7 +165,7 @@ int32 OS_CountSemTimedWait_Impl(uint32 sem_id, uint32 msecs)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_CountSemGetInfo_Impl(uint32 sem_id, OS_count_sem_prop_t *count_prop)
+int32 OS_CountSemGetInfo_Impl(osal_index_t sem_id, OS_count_sem_prop_t *count_prop)
 {
     /* VxWorks does not provide an API to get the value */
     return OS_SUCCESS;

--- a/src/os/vxworks/src/os-impl-dirs.c
+++ b/src/os/vxworks/src/os-impl-dirs.c
@@ -83,7 +83,7 @@ int32 OS_DirCreate_Impl(const char *local_path, uint32 access)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
+int32 OS_DirOpen_Impl(osal_index_t local_id, const char *local_path)
 {
     OS_impl_dir_table[local_id].dp = opendir(local_path);
     if (OS_impl_dir_table[local_id].dp == NULL)
@@ -101,7 +101,7 @@ int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirClose_Impl(uint32 local_id)
+int32 OS_DirClose_Impl(osal_index_t local_id)
 {
     closedir(OS_impl_dir_table[local_id].dp);
     OS_impl_dir_table[local_id].dp = NULL;
@@ -116,7 +116,7 @@ int32 OS_DirClose_Impl(uint32 local_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
+int32 OS_DirRead_Impl(osal_index_t local_id, os_dirent_t *dirent)
 {
     struct dirent *de;
 
@@ -149,7 +149,7 @@ int32 OS_DirRead_Impl(uint32 local_id, os_dirent_t *dirent)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_DirRewind_Impl(uint32 local_id)
+int32 OS_DirRewind_Impl(osal_index_t local_id)
 {
     rewinddir(OS_impl_dir_table[local_id].dp);
     return OS_SUCCESS;

--- a/src/os/vxworks/src/os-impl-files.c
+++ b/src/os/vxworks/src/os-impl-files.c
@@ -38,7 +38,7 @@
  *
  * This is shared by all OSAL entities that perform low-level I/O.
  */
-OS_VxWorks_filehandle_entry_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+OS_impl_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
 
 /*----------------------------------------------------------------
  *
@@ -49,7 +49,7 @@ OS_VxWorks_filehandle_entry_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
  *-----------------------------------------------------------------*/
 int32 OS_VxWorks_StreamAPI_Impl_Init(void)
 {
-    uint32 local_id;
+    osal_index_t local_id;
 
     /*
      * init all filehandles to -1, which is always invalid.

--- a/src/os/vxworks/src/os-impl-filesys.c
+++ b/src/os/vxworks/src/os-impl-filesys.c
@@ -76,7 +76,7 @@ OS_impl_filesys_internal_record_t OS_impl_filesys_table[OS_MAX_FILE_SYSTEMS];
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStartVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysStartVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *     local = &OS_filesys_table[filesys_id];
     OS_impl_filesys_internal_record_t *impl  = &OS_impl_filesys_table[filesys_id];
@@ -192,7 +192,7 @@ int32 OS_FileSysStartVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStopVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysStopVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *     local = &OS_filesys_table[filesys_id];
     OS_impl_filesys_internal_record_t *impl  = &OS_impl_filesys_table[filesys_id];
@@ -231,7 +231,7 @@ int32 OS_FileSysStopVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysFormatVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *local       = &OS_filesys_table[filesys_id];
     int32                         return_code = OS_ERR_NOT_IMPLEMENTED;
@@ -282,7 +282,7 @@ int32 OS_FileSysFormatVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysMountVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysMountVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     int32                         status;
@@ -315,7 +315,7 @@ int32 OS_FileSysMountVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id)
+int32 OS_FileSysUnmountVolume_Impl(osal_index_t filesys_id)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     int32                         status;
@@ -355,7 +355,7 @@ int32 OS_FileSysUnmountVolume_Impl(uint32 filesys_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
+int32 OS_FileSysStatVolume_Impl(osal_index_t filesys_id, OS_statvfs_t *result)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     struct statfs                 stat_buf;
@@ -368,9 +368,9 @@ int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
     }
     else
     {
-        result->block_size   = stat_buf.f_bsize;
-        result->blocks_free  = stat_buf.f_bfree;
-        result->total_blocks = stat_buf.f_blocks;
+        result->block_size   = OSAL_SIZE_C(stat_buf.f_bsize);
+        result->blocks_free  = OSAL_BLOCKCOUNT_C(stat_buf.f_bfree);
+        result->total_blocks = OSAL_BLOCKCOUNT_C(stat_buf.f_blocks);
         return_code          = OS_SUCCESS;
     }
 
@@ -386,7 +386,7 @@ int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileSysCheckVolume_Impl(uint32 filesys_id, bool repair)
+int32 OS_FileSysCheckVolume_Impl(osal_index_t filesys_id, bool repair)
 {
     OS_filesys_internal_record_t *local = &OS_filesys_table[filesys_id];
     STATUS                        chk_status;

--- a/src/os/vxworks/src/os-impl-heap.c
+++ b/src/os/vxworks/src/os-impl-heap.c
@@ -57,9 +57,9 @@ int32 OS_HeapGetInfo_Impl(OS_heap_prop_t *heap_prop)
         return OS_ERROR;
     }
 
-    heap_prop->free_bytes         = stats.numBytesFree;
-    heap_prop->free_blocks        = stats.numBlocksFree;
-    heap_prop->largest_free_block = stats.maxBlockSizeFree;
+    heap_prop->free_bytes         = OSAL_SIZE_C(stats.numBytesFree);
+    heap_prop->free_blocks        = OSAL_BLOCKCOUNT_C(stats.numBlocksFree);
+    heap_prop->largest_free_block = OSAL_SIZE_C(stats.maxBlockSizeFree);
 
     return (OS_SUCCESS);
 } /* end OS_HeapGetInfo_Impl */

--- a/src/os/vxworks/src/os-impl-idmap.c
+++ b/src/os/vxworks/src/os-impl-idmap.c
@@ -86,7 +86,7 @@ enum
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(uint32 idtype)
+int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
 {
     VxWorks_GlobalMutex_t *mut;
 
@@ -118,7 +118,7 @@ int32 OS_Lock_Global_Impl(uint32 idtype)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(uint32 idtype)
+int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
 {
     VxWorks_GlobalMutex_t *mut;
 
@@ -154,7 +154,7 @@ int32 OS_Unlock_Global_Impl(uint32 idtype)
  *           about objects
  *
  *-----------------------------------------------------------------*/
-int32 OS_VxWorks_TableMutex_Init(uint32 idtype)
+int32 OS_VxWorks_TableMutex_Init(osal_objtype_t idtype)
 {
     int32  return_code = OS_SUCCESS;
     SEM_ID semid;

--- a/src/os/vxworks/src/os-impl-loader.c
+++ b/src/os/vxworks/src/os-impl-loader.c
@@ -71,7 +71,7 @@ int32 OS_VxWorks_ModuleAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleLoad_Impl(uint32 local_id, const char *translated_path)
+int32 OS_ModuleLoad_Impl(osal_index_t local_id, const char *translated_path)
 {
     int32     return_code;
     int       fd;
@@ -126,7 +126,7 @@ int32 OS_ModuleLoad_Impl(uint32 local_id, const char *translated_path)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleUnload_Impl(uint32 local_id)
+int32 OS_ModuleUnload_Impl(osal_index_t local_id)
 {
     STATUS vxStatus;
 
@@ -152,7 +152,7 @@ int32 OS_ModuleUnload_Impl(uint32 local_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleGetInfo_Impl(uint32 local_id, OS_module_prop_t *module_prop)
+int32 OS_ModuleGetInfo_Impl(osal_index_t local_id, OS_module_prop_t *module_prop)
 {
     MODULE_INFO vxModuleInfo;
     STATUS      vxStatus;

--- a/src/os/vxworks/src/os-impl-mutex.c
+++ b/src/os/vxworks/src/os-impl-mutex.c
@@ -67,7 +67,7 @@ int32 OS_VxWorks_MutexAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options)
+int32 OS_MutSemCreate_Impl(osal_index_t sem_id, uint32 options)
 {
     SEM_ID tmp_sem_id;
 
@@ -93,7 +93,7 @@ int32 OS_MutSemCreate_Impl(uint32 sem_id, uint32 options)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemDelete_Impl(uint32 sem_id)
+int32 OS_MutSemDelete_Impl(osal_index_t sem_id)
 {
     /*
      * As the memory for the sem is statically allocated, delete is a no-op.
@@ -111,7 +111,7 @@ int32 OS_MutSemDelete_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemGive_Impl(uint32 sem_id)
+int32 OS_MutSemGive_Impl(osal_index_t sem_id)
 {
     /* Give VxWorks Semaphore */
     return OS_VxWorks_GenericSemGive(OS_impl_mutex_table[sem_id].vxid);
@@ -125,7 +125,7 @@ int32 OS_MutSemGive_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemTake_Impl(uint32 sem_id)
+int32 OS_MutSemTake_Impl(osal_index_t sem_id)
 {
     /* Take VxWorks Semaphore */
     return OS_VxWorks_GenericSemTake(OS_impl_mutex_table[sem_id].vxid, WAIT_FOREVER);
@@ -139,7 +139,7 @@ int32 OS_MutSemTake_Impl(uint32 sem_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_MutSemGetInfo_Impl(uint32 sem_id, OS_mut_sem_prop_t *mut_prop)
+int32 OS_MutSemGetInfo_Impl(osal_index_t sem_id, OS_mut_sem_prop_t *mut_prop)
 {
     /* VxWorks provides no additional info */
     return OS_SUCCESS;

--- a/src/os/vxworks/src/os-impl-network.c
+++ b/src/os/vxworks/src/os-impl-network.c
@@ -43,7 +43,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_NetworkGetHostName_Impl(char *host_name, uint32 name_len)
+int32 OS_NetworkGetHostName_Impl(char *host_name, size_t name_len)
 {
     int32 return_code;
 

--- a/src/os/vxworks/src/os-impl-queues.c
+++ b/src/os/vxworks/src/os-impl-queues.c
@@ -63,7 +63,7 @@ int32 OS_VxWorks_QueueAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags)
+int32 OS_QueueCreate_Impl(osal_index_t queue_id, uint32 flags)
 {
     MSG_Q_ID tmp_msgq_id;
     int      queue_depth = OS_queue_table[queue_id].max_depth; /* maximum number of messages in queue (queue depth) */
@@ -92,7 +92,7 @@ int32 OS_QueueCreate_Impl(uint32 queue_id, uint32 flags)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueDelete_Impl(uint32 queue_id)
+int32 OS_QueueDelete_Impl(osal_index_t queue_id)
 {
     /* Try to delete the queue */
     if (msgQDelete(OS_impl_queue_table[queue_id].vxid) != OK)
@@ -114,7 +114,7 @@ int32 OS_QueueDelete_Impl(uint32 queue_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+int32 OS_QueueGet_Impl(osal_index_t queue_id, void *data, size_t size, size_t *size_copied, int32 timeout)
 {
     int32  return_code;
     STATUS status;
@@ -159,7 +159,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
     }
     else
     {
-        *size_copied = status;
+        *size_copied = OSAL_SIZE_C(status);
         return_code  = OS_SUCCESS;
     }
 
@@ -174,7 +174,7 @@ int32 OS_QueueGet_Impl(uint32 queue_id, void *data, uint32 size, uint32 *size_co
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 flags)
+int32 OS_QueuePut_Impl(osal_index_t queue_id, const void *data, size_t size, uint32 flags)
 {
     int32 return_code;
 
@@ -204,7 +204,7 @@ int32 OS_QueuePut_Impl(uint32 queue_id, const void *data, uint32 size, uint32 fl
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGetInfo_Impl(uint32 queue_id, OS_queue_prop_t *queue_prop)
+int32 OS_QueueGetInfo_Impl(osal_index_t queue_id, OS_queue_prop_t *queue_prop)
 {
     /* No extra info for queues in the OS implementation */
     return OS_SUCCESS;

--- a/src/os/vxworks/src/os-impl-shell.c
+++ b/src/os/vxworks/src/os-impl-shell.c
@@ -52,13 +52,13 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char *Cmd)
+int32 OS_ShellOutputToFile_Impl(osal_index_t file_id, const char *Cmd)
 {
-    int32     ReturnCode = OS_ERROR;
-    int32     Result;
-    osal_id_t fdCmd;
-    uint32    cmdidx;
-    char *    shellName;
+    int32        ReturnCode = OS_ERROR;
+    int32        Result;
+    osal_id_t    fdCmd;
+    osal_index_t cmdidx;
+    char *       shellName;
 
     /* Create a file to write the command to (or write over the old one) */
     Result =

--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -128,7 +128,7 @@ int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName)
+int32 OS_ModuleSymbolLookup_Impl(osal_index_t local_id, cpuaddr *SymbolAddress, const char *SymbolName)
 {
     /*
      * NOTE: this is currently exactly the same as OS_GlobalSymbolLookup_Impl().
@@ -165,7 +165,7 @@ int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const 
 BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_arg_t arg, SYM_GROUP group)
 {
     SymbolRecord_t     symRecord;
-    uint32             NextSize;
+    size_t             NextSize;
     int                status;
     SymbolDumpState_t *state;
 
@@ -234,7 +234,7 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_SymbolTableDump_Impl(const char *local_filename, uint32 SizeLimit)
+int32 OS_SymbolTableDump_Impl(const char *filename, size_t size_limit)
 {
     SymbolDumpState_t *state;
 
@@ -245,15 +245,15 @@ int32 OS_SymbolTableDump_Impl(const char *local_filename, uint32 SizeLimit)
     state = &OS_VxWorks_SymbolDumpState;
 
     memset(state, 0, sizeof(*state));
-    state->Sizelimit = SizeLimit;
+    state->Sizelimit = size_limit;
 
     /*
     ** Open file
     */
-    state->fd = open(local_filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    state->fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (state->fd < 0)
     {
-        OS_DEBUG("open(%s): error: %s\n", local_filename, strerror(errno));
+        OS_DEBUG("open(%s): error: %s\n", filename, strerror(errno));
         state->StatusCode = OS_ERROR;
     }
     else

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -117,7 +117,7 @@ int32 OS_VxWorks_TaskAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags)
+int32 OS_TaskCreate_Impl(osal_index_t task_id, uint32 flags)
 {
     STATUS                          status;
     int                             vxflags;
@@ -268,7 +268,7 @@ int32 OS_TaskCreate_Impl(uint32 task_id, uint32 flags)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskDelete_Impl(uint32 task_id)
+int32 OS_TaskDelete_Impl(osal_index_t task_id)
 {
     /*
     ** Try to delete the task
@@ -336,7 +336,7 @@ int32 OS_TaskDelay_Impl(uint32 milli_second)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskSetPriority_Impl(uint32 task_id, uint32 new_priority)
+int32 OS_TaskSetPriority_Impl(osal_index_t task_id, osal_priority_t new_priority)
 {
     /* Set VxWorks Task Priority */
     if (taskPrioritySet(OS_impl_task_table[task_id].vxid, new_priority) != OK)
@@ -356,7 +356,7 @@ int32 OS_TaskSetPriority_Impl(uint32 task_id, uint32 new_priority)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskMatch_Impl(uint32 task_id)
+int32 OS_TaskMatch_Impl(osal_index_t task_id)
 {
     /*
     ** Get VxWorks Task Id
@@ -393,7 +393,7 @@ int32 OS_TaskRegister_Impl(osal_id_t global_task_id)
 osal_id_t OS_TaskGetId_Impl(void)
 {
     OS_impl_task_internal_record_t *lrec;
-    size_t                          index;
+    size_t                          idx;
     osal_id_t                       id;
 
     id   = OS_OBJECT_ID_UNDEFINED;
@@ -401,10 +401,10 @@ osal_id_t OS_TaskGetId_Impl(void)
 
     if (lrec != NULL)
     {
-        index = lrec - &OS_impl_task_table[0];
-        if (index < OS_MAX_TASKS)
+        idx = lrec - &OS_impl_task_table[0];
+        if (idx < OS_MAX_TASKS)
         {
-            id = OS_global_task_table[index].active_id;
+            id = OS_global_task_table[idx].active_id;
         }
     }
 
@@ -420,7 +420,7 @@ osal_id_t OS_TaskGetId_Impl(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskGetInfo_Impl(uint32 task_id, OS_task_prop_t *task_prop)
+int32 OS_TaskGetInfo_Impl(osal_index_t task_id, OS_task_prop_t *task_prop)
 {
     return OS_SUCCESS;
 
@@ -434,7 +434,7 @@ int32 OS_TaskGetInfo_Impl(uint32 task_id, OS_task_prop_t *task_prop)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, size_t sysdata_size)
 {
     if (sysdata == NULL || sysdata_size != sizeof(TASK_ID))
     {
@@ -451,7 +451,7 @@ int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+bool OS_TaskIdMatchSystemData_Impl(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     const TASK_ID *target = (const TASK_ID *)ref;
 

--- a/src/os/vxworks/src/os-impl-timebase.c
+++ b/src/os/vxworks/src/os-impl-timebase.c
@@ -501,7 +501,7 @@ int32 OS_TimeBaseCreate_Impl(osal_index_t timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, int32 start_time, int32 interval_time)
+int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, uint32 start_time, uint32 interval_time)
 {
     OS_impl_timebase_internal_record_t *local;
     struct itimerspec                   timeout;

--- a/src/os/vxworks/src/os-impl-timebase.c
+++ b/src/os/vxworks/src/os-impl-timebase.c
@@ -93,7 +93,7 @@ static uint32 OS_ClockAccuracyNsec;
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_TimeBaseLock_Impl(uint32 local_id)
+void OS_TimeBaseLock_Impl(osal_index_t local_id)
 {
     semTake(OS_impl_timebase_table[local_id].handler_mutex, WAIT_FOREVER);
 } /* end OS_TimeBaseLock_Impl */
@@ -106,7 +106,7 @@ void OS_TimeBaseLock_Impl(uint32 local_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void OS_TimeBaseUnlock_Impl(uint32 local_id)
+void OS_TimeBaseUnlock_Impl(osal_index_t local_id)
 {
     semGive(OS_impl_timebase_table[local_id].handler_mutex);
 } /* end OS_TimeBaseUnlock_Impl */
@@ -140,7 +140,7 @@ void OS_VxWorks_UsecToTimespec(uint32 usecs, struct timespec *time_spec)
  *           Blocks the calling task until the timer tick arrives
  *
  *-----------------------------------------------------------------*/
-uint32 OS_VxWorks_SigWait(uint32 local_id)
+uint32 OS_VxWorks_SigWait(osal_index_t local_id)
 {
     OS_impl_timebase_internal_record_t *local;
     OS_common_record_t *                global;
@@ -204,7 +204,7 @@ uint32 OS_VxWorks_SigWait(uint32 local_id)
  *  Purpose: Local helper routine, not part of OSAL API.
  *
  *-----------------------------------------------------------------*/
-void OS_VxWorks_RegisterTimer(uint32 local_id)
+void OS_VxWorks_RegisterTimer(osal_index_t local_id)
 {
     OS_impl_timebase_internal_record_t *local;
     struct sigevent                     evp;
@@ -253,7 +253,7 @@ void OS_VxWorks_RegisterTimer(uint32 local_id)
 int OS_VxWorks_TimeBaseTask(int arg)
 {
     VxWorks_ID_Buffer_t id;
-    uint32              local_id;
+    osal_index_t        local_id;
 
     id.arg = arg;
     if (OS_ConvertToArrayIndex(id.id, &local_id) == OS_SUCCESS)
@@ -323,7 +323,7 @@ int32 OS_VxWorks_TimeBaseAPI_Impl_Init(void)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
+int32 OS_TimeBaseCreate_Impl(osal_index_t timer_id)
 {
     /*
      * The tick_sem is a simple semaphore posted by the ISR and taken by the
@@ -334,6 +334,7 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
     OS_common_record_t *                global;
     int                                 signo;
     sigset_t                            inuse;
+    osal_index_t                        idx;
     uint32                              i;
     VxWorks_ID_Buffer_t                 idbuf;
 
@@ -367,13 +368,13 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
          */
         sigemptyset(&inuse);
 
-        for (i = 0; i < OS_MAX_TIMEBASES; ++i)
+        for (idx = 0; idx < OS_MAX_TIMEBASES; ++idx)
         {
-            if (OS_ObjectIdDefined(OS_global_timebase_table[i].active_id) &&
-                OS_impl_timebase_table[i].assigned_signal > 0)
+            if (OS_ObjectIdDefined(OS_global_timebase_table[idx].active_id) &&
+                OS_impl_timebase_table[idx].assigned_signal > 0)
             {
                 /* mark signal as in-use */
-                sigaddset(&inuse, OS_impl_timebase_table[i].assigned_signal);
+                sigaddset(&inuse, OS_impl_timebase_table[idx].assigned_signal);
             }
         }
 
@@ -500,7 +501,7 @@ int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseSet_Impl(uint32 timer_id, int32 start_time, int32 interval_time)
+int32 OS_TimeBaseSet_Impl(osal_index_t timer_id, int32 start_time, int32 interval_time)
 {
     OS_impl_timebase_internal_record_t *local;
     struct itimerspec                   timeout;
@@ -588,7 +589,7 @@ int32 OS_TimeBaseSet_Impl(uint32 timer_id, int32 start_time, int32 interval_time
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseDelete_Impl(uint32 timer_id)
+int32 OS_TimeBaseDelete_Impl(osal_index_t timer_id)
 {
     OS_impl_timebase_internal_record_t *local;
     int32                               return_code;
@@ -622,7 +623,7 @@ int32 OS_TimeBaseDelete_Impl(uint32 timer_id)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TimeBaseGetInfo_Impl(uint32 timer_id, OS_timebase_prop_t *timer_prop)
+int32 OS_TimeBaseGetInfo_Impl(osal_index_t timer_id, OS_timebase_prop_t *timer_prop)
 {
     return OS_SUCCESS;
 

--- a/src/tests/bin-sem-flush-test/bin-sem-flush-test.c
+++ b/src/tests/bin-sem-flush-test/bin-sem-flush-test.c
@@ -222,13 +222,16 @@ void BinSemFlushSetup(void)
     /*
     ** Create the tasks
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, task_1_stack, TASK_STACK_SIZE, TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_STACKPTR_C(task_1_stack), sizeof(task_1_stack),
+                           OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
-    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, task_2_stack, TASK_STACK_SIZE, TASK_2_PRIORITY, 0);
+    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, OSAL_STACKPTR_C(task_2_stack), sizeof(task_2_stack),
+                           OSAL_PRIORITY_C(TASK_2_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 2 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_2_id), (int)status);
 
-    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, task_3_stack, TASK_STACK_SIZE, TASK_3_PRIORITY, 0);
+    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, OSAL_STACKPTR_C(task_3_stack), sizeof(task_3_stack),
+                           OSAL_PRIORITY_C(TASK_3_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 3 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_3_id), (int)status);
 
     /*

--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -224,7 +224,8 @@ void BinSemSetup(void)
     /*
     ** Create the "consumer" task.
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, task_1_stack, TASK_1_STACK_SIZE, TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_STACKPTR_C(task_1_stack), sizeof(task_1_stack),
+                           OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
     /*

--- a/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
+++ b/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
@@ -220,7 +220,8 @@ void BinSemTimeoutSetup(void)
     /*
     ** Create the "consumer" task.
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, task_1_stack, TASK_1_STACK_SIZE, TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_STACKPTR_C(task_1_stack), sizeof(task_1_stack),
+                           OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
     /*

--- a/src/tests/count-sem-test/count-sem-test.c
+++ b/src/tests/count-sem-test/count-sem-test.c
@@ -191,13 +191,16 @@ void CountSemSetup(void)
     /*
     ** Create the tasks
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, task_1_stack, TASK_STACK_SIZE, TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_STACKPTR_C(task_1_stack), sizeof(task_1_stack),
+                           OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
-    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, task_2_stack, TASK_STACK_SIZE, TASK_2_PRIORITY, 0);
+    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, OSAL_STACKPTR_C(task_2_stack), sizeof(task_2_stack),
+                           OSAL_PRIORITY_C(TASK_2_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 2 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_2_id), (int)status);
 
-    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, task_3_stack, TASK_STACK_SIZE, TASK_3_PRIORITY, 0);
+    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, OSAL_STACKPTR_C(task_3_stack), sizeof(task_3_stack),
+                           OSAL_PRIORITY_C(TASK_3_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 3 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_3_id), (int)status);
 
     /*

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -89,7 +89,7 @@ void TestMkfsMount(void)
     int32 status;
 
     /* Make the file system */
-    status = OS_mkfs(0, "/ramdev0", "RAM", 512, 200);
+    status = OS_mkfs(0, "/ramdev0", "RAM", OSAL_SIZE_C(512), OSAL_BLOCKCOUNT_C(200));
     UtAssert_True(status == OS_SUCCESS, "status after mkfs = %d", (int)status);
 
     status = OS_mount("/ramdev0", "/drive0");
@@ -249,8 +249,8 @@ void TestReadWriteLseek(void)
     char      copyofbuffer[30];
     char      seekbuffer[30];
     char      newbuffer[30];
-    int       offset;
-    int       size;
+    size_t    offset;
+    size_t    size;
     int32     status;
     osal_id_t fd;
 
@@ -274,7 +274,7 @@ void TestReadWriteLseek(void)
 
     /* test write portion of R/W mode */
     status = OS_write(fd, (void *)buffer, size);
-    UtAssert_True(status == size, "status after write = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write = %d size = %lu", (int)status, (unsigned long)size);
 
     strcpy(buffer, "");
 
@@ -284,7 +284,7 @@ void TestReadWriteLseek(void)
 
     /*Read what we wrote to the file */
     status = OS_read(fd, (void *)buffer, size);
-    UtAssert_True(status == size, "status after read = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after read = %d size = %lu", (int)status, (unsigned long)size);
     if (status >= OS_SUCCESS)
     {
         UtAssert_True(strcmp(buffer, copyofbuffer) == 0, "Read: %s, Written: %s", buffer, copyofbuffer);
@@ -305,7 +305,7 @@ void TestReadWriteLseek(void)
     /* try to read in READ ONLY MODE */
 
     status = OS_read(fd, (void *)buffer, size);
-    UtAssert_True(status == size, "status after read = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after read = %d size = %lu", (int)status, (unsigned long)size);
     if (status >= OS_SUCCESS)
     {
         UtAssert_True(strcmp(buffer, copyofbuffer) == 0, "Read: %s, Written: %s", buffer, copyofbuffer);
@@ -317,8 +317,9 @@ void TestReadWriteLseek(void)
 
     /* now try to read out only the last chars of the file */
 
-    status = OS_read(fd, (void *)newbuffer, (size - offset));
-    UtAssert_True(status == (size - offset), "status after read = %d size = %d", (int)status, (int)(size - offset));
+    status = OS_read(fd, (void *)newbuffer, OSAL_SIZE_C(size - offset));
+    UtAssert_True(status == (size - offset), "status after read = %d size = %lu", (int)status,
+                  (unsigned long)(size - offset));
     if (status >= OS_SUCCESS)
     {
         UtAssert_True(strncmp(newbuffer, seekbuffer, size - offset) == 0, "Read: %s, Written: %s", newbuffer,
@@ -335,7 +336,7 @@ void TestReadWriteLseek(void)
 
     /* test write in WRITE ONLY mode */
     status = OS_write(fd, (void *)buffer, size);
-    UtAssert_True(status == size, "status after write = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write = %d size = %lu", (int)status, (unsigned long)size);
 
     /* try to read in WRITE ONLY MODE */
     status = OS_read(fd, (void *)buffer, size);
@@ -346,7 +347,7 @@ void TestReadWriteLseek(void)
     UtAssert_True(status >= OS_SUCCESS, "status after lseek = %d", (int)status);
 
     /* now try to read out only the last chars of the file */
-    status = OS_read(fd, (void *)newbuffer, (size - offset));
+    status = OS_read(fd, (void *)newbuffer, OSAL_SIZE_C(size - offset));
     UtAssert_True(status < OS_SUCCESS, "status after read = %d", (int)status);
 
     /* close the file */
@@ -374,7 +375,7 @@ void TestMkRmDirFreeBytes(void)
     char      copybuffer2[OS_MAX_PATH_LEN];
     osal_id_t fd1;
     osal_id_t fd2;
-    int       size;
+    size_t    size;
 
     /* make the directory names for testing, as well as the filenames and the buffers
      * to put in the files */
@@ -410,11 +411,11 @@ void TestMkRmDirFreeBytes(void)
     /* write the propper buffers into each of the files */
     size   = strlen(buffer1);
     status = OS_write(fd1, buffer1, size);
-    UtAssert_True(status == size, "status after write 1 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write 1 = %d size = %lu", (int)status, (unsigned long)size);
 
     size   = strlen(buffer2);
     status = OS_write(fd2, buffer2, size);
-    UtAssert_True(status == size, "status after write 2 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write 2 = %d size = %lu", (int)status, (unsigned long)size);
 
     /* lseek back to the beginning of the file */
     status = OS_lseek(fd1, 0, 0);
@@ -431,7 +432,7 @@ void TestMkRmDirFreeBytes(void)
     /* read back out of the files what we wrote into them */
     size   = strlen(copybuffer1);
     status = OS_read(fd1, (void *)buffer1, size);
-    UtAssert_True(status == size, "status after read 1 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after read 1 = %d size = %lu", (int)status, (unsigned long)size);
     if (status >= OS_SUCCESS)
     {
         UtAssert_True(strncmp(buffer1, copybuffer1, size) == 0, "Read: %s, Written: %s", buffer1, copybuffer1);
@@ -439,7 +440,7 @@ void TestMkRmDirFreeBytes(void)
 
     size   = strlen(copybuffer2);
     status = OS_read(fd2, (void *)buffer2, size);
-    UtAssert_True(status == size, "status after read 2 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after read 2 = %d size = %lu", (int)status, (unsigned long)size);
     if (status >= OS_SUCCESS)
     {
         UtAssert_True(strncmp(buffer2, copybuffer2, size) == 0, "Read: %s, Written: %s", buffer1, copybuffer1);
@@ -481,7 +482,7 @@ void TestOpenReadCloseDir(void)
     char        dir2[OS_MAX_PATH_LEN];
     char        buffer1[OS_MAX_PATH_LEN];
     char        buffer2[OS_MAX_PATH_LEN];
-    int         size;
+    size_t      size;
     osal_id_t   fd1;
     osal_id_t   fd2;
     osal_id_t   dirh;
@@ -516,11 +517,11 @@ void TestOpenReadCloseDir(void)
     /* write the proper buffers into each of the files */
     size   = strlen(buffer1);
     status = OS_write(fd1, buffer1, size);
-    UtAssert_True(status == size, "status after write 1 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write 1 = %d size = %lu", (int)status, (unsigned long)size);
 
     size   = strlen(buffer2);
     status = OS_write(fd2, buffer2, size);
-    UtAssert_True(status == size, "status after write 2 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write 2 = %d size = %lu", (int)status, (unsigned long)size);
 
     /* close the files */
 
@@ -690,7 +691,7 @@ void TestRename(void)
     char newfilename1[OS_MAX_PATH_LEN];
 
     osal_id_t fd1;
-    int       size;
+    size_t    size;
 
     /* make the directory names for testing, as well as the filenames and the buffers
      * to put in the files */
@@ -719,7 +720,7 @@ void TestRename(void)
 
     size   = strlen(buffer1);
     status = OS_write(fd1, buffer1, size);
-    UtAssert_True(status == size, "status after write 1 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write 1 = %d size = %lu", (int)status, (unsigned long)size);
 
     /* close the file */
 
@@ -745,7 +746,7 @@ void TestRename(void)
 
     size   = strlen(copybuffer1);
     status = OS_read(fd1, buffer1, size);
-    UtAssert_True(status == size, "status after read 1 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after read 1 = %d size = %lu", (int)status, (unsigned long)size);
     if (status >= OS_SUCCESS)
     {
         UtAssert_True(strncmp(buffer1, copybuffer1, size) == 0, "Read and Written Results are equal");
@@ -775,7 +776,7 @@ void TestStat(void)
     char       buffer1[OS_MAX_PATH_LEN];
     os_fstat_t StatBuff;
     osal_id_t  fd1;
-    int        size;
+    size_t     size;
 
     strcpy(dir1, "/drive0/DirectoryName");
     strcpy(dir1slash, dir1);
@@ -795,7 +796,7 @@ void TestStat(void)
 
     size   = strlen(buffer1);
     status = OS_write(fd1, buffer1, size);
-    UtAssert_True(status == size, "status after write 1 = %d size = %d", (int)status, (int)size);
+    UtAssert_True(status == size, "status after write 1 = %d size = %lu", (int)status, (unsigned long)size);
 
     status = OS_close(fd1);
     UtAssert_True(status == OS_SUCCESS, "status after close 1 = %d", (int)status);

--- a/src/tests/idmap-api-test/idmap-api-test.c
+++ b/src/tests/idmap-api-test/idmap-api-test.c
@@ -109,9 +109,10 @@ void TestIdMapApi_Setup(void)
     /*
      * Create all allowed objects
      */
-    status = OS_TaskCreate(&task_id, "Task", Test_Void_Fn, NULL, 4096, 50, 0);
+    status = OS_TaskCreate(&task_id, "Task", Test_Void_Fn, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(4096),
+                           OSAL_PRIORITY_C(50), 0);
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate() (%ld) == OS_SUCCESS", (long)status);
-    status = OS_QueueCreate(&queue_id, "Queue", 5, 5, 0);
+    status = OS_QueueCreate(&queue_id, "Queue", OSAL_BLOCKCOUNT_C(5), OSAL_SIZE_C(5), 0);
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate() (%ld) == OS_SUCCESS", (long)status);
     status = OS_CountSemCreate(&count_sem_id, "CountSem", 1, 0);
     UtAssert_True(status == OS_SUCCESS, "OS_CountSemCreate() (%ld) == OS_SUCCESS", (long)status);
@@ -141,9 +142,9 @@ void TestIdMapApi(void)
 {
     int32                  expected;
     int32                  actual;
-    uint32                 TestArrayIndex;
-    uint32                 TestMutex1Index;
-    uint32                 TestMutex2Index;
+    osal_index_t           TestArrayIndex;
+    osal_index_t           TestMutex1Index;
+    osal_index_t           TestMutex2Index;
     osal_id_t              badid;
     Test_OS_ObjTypeCount_t Count;
 

--- a/src/tests/mutex-test/mutex-test.c
+++ b/src/tests/mutex-test/mutex-test.c
@@ -259,13 +259,16 @@ void MutexSetup(void)
     /*
     ** Create the tasks
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, task_1_stack, TASK_STACK_SIZE, TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_STACKPTR_C(task_1_stack), sizeof(task_1_stack),
+                           OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
-    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, task_2_stack, TASK_STACK_SIZE, TASK_2_PRIORITY, 0);
+    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, OSAL_STACKPTR_C(task_2_stack), sizeof(task_2_stack),
+                           OSAL_PRIORITY_C(TASK_2_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 2 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_2_id), (int)status);
 
-    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, task_3_stack, TASK_STACK_SIZE, TASK_3_PRIORITY, 0);
+    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, OSAL_STACKPTR_C(task_3_stack), sizeof(task_3_stack),
+                           OSAL_PRIORITY_C(TASK_3_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 3 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_3_id), (int)status);
 
     /*

--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -266,43 +266,43 @@ void TestDatagramNetworkApi(void)
 
     /* OS_SocketSendTo */
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketSendTo(p1_socket_id, NULL, 0, NULL);
+    actual   = OS_SocketSendTo(p1_socket_id, NULL, OSAL_SIZE_C(0), NULL);
     UtAssert_True(actual == expected, "OS_SocketSendTo(NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketSendTo(p1_socket_id, NULL, 1, &p2_addr);
+    actual   = OS_SocketSendTo(p1_socket_id, NULL, OSAL_SIZE_C(1), &p2_addr);
     UtAssert_True(actual == expected, "OS_SocketSendTo() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_ERR_INVALID_ID;
     objid    = OS_ObjectIdFromInteger(0xFFFFFFFF);
-    actual   = OS_SocketSendTo(objid, &Buf1, 1, &p2_addr);
+    actual   = OS_SocketSendTo(objid, &Buf1, sizeof(Buf1), &p2_addr);
     UtAssert_True(actual == expected, "OS_SocketSendTo() (%ld) == OS_ERR_INVALID_ID", (long)actual);
 
     /* OS_SocketRecvFrom */
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketRecvFrom(p2_socket_id, NULL, 1, NULL, 100);
+    actual   = OS_SocketRecvFrom(p2_socket_id, NULL, OSAL_SIZE_C(1), NULL, 100);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketRecvFrom(p2_socket_id, NULL, 0, NULL, 0);
+    actual   = OS_SocketRecvFrom(p2_socket_id, NULL, OSAL_SIZE_C(0), NULL, 0);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom(NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_ERR_INVALID_ID;
     objid    = OS_ObjectIdFromInteger(0xFFFFFFFF);
-    actual   = OS_SocketRecvFrom(objid, &Buf2, 1, &l_addr, 100);
+    actual   = OS_SocketRecvFrom(objid, &Buf2, sizeof(Buf2), &l_addr, 100);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() (%ld) == OS_ERR_INVALID_ID", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketRecvFrom(p2_socket_id, &Buf2, 0, &l_addr, 100);
+    actual   = OS_SocketRecvFrom(p2_socket_id, &Buf2, OSAL_SIZE_C(0), &l_addr, 100);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketRecvFrom(p2_socket_id, &Buf2, 0, NULL, 100);
+    actual   = OS_SocketRecvFrom(p2_socket_id, &Buf2, OSAL_SIZE_C(0), NULL, 100);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     /* OS_SocketAddrToString */
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketAddrToString(NULL, 0, NULL);
+    actual   = OS_SocketAddrToString(NULL, OSAL_SIZE_C(0), NULL);
     UtAssert_True(actual == expected, "OS_SocketAddrToString() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
@@ -310,7 +310,7 @@ void TestDatagramNetworkApi(void)
     UtAssert_True(actual == expected, "OS_SocketAddrToString() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketAddrToString(0, 0, &p2_addr);
+    actual   = OS_SocketAddrToString(NULL, OSAL_SIZE_C(0), &p2_addr);
     UtAssert_True(actual == expected, "OS_SocketAddrToString() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     /* OS_SocketAddrGetPort */
@@ -319,7 +319,7 @@ void TestDatagramNetworkApi(void)
     UtAssert_True(actual == expected, "OS_SocketAddrGetPort() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketAddrGetPort(0, &l_addr);
+    actual   = OS_SocketAddrGetPort(NULL, &l_addr);
     UtAssert_True(actual == expected, "OS_SocketAddrGetPort() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     expected = OS_INVALID_POINTER;
@@ -477,7 +477,8 @@ void TestStreamNetworkApi(void)
      */
 
     /* Create a server task/thread */
-    status = OS_TaskCreate(&s_task_id, "Server", Server_Fn, 0, 16384, 50, 0);
+    status = OS_TaskCreate(&s_task_id, "Server", Server_Fn, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(16384),
+                           OSAL_PRIORITY_C(50), 0);
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate() (%ld) == OS_SUCCESS", (long)status);
 
     /* Connect to a server */

--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -123,8 +123,9 @@ void TestTasks(void)
     for (tasknum = 0; tasknum < (OS_MAX_TASKS + 1); ++tasknum)
     {
         snprintf(taskname, sizeof(taskname), "Task %d", tasknum);
-        status = OS_TaskCreate(&TaskData[tasknum].task_id, taskname, task_generic_no_exit, TaskData[tasknum].task_stack,
-                               TASK_0_STACK_SIZE, (250 - OS_MAX_TASKS) + tasknum, 0);
+        status = OS_TaskCreate(&TaskData[tasknum].task_id, taskname, task_generic_no_exit,
+                               OSAL_STACKPTR_C(TaskData[tasknum].task_stack), sizeof(TaskData[tasknum].task_stack),
+                               OSAL_PRIORITY_C(250 - OS_MAX_TASKS + tasknum), 0);
 
         UtDebug("Create %s Status = %d, Id = %lx\n", taskname, (int)status,
                 OS_ObjectIdToInteger(TaskData[tasknum].task_id));
@@ -161,7 +162,8 @@ void TestTasks(void)
     {
         snprintf(taskname, sizeof(taskname), "Task %d", tasknum);
         status = OS_TaskCreate(&TaskData[tasknum].task_id, taskname, task_generic_with_exit,
-                               TaskData[tasknum].task_stack, TASK_0_STACK_SIZE, (250 - OS_MAX_TASKS) + tasknum, 0);
+                               OSAL_STACKPTR_C(TaskData[tasknum].task_stack), sizeof(TaskData[tasknum].task_stack),
+                               OSAL_PRIORITY_C((250 - OS_MAX_TASKS) + tasknum), 0);
 
         UtDebug("Create %s Status = %d, Id = %lx\n", taskname, (int)status,
                 OS_ObjectIdToInteger(TaskData[tasknum].task_id));
@@ -193,19 +195,23 @@ void TestTasks(void)
 
     InitializeTaskIds();
     /* Create Task 0 again */
-    status = OS_TaskCreate(&task_0_id, "Task 0", task_0, task_0_stack, TASK_0_STACK_SIZE, TASK_0_PRIORITY, 0);
+    status = OS_TaskCreate(&task_0_id, "Task 0", task_0, OSAL_STACKPTR_C(task_0_stack), sizeof(task_0_stack),
+                           OSAL_PRIORITY_C(TASK_0_PRIORITY), 0);
     /*UtDebug("Create Status = %d, Id = %d\n",status,task_0_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate, recreate 0");
 
     /* Try and create another "Task 0", should fail as we already have one named "Task 0" */
-    status = OS_TaskCreate(&task_1_id, "Task 0", task_0, task_0_stack, TASK_0_STACK_SIZE, TASK_0_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 0", task_0, OSAL_STACKPTR_C(task_0_stack), sizeof(task_0_stack),
+                           OSAL_PRIORITY_C(TASK_0_PRIORITY), 0);
     UtAssert_True(status != OS_SUCCESS, "OS_TaskCreate, dupe name 0");
 
-    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, task_2_stack, TASK_2_STACK_SIZE, TASK_2_PRIORITY, 0);
+    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, OSAL_STACKPTR_C(task_2_stack), sizeof(task_2_stack),
+                           OSAL_PRIORITY_C(TASK_2_PRIORITY), 0);
     /*  UtDebug("Create Status = %d, Id = %d\n",status,task_2_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate, recreate 2");
 
-    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, task_3_stack, TASK_3_STACK_SIZE, TASK_3_PRIORITY, 0);
+    status = OS_TaskCreate(&task_3_id, "Task 3", task_3, OSAL_STACKPTR_C(task_3_stack), sizeof(task_3_stack),
+                           OSAL_PRIORITY_C(TASK_3_PRIORITY), 0);
     /*  UtDebug("Create Status = %d, Id = %d\n",status,task_3_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate, recreate 3");
 
@@ -255,7 +261,7 @@ void TestQueues(void)
     for (qnum = 0; qnum < (OS_MAX_QUEUES + 1); ++qnum)
     {
         snprintf(qname, sizeof(qname), "q %d", qnum);
-        status = OS_QueueCreate(&msgq_ids[qnum], qname, MSGQ_DEPTH, MSGQ_SIZE, 0);
+        status = OS_QueueCreate(&msgq_ids[qnum], qname, OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
 
         UtAssert_True((qnum < OS_MAX_QUEUES && status == OS_SUCCESS) || (qnum >= OS_MAX_QUEUES && status != OS_SUCCESS),
                       "OS_QueueCreate, nominal");
@@ -275,20 +281,20 @@ void TestQueues(void)
     /*     Create Some more Queues for trying to get the id by name */
 
     InitializeQIds();
-    status = OS_QueueCreate(&msgq_0, "q 0", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_0, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     /* UtDebug("Status after Creating q 0: %d,%d\n",status,msgq_0);*/
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate, recreate 0");
 
     /* This one should fail */
-    status = OS_QueueCreate(&msgq_1, "q 0", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_1, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     /* UtDebug("Status after Creating q 0 again: %d,%d\n",status,msgq_1); */
     UtAssert_True(status != OS_SUCCESS, "OS_QueueCreate, dupe name 0");
 
-    status = OS_QueueCreate(&msgq_2, "q 2", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_2, "q 2", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     /* UtDebug("Status after Creating q 2: %d,%d\n",status,msgq_2); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate, recreate 2");
 
-    status = OS_QueueCreate(&msgq_3, "q 3", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_3, "q 3", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     /* UtDebug("Status after Creating q 3: %d,%d\n",status,msgq_3); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate, recreate 3");
 
@@ -613,10 +619,11 @@ void TestGetInfos(void)
 
     /* first step is to create an object to to get the properties of */
 
-    status = OS_TaskCreate(&task_0_id, "Task 0", task_0, task_0_stack, TASK_0_STACK_SIZE, TASK_0_PRIORITY, 0);
+    status = OS_TaskCreate(&task_0_id, "Task 0", task_0, OSAL_STACKPTR_C(task_0_stack), sizeof(task_0_stack),
+                           OSAL_PRIORITY_C(TASK_0_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate");
 
-    status = OS_QueueCreate(&msgq_0, "q 0", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_0, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     /* UtDebug("Status after Creating q 0: %d,%d\n",status,msgq_0); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate");
 
@@ -668,10 +675,11 @@ void TestGenericQueries(void)
     TestCallbackState_t State;
     char                ResourceName[OS_MAX_API_NAME];
 
-    status = OS_TaskCreate(&task_0_id, "Task 0", task_0, task_0_stack, TASK_0_STACK_SIZE, TASK_0_PRIORITY, 0);
+    status = OS_TaskCreate(&task_0_id, "Task 0", task_0, OSAL_STACKPTR_C(task_0_stack), sizeof(task_0_stack),
+                           OSAL_PRIORITY_C(TASK_0_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate (%ld) == OS_SUCCESS", (long)status);
 
-    status = OS_QueueCreate(&msgq_0, "q 0", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_0, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate (%ld) == OS_SUCCESS", (long)status);
 
     status = OS_BinSemCreate(&bin_0, "Bin 0", 1, 0);
@@ -711,7 +719,7 @@ void TestGenericQueries(void)
     UtAssert_True(State.NumInvocations >= 4, "State.NumInvocations (%lu) >= 4", (unsigned long)State.NumInvocations);
 
     /* Test the OS_GetResourceName() API function */
-    status = OS_GetResourceName(mut_0, ResourceName, 0);
+    status = OS_GetResourceName(mut_0, ResourceName, OSAL_SIZE_C(0));
     UtAssert_True(status == OS_INVALID_POINTER, "OS_GetResourceName (%lx,%ld) == OS_INVALID_POINTER",
                   OS_ObjectIdToInteger(mut_0), (long)status);
 
@@ -724,7 +732,7 @@ void TestGenericQueries(void)
     UtAssert_True(status == OS_ERR_INVALID_ID, "OS_GetResourceName (%lx,%ld) == OS_ERR_INVALID_ID",
                   OS_ObjectIdToInteger(OS_OBJECT_ID_UNDEFINED), (long)status);
 
-    status = OS_GetResourceName(bin_0, ResourceName, 1);
+    status = OS_GetResourceName(bin_0, ResourceName, OSAL_SIZE_C(1));
     UtAssert_True(status == OS_ERR_NAME_TOO_LONG, "OS_GetResourceName (%lx,%ld) == OS_ERR_NAME_TOO_LONG",
                   OS_ObjectIdToInteger(bin_0), (long)status);
 

--- a/src/tests/queue-timeout-test/queue-timeout-test.c
+++ b/src/tests/queue-timeout-test/queue-timeout-test.c
@@ -65,7 +65,7 @@ void task_1(void)
 {
     int32  status;
     uint32 data_received;
-    uint32 data_size;
+    size_t data_size;
 
     OS_printf("Starting task 1\n");
 
@@ -78,7 +78,7 @@ void task_1(void)
     while (task_1_failures < 20)
     {
 
-        status = OS_QueueGet(msgq_id, (void *)&data_received, MSGQ_SIZE, &data_size, 1000);
+        status = OS_QueueGet(msgq_id, (void *)&data_received, OSAL_SIZE_C(MSGQ_SIZE), &data_size, 1000);
 
         if (status == OS_SUCCESS)
         {
@@ -149,13 +149,14 @@ void QueueTimeoutSetup(void)
     task_1_messages = 0;
     task_1_timeouts = 0;
 
-    status = OS_QueueCreate(&msgq_id, "MsgQ", MSGQ_DEPTH, MSGQ_SIZE, 0);
+    status = OS_QueueCreate(&msgq_id, "MsgQ", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
     UtAssert_True(status == OS_SUCCESS, "MsgQ create Id=%lx Rc=%d", OS_ObjectIdToInteger(msgq_id), (int)status);
 
     /*
     ** Create the "consumer" task.
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, task_1_stack, TASK_1_STACK_SIZE, TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_STACKPTR_C(task_1_stack), sizeof(task_1_stack),
+                           OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
     /*

--- a/src/tests/sem-speed-test/sem-speed-test.c
+++ b/src/tests/sem-speed-test/sem-speed-test.c
@@ -176,10 +176,12 @@ void SemSetup(void)
     /*
     ** Create the tasks
     */
-    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, NULL, 4096, SEMTEST_TASK_PRIORITY, 0);
+    status = OS_TaskCreate(&task_1_id, "Task 1", task_1, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(4096),
+                           OSAL_PRIORITY_C(SEMTEST_TASK_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 1 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_1_id), (int)status);
 
-    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, NULL, 4096, SEMTEST_TASK_PRIORITY, 0);
+    status = OS_TaskCreate(&task_2_id, "Task 2", task_2, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(4096),
+                           OSAL_PRIORITY_C(SEMTEST_TASK_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Task 2 create Id=%lx Rc=%d", OS_ObjectIdToInteger(task_2_id), (int)status);
 
     /* A small delay just to allow the tasks

--- a/src/tests/time-base-api-test/time-base-api-test.c
+++ b/src/tests/time-base-api-test/time-base-api-test.c
@@ -35,7 +35,7 @@
 #include "uttest.h"
 #include "utbsp.h"
 
-static uint32 UT_TimerSync(uint32 timer_id)
+static uint32 UT_TimerSync(osal_index_t timer_id)
 {
     OS_TaskDelay(1);
     return 1;

--- a/src/tests/timer-test/timer-test.c
+++ b/src/tests/timer-test/timer-test.c
@@ -59,9 +59,9 @@ uint32 timer_idlookup[OS_MAX_TIMERS];
  */
 void test_func(osal_id_t timer_id)
 {
-    uint32 indx;
-    OS_ConvertToArrayIndex(timer_id, &indx);
-    timer_counter[timer_idlookup[indx]]++;
+    osal_index_t idx;
+    OS_ConvertToArrayIndex(timer_id, &idx);
+    timer_counter[timer_idlookup[idx]]++;
 }
 
 /* ********************** MAIN **************************** */
@@ -89,8 +89,8 @@ void TimerTestSetup(void)
      * In the new versions of OSAL, timers do NOT work in the "main" thread,
      * so we must create a task to handle them.
      */
-    status = OS_TaskCreate(&TimerTestTaskId, "Task 1", TimerTestTask, TimerTestTaskStack, TASK_1_STACK_SIZE,
-                           TASK_1_PRIORITY, 0);
+    status = OS_TaskCreate(&TimerTestTaskId, "Task 1", TimerTestTask, OSAL_STACKPTR_C(TimerTestTaskStack),
+                           sizeof(TimerTestTaskStack), OSAL_PRIORITY_C(TASK_1_PRIORITY), 0);
     UtAssert_True(status == OS_SUCCESS, "Timer Test Task Created RC=%d", (int)status);
 
     /*
@@ -111,12 +111,12 @@ void TimerTestSetup(void)
 void TimerTestTask(void)
 {
 
-    int       i = 0;
-    int32     TimerStatus[NUMBER_OF_TIMERS];
-    uint32    TableId;
-    osal_id_t TimerID[NUMBER_OF_TIMERS];
-    char      TimerName[NUMBER_OF_TIMERS][20] = {"TIMER1", "TIMER2", "TIMER3", "TIMER4"};
-    uint32    ClockAccuracy;
+    int          i = 0;
+    int32        TimerStatus[NUMBER_OF_TIMERS];
+    osal_index_t TableId;
+    osal_id_t    TimerID[NUMBER_OF_TIMERS];
+    char         TimerName[NUMBER_OF_TIMERS][20] = {"TIMER1", "TIMER2", "TIMER3", "TIMER4"};
+    uint32       ClockAccuracy;
 
     for (i = 0; i < NUMBER_OF_TIMERS && i < OS_MAX_TIMERS; i++)
     {

--- a/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-files.h
+++ b/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-files.h
@@ -29,8 +29,9 @@
 #define INCLUDE_UT_ADAPTOR_PORTABLE_POSIX_FILES_H_
 
 #include <common_types.h>
+#include <OCS_sys_types.h>
 
-unsigned int UT_PortablePosixFileTest_GetSelfEUID(void);
-unsigned int UT_PortablePosixFileTest_GetSelfEGID(void);
+OCS_uid_t UT_PortablePosixFileTest_GetSelfEUID(void);
+OCS_gid_t UT_PortablePosixFileTest_GetSelfEGID(void);
 
 #endif /* INCLUDE_UT_ADAPTOR_PORTABLE_POSIX_FILES_H_ */

--- a/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-io.h
+++ b/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-io.h
@@ -48,7 +48,7 @@
  * but are not exposed directly through the implementation API.
  *
  *****************************************************/
-void UT_PortablePosixIOTest_Set_Selectable(uint32 local_id, bool is_selectable);
+void UT_PortablePosixIOTest_Set_Selectable(osal_index_t local_id, bool is_selectable);
 
 #endif /* _UT_OSFILEAPI_H_ */
 

--- a/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-files.c
+++ b/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-files.c
@@ -31,12 +31,12 @@
 
 #include <os-impl-files.h>
 
-unsigned int UT_PortablePosixFileTest_GetSelfEUID(void)
+OCS_uid_t UT_PortablePosixFileTest_GetSelfEUID(void)
 {
     return OS_IMPL_SELF_EUID;
 }
 
-unsigned int UT_PortablePosixFileTest_GetSelfEGID(void)
+OCS_gid_t UT_PortablePosixFileTest_GetSelfEGID(void)
 {
     return OS_IMPL_SELF_EGID;
 }

--- a/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
+++ b/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
@@ -31,7 +31,7 @@
 
 #include <os-impl-io.h>
 
-void UT_PortablePosixIOTest_Set_Selectable(uint32 local_id, bool is_selectable)
+void UT_PortablePosixIOTest_Set_Selectable(osal_index_t local_id, bool is_selectable)
 {
     OS_impl_filehandle_table[local_id].selectable = is_selectable;
 }

--- a/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
@@ -35,15 +35,15 @@ void Test_OS_SelectSingle_Impl(void)
      * int32 OS_SelectSingle_Impl(uint32 stream_id, uint32 *SelectFlags, int32 msecs)
      */
     uint32              SelectFlags;
-    uint32              StreamID;
+    osal_index_t        StreamID;
     struct OCS_timespec nowtime;
     struct OCS_timespec latertime;
 
-    StreamID = 0;
-    UT_PortablePosixIOTest_Set_Selectable(0, false);
+    StreamID = UT_INDEX_0;
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, false);
     SelectFlags = OS_STREAM_STATE_READABLE | OS_STREAM_STATE_WRITABLE;
     OSAPI_TEST_FUNCTION_RC(OS_SelectSingle_Impl, (StreamID, &SelectFlags, 0), OS_ERR_OPERATION_NOT_SUPPORTED);
-    UT_PortablePosixIOTest_Set_Selectable(0, true);
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
     OSAPI_TEST_FUNCTION_RC(OS_SelectSingle_Impl, (StreamID, &SelectFlags, 0), OS_SUCCESS);
     SelectFlags = OS_STREAM_STATE_READABLE | OS_STREAM_STATE_WRITABLE;
     OSAPI_TEST_FUNCTION_RC(OS_SelectSingle_Impl, (StreamID, &SelectFlags, -1), OS_SUCCESS);

--- a/src/unit-test-coverage/portable/src/coveragetest-no-loader.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-no-loader.c
@@ -32,7 +32,7 @@ void Test_OS_ModuleLoad_Impl(void)
     /* Test Case For:
      * int32 OS_ModuleLoad_Impl ( uint32 module_id, char *translated_path )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl, (0, "local"), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl, (UT_INDEX_0, "local"), OS_ERR_NOT_IMPLEMENTED);
 }
 
 void Test_OS_ModuleUnload_Impl(void)
@@ -40,7 +40,7 @@ void Test_OS_ModuleUnload_Impl(void)
     /* Test Case For:
      * int32 OS_ModuleUnload_Impl ( uint32 module_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl, (0), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl, (UT_INDEX_0), OS_ERR_NOT_IMPLEMENTED);
 }
 
 void Test_OS_ModuleGetInfo_Impl(void)
@@ -51,7 +51,7 @@ void Test_OS_ModuleGetInfo_Impl(void)
     OS_module_prop_t module_prop;
 
     memset(&module_prop, 0, sizeof(module_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl, (0, &module_prop), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl, (UT_INDEX_0, &module_prop), OS_ERR_NOT_IMPLEMENTED);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/portable/src/coveragetest-no-shell.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-no-shell.c
@@ -33,7 +33,7 @@ void Test_OS_ShellOutputToFile_Impl(void)
     /* Test Case For:
      * int32 OS_ShellOutputToFile_Impl(uint32 stream_id, const char* Cmd)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_ShellOutputToFile_Impl, (0, "ut"), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_ShellOutputToFile_Impl, (UT_INDEX_0, "ut"), OS_ERR_NOT_IMPLEMENTED);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
@@ -73,7 +73,7 @@ void Test_OS_FileStat_Impl(void)
     /* all permission bits with uid/gid match */
     RefStat.st_uid   = UT_PortablePosixFileTest_GetSelfEUID();
     RefStat.st_gid   = UT_PortablePosixFileTest_GetSelfEGID();
-    RefStat.st_mode  = ~0;
+    RefStat.st_mode  = ~((OCS_mode_t)0);
     RefStat.st_size  = 1234;
     RefStat.st_mtime = 5678;
     UT_SetDataBuffer(UT_KEY(OCS_stat), &RefStat, sizeof(RefStat), false);
@@ -114,7 +114,7 @@ void Test_OS_FileChmod_Impl(void)
     /* all permission bits with uid/gid match */
     RefStat.st_uid   = UT_PortablePosixFileTest_GetSelfEUID();
     RefStat.st_gid   = UT_PortablePosixFileTest_GetSelfEGID();
-    RefStat.st_mode  = ~0;
+    RefStat.st_mode  = ~((OCS_mode_t)0);
     RefStat.st_size  = 1234;
     RefStat.st_mtime = 5678;
     UT_SetDataBuffer(UT_KEY(OCS_fstat), &RefStat, sizeof(RefStat), false);

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
@@ -41,14 +41,14 @@ void Test_OS_FileOpen_Impl(void)
      * Test Case For:
      * int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int32 access)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (0, "local", OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (0, "local", 0, OS_READ_ONLY), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (0, "local", OS_FILE_FLAG_CREATE, OS_READ_WRITE), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (0, "local", 0, -1234), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (UT_INDEX_0, "local", OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (UT_INDEX_0, "local", 0, OS_READ_ONLY), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (UT_INDEX_0, "local", OS_FILE_FLAG_CREATE, OS_READ_WRITE), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (UT_INDEX_0, "local", 0, -1234), OS_ERROR);
 
     /* failure mode */
     UT_SetForceFail(UT_KEY(OCS_open), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (0, "local", 0, OS_READ_ONLY), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_FileOpen_Impl, (UT_INDEX_0, "local", 0, OS_READ_ONLY), OS_ERROR);
 }
 
 void Test_OS_FileStat_Impl(void)

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
@@ -69,7 +69,7 @@ void Test_OS_GenericSeek_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, OS_SEEK_END), 333);
 
     /* bad whence */
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, -1234), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, 1234), OS_ERROR);
 
     /* generic failure of lseek() */
     UT_SetForceFail(UT_KEY(OCS_lseek), -1);

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
@@ -43,14 +43,14 @@ void Test_OS_GenericClose_Impl(void)
      * Test Case For:
      * int32 OS_GenericClose_Impl(uint32 local_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_GenericClose_Impl, (0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericClose_Impl, (UT_INDEX_0), OS_SUCCESS);
 
     /*
      * Test path where underlying close() fails.
      * Should still return success.
      */
     UT_SetForceFail(UT_KEY(OCS_close), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericClose_Impl, (0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericClose_Impl, (UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_GenericSeek_Impl(void)
@@ -62,22 +62,22 @@ void Test_OS_GenericSeek_Impl(void)
 
     /* note on success this wrapper returns the result of lseek(), not OS_SUCCESS */
     UT_SetForceFail(UT_KEY(OCS_lseek), 111);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (0, 0, OS_SEEK_CUR), 111);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, OS_SEEK_CUR), 111);
     UT_SetForceFail(UT_KEY(OCS_lseek), 222);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (0, 0, OS_SEEK_SET), 222);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, OS_SEEK_SET), 222);
     UT_SetForceFail(UT_KEY(OCS_lseek), 333);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (0, 0, OS_SEEK_END), 333);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, OS_SEEK_END), 333);
 
     /* bad whence */
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (0, 0, -1234), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, -1234), OS_ERROR);
 
     /* generic failure of lseek() */
     UT_SetForceFail(UT_KEY(OCS_lseek), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (0, 0, OS_SEEK_END), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, OS_SEEK_END), OS_ERROR);
 
     /* The seek implementation also checks for this specific pipe errno */
     OCS_errno = OCS_ESPIPE;
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (0, 0, OS_SEEK_END), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (UT_INDEX_0, 0, OS_SEEK_END), OS_ERR_NOT_IMPLEMENTED);
 }
 
 void Test_OS_GenericRead_Impl(void)
@@ -90,20 +90,20 @@ void Test_OS_GenericRead_Impl(void)
     char DestData[sizeof(SrcData)] = {0};
 
     UT_SetDataBuffer(UT_KEY(OCS_read), SrcData, sizeof(SrcData), false);
-    UT_PortablePosixIOTest_Set_Selectable(0, false);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (0, DestData, sizeof(DestData), 0), sizeof(DestData));
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, false);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (UT_INDEX_0, DestData, sizeof(DestData), 0), sizeof(DestData));
     UtAssert_MemCmp(SrcData, DestData, sizeof(SrcData), "read() data Valid");
 
     /* test invocation of select() in nonblocking mode */
     UT_ResetState(UT_KEY(OCS_read));
     UT_SetDataBuffer(UT_KEY(OCS_read), SrcData, sizeof(SrcData), false);
-    UT_PortablePosixIOTest_Set_Selectable(0, true);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (0, DestData, sizeof(DestData), 0), sizeof(DestData));
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (UT_INDEX_0, DestData, sizeof(DestData), 0), sizeof(DestData));
     UtAssert_True(UT_GetStubCount(UT_KEY(OS_SelectSingle_Impl)) == 1, "OS_SelectSingle() called");
 
     /* read() failure */
     UT_SetForceFail(UT_KEY(OCS_read), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (0, DestData, sizeof(DestData), 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (UT_INDEX_0, DestData, sizeof(DestData), 0), OS_ERROR);
 }
 
 void Test_OS_GenericWrite_Impl(void)
@@ -116,20 +116,20 @@ void Test_OS_GenericWrite_Impl(void)
     char DestData[sizeof(SrcData)] = {0};
 
     UT_SetDataBuffer(UT_KEY(OCS_write), DestData, sizeof(DestData), false);
-    UT_PortablePosixIOTest_Set_Selectable(0, false);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (0, SrcData, sizeof(SrcData), 0), sizeof(SrcData));
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, false);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (UT_INDEX_0, SrcData, sizeof(SrcData), 0), sizeof(SrcData));
     UtAssert_MemCmp(SrcData, DestData, sizeof(SrcData), "write() data valid");
 
     /* test invocation of select() in nonblocking mode */
     UT_ResetState(UT_KEY(OCS_write));
     UT_SetDataBuffer(UT_KEY(OCS_write), DestData, sizeof(DestData), false);
-    UT_PortablePosixIOTest_Set_Selectable(0, true);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (0, SrcData, sizeof(SrcData), 0), sizeof(SrcData));
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (UT_INDEX_0, SrcData, sizeof(SrcData), 0), sizeof(SrcData));
     UtAssert_True(UT_GetStubCount(UT_KEY(OS_SelectSingle_Impl)) == 1, "OS_SelectSingle() called");
 
     /* write() failure */
     UT_SetForceFail(UT_KEY(OCS_write), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (0, DestData, sizeof(DestData), 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (UT_INDEX_0, DestData, sizeof(DestData), 0), OS_ERROR);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/portable/src/os-portable-coveragetest.h
+++ b/src/unit-test-coverage/portable/src/os-portable-coveragetest.h
@@ -57,6 +57,17 @@
 
 #define ADD_TEST(test) UtTest_Add((Test_##test), Osapi_Test_Setup, Osapi_Test_Teardown, #test)
 
+/*
+ * The default/primary table index used by most coverage tests.
+ */
+#define UT_INDEX_0 OSAL_INDEX_C(0)
+
+/*
+ * A secondary table index for coverage tests which require
+ * more than one entry
+ */
+#define UT_INDEX_1 OSAL_INDEX_C(1)
+
 /* Osapi_Test_Setup
  *
  * Purpose:

--- a/src/unit-test-coverage/shared/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-binsem.c
@@ -168,7 +168,7 @@ void Test_OS_BinSemGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_bin_sem_prop_t   prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-countsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-countsem.c
@@ -156,7 +156,7 @@ void Test_OS_CountSemGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_count_sem_prop_t prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-file.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-file.c
@@ -313,7 +313,7 @@ void Test_OS_FDGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_file_prop_t      file_prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -86,40 +86,40 @@ void Test_OS_mkfs(void)
 
     char TestBuffer[128];
 
-    actual = OS_mkfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual = OS_mkfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_SUCCESS", (long)actual);
 
     /*
      * Test an entry NOT found in the OS_VolumeTable
      */
-    actual = OS_mkfs(TestBuffer, "/rd1", "vol1", 0, 0);
+    actual = OS_mkfs(TestBuffer, "/rd1", "vol1", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_SUCCESS", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_mkfs(NULL, NULL, NULL, 0, 0);
+    actual   = OS_mkfs(NULL, NULL, NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
-    actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strlen));
 
     /* set up for failure due to empty strings */
     expected = OS_FS_ERR_PATH_INVALID;
-    actual   = OS_mkfs(TestBuffer, "", "", 0, 0);
+    actual   = OS_mkfs(TestBuffer, "", "", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
 
     /* set up for failure due to formatting */
     UT_SetForceFail(UT_KEY(OS_FileSysFormatVolume_Impl), OS_FS_ERR_DRIVE_NOT_CREATED);
     expected = OS_FS_ERR_DRIVE_NOT_CREATED;
-    actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_DRIVE_NOT_CREATED (format failure)", (long)actual);
 
     /* set up for failure due to no free slots */
     UT_SetForceFail(UT_KEY(OS_ObjectIdAllocateNew), OS_ERR_NO_FREE_IDS);
     expected = OS_FS_ERR_DEVICE_NOT_FREE;
-    actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_DEVICE_NOT_FREE", (long)actual);
 }
 
@@ -164,26 +164,26 @@ void Test_OS_initfs(void)
 
     char TestBuffer[128];
 
-    actual = OS_initfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual = OS_initfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_SUCCESS", (long)actual);
 
-    actual = OS_initfs(NULL, "/hda2", "vol2", 0, 0);
+    actual = OS_initfs(NULL, "/hda2", "vol2", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_SUCCESS", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_initfs(NULL, NULL, NULL, 0, 0);
+    actual   = OS_initfs(NULL, NULL, NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_FS_DEV_NAME_LEN);
     expected = OS_FS_ERR_PATH_TOO_LONG;
-    actual   = OS_initfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual   = OS_initfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strlen));
 
     /* set up for failure */
     UT_SetForceFail(UT_KEY(OS_ObjectIdAllocateNew), OS_ERR_NO_FREE_IDS);
     expected = OS_FS_ERR_DEVICE_NOT_FREE;
-    actual   = OS_initfs(TestBuffer, "/ramdev0", "vol", 0, 0);
+    actual   = OS_initfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_FS_ERR_DEVICE_NOT_FREE", (long)actual);
 }
 
@@ -263,9 +263,9 @@ void Test_OS_fsBlocksFree(void)
     int32        actual   = ~OS_SUCCESS;
     OS_statvfs_t statval;
 
-    statval.block_size   = 1024;
-    statval.blocks_free  = 1111;
-    statval.total_blocks = 2222;
+    statval.block_size   = OSAL_SIZE_C(1024);
+    statval.blocks_free  = OSAL_BLOCKCOUNT_C(1111);
+    statval.total_blocks = OSAL_BLOCKCOUNT_C(2222);
     UT_SetDataBuffer(UT_KEY(OS_FileSysStatVolume_Impl), &statval, sizeof(statval), false);
     OS_filesys_table[1].flags =
         OS_FILESYS_FLAG_IS_READY | OS_FILESYS_FLAG_IS_MOUNTED_SYSTEM | OS_FILESYS_FLAG_IS_MOUNTED_VIRTUAL;
@@ -300,9 +300,9 @@ void Test_OS_fsBytesFree(void)
     OS_statvfs_t statval;
     uint64       bytes_free = 0;
 
-    statval.block_size   = 1024;
-    statval.blocks_free  = 1111;
-    statval.total_blocks = 2222;
+    statval.block_size   = OSAL_SIZE_C(1024);
+    statval.blocks_free  = OSAL_BLOCKCOUNT_C(1111);
+    statval.total_blocks = OSAL_BLOCKCOUNT_C(2222);
     UT_SetDataBuffer(UT_KEY(OS_FileSysStatVolume_Impl), &statval, sizeof(statval), false);
     OS_filesys_table[1].flags =
         OS_FILESYS_FLAG_IS_READY | OS_FILESYS_FLAG_IS_MOUNTED_SYSTEM | OS_FILESYS_FLAG_IS_MOUNTED_VIRTUAL;

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -39,7 +39,7 @@ typedef struct
 } Test_OS_ObjTypeCount_t;
 
 /* a match function that always matches */
-static bool TestAlwaysMatch(void *ref, uint32 local_id, const OS_common_record_t *obj)
+static bool TestAlwaysMatch(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     return true;
 }
@@ -113,7 +113,7 @@ void Test_OS_ObjectIdConvertLock(void)
      */
     int32               expected;
     int32               actual;
-    uint32              array_index;
+    osal_index_t        array_index;
     OS_common_record_t *record;
     osal_id_t           objid;
     UT_idbuf_t          corrupt_objid;
@@ -186,9 +186,9 @@ void Test_OS_GetMaxForObjectType(void)
      * Test Case For:
      * uint32 OS_GetMaxForObjectType(uint32 idtype);
      */
-    uint32 idtype   = 0;
-    uint32 expected = 0xFFFFFFFF;
-    uint32 max      = 0;
+    osal_objtype_t idtype;
+    uint32         expected = 0xFFFFFFFF;
+    uint32         max      = 0;
 
     for (idtype = 0; idtype < OS_OBJECT_TYPE_USER; ++idtype)
     {
@@ -219,9 +219,9 @@ void Test_OS_GetBaseForObjectType(void)
      * Test Case For:
      * uint32 OS_GetBaseForObjectType(uint32 idtype);
      */
-    uint32 idtype   = 0;
-    uint32 expected = 0xFFFFFFFF;
-    uint32 max      = 0;
+    osal_objtype_t idtype;
+    uint32         expected = 0xFFFFFFFF;
+    uint32         max      = 0;
 
     for (idtype = 0; idtype < OS_OBJECT_TYPE_USER; ++idtype)
     {
@@ -256,10 +256,10 @@ void Test_OS_ObjectIdToArrayIndex(void)
      * different test case.  The only additional test here is to provide a value
      * which is out of range.
      */
-    osal_id_t objid;
-    uint32    local_idx = 0xFFFFFFFF;
-    int32     expected  = OS_SUCCESS;
-    int32     actual    = ~OS_SUCCESS;
+    osal_id_t    objid;
+    osal_index_t local_idx;
+    int32        expected = OS_SUCCESS;
+    int32        actual   = ~OS_SUCCESS;
 
     /* need to get a "valid" objid for the nominal case */
     OS_ObjectIdCompose_Impl(OS_OBJECT_TYPE_OS_TASK, 1, &objid);
@@ -271,7 +271,7 @@ void Test_OS_ObjectIdToArrayIndex(void)
 
     /* coverage for off-nominal case */
     expected = OS_ERR_INVALID_ID;
-    actual   = OS_ObjectIdToArrayIndex(0xFFFFFFFF, UT_OBJID_OTHER, &local_idx);
+    actual   = OS_ObjectIdToArrayIndex(0xFFFF, UT_OBJID_OTHER, &local_idx);
     UtAssert_True(actual == expected, "OS_ObjectIdToArrayIndex() (%ld) == OS_ERR_INVALID_ID", (long)actual);
 }
 
@@ -335,8 +335,8 @@ void Test_OS_ObjectIdGetById(void)
     int32               actual   = ~OS_SUCCESS;
     int32               expected = OS_SUCCESS;
     osal_id_t           refobjid;
-    uint32              local_idx = 0xFFFFFFFF;
-    OS_common_record_t *rptr      = NULL;
+    osal_index_t        local_idx;
+    OS_common_record_t *rptr = NULL;
 
     /* verify that the call returns ERROR when not initialized */
     OS_SharedGlobalVars.Initialized = false;
@@ -373,7 +373,7 @@ void Test_OS_ObjectIdGetById(void)
 
     /* attempt to get lock for invalid type object should fail */
     expected = OS_ERR_INVALID_ID;
-    actual   = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, 0xFFFFFFFF, refobjid, &local_idx, &rptr);
+    actual   = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, 0xFFFF, refobjid, &local_idx, &rptr);
     UtAssert_True(actual == expected, "OS_ObjectIdGetById() (%ld) == OS_ERR_INVALID_ID", (long)actual);
     OS_SharedGlobalVars.ShutdownFlag = 0;
 
@@ -532,32 +532,32 @@ void Test_OS_ObjectIdAllocateNew(void)
      */
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
-    uint32              indx;
+    osal_index_t        idx;
     OS_common_record_t *rptr = NULL;
 
-    actual = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, "UT_alloc", &indx, &rptr);
+    actual = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, "UT_alloc", &idx, &rptr);
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_SUCCESS", (long)actual);
     UtAssert_True(rptr != NULL, "rptr (%p) != NULL", (void *)rptr);
 
     /* Passing a NULL name also should work here (used for internal objects) */
-    actual = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, NULL, &indx, &rptr);
+    actual = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, NULL, &idx, &rptr);
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate(NULL) (%ld) == OS_SUCCESS", (long)actual);
 
     rptr->name_entry = "UT_alloc";
     expected         = OS_ERR_NAME_TAKEN;
-    actual           = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, "UT_alloc", &indx, &rptr);
+    actual           = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, "UT_alloc", &idx, &rptr);
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_ERR_NAME_TAKEN", (long)actual);
 
     OS_SharedGlobalVars.ShutdownFlag = OS_SHUTDOWN_MAGIC_NUMBER;
     expected                         = OS_ERROR;
-    actual                           = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, "UT_alloc", &indx, &rptr);
+    actual                           = OS_ObjectIdAllocateNew(OS_OBJECT_TYPE_OS_TASK, "UT_alloc", &idx, &rptr);
     OS_SharedGlobalVars.ShutdownFlag = 0;
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_ERR_NAME_TAKEN", (long)actual);
 
     expected = OS_ERR_INCORRECT_OBJ_TYPE;
-    actual   = OS_ObjectIdAllocateNew(0xFFFFFFFF, "UT_alloc", &indx, &rptr);
+    actual   = OS_ObjectIdAllocateNew(0xFFFF, "UT_alloc", &idx, &rptr);
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_ERR_INCORRECT_OBJ_TYPE", (long)actual);
 }
 
@@ -569,11 +569,11 @@ void Test_OS_ConvertToArrayIndex(void)
      *
      *
      */
-    int32               expected   = OS_SUCCESS;
-    int32               actual     = ~OS_SUCCESS; // OS_ConvertToArrayIndex();
-    uint32              local_idx1 = 0xFFFFFFF0;
-    uint32              local_idx2 = 0xFFFFFFF1;
-    OS_common_record_t *rptr       = NULL;
+    int32               expected = OS_SUCCESS;
+    int32               actual   = ~OS_SUCCESS; // OS_ConvertToArrayIndex();
+    osal_index_t        local_idx1;
+    osal_index_t        local_idx2;
+    OS_common_record_t *rptr = NULL;
 
     /* Need a valid ID to work with */
     OS_ObjectIdFindNext(OS_OBJECT_TYPE_OS_TASK, &local_idx1, &rptr);
@@ -593,9 +593,9 @@ void Test_OS_ForEachObject(void)
      * Test Case For:
      * void OS_ForEachObject (uint32 creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg);
      */
-    uint32                 objtype   = OS_OBJECT_TYPE_UNDEFINED;
-    OS_common_record_t *   rptr      = NULL;
-    uint32                 local_idx = 0xFFFFFFFF;
+    osal_objtype_t         objtype;
+    OS_common_record_t *   rptr = NULL;
+    osal_index_t           local_idx;
     UT_idbuf_t             self_id;
     Test_OS_ObjTypeCount_t Count;
 
@@ -603,6 +603,7 @@ void Test_OS_ForEachObject(void)
 
     memset(&Count, 0, sizeof(Count));
 
+    objtype = OS_OBJECT_TYPE_UNDEFINED;
     while (objtype < OS_OBJECT_TYPE_USER)
     {
         OS_ObjectIdFindNext(objtype, &local_idx, &rptr);
@@ -641,8 +642,8 @@ void Test_OS_GetResourceName(void)
      * Test Case For:
      * int32 OS_GetResourceName(uint32 id, char *buffer, uint32 buffer_size)
      */
-    uint32              local_idx = 0xFFFFFFFF;
-    OS_common_record_t *rptr      = NULL;
+    osal_index_t        local_idx;
+    OS_common_record_t *rptr = NULL;
     char                NameBuffer[OS_MAX_API_NAME];
     int32               expected;
     int32               actual;
@@ -659,11 +660,11 @@ void Test_OS_GetResourceName(void)
     UtAssert_True(strcmp(NameBuffer, "UTTask") == 0, "NameBuffer (%s) == UTTask", NameBuffer);
 
     expected = OS_ERR_NAME_TOO_LONG;
-    actual   = OS_GetResourceName(rptr->active_id, NameBuffer, 2);
+    actual   = OS_GetResourceName(rptr->active_id, NameBuffer, OSAL_SIZE_C(2));
     UtAssert_True(actual == expected, "OS_GetResourceName() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_GetResourceName(rptr->active_id, NULL, 0);
+    actual   = OS_GetResourceName(rptr->active_id, NULL, OSAL_SIZE_C(0));
     UtAssert_True(actual == expected, "OS_GetResourceName() (%ld) == OS_INVALID_POINTER", (long)actual);
 }
 

--- a/src/unit-test-coverage/shared/src/coveragetest-module.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-module.c
@@ -210,16 +210,16 @@ void Test_OS_SymbolTableDump(void)
     int32 expected = OS_SUCCESS;
     int32 actual   = ~OS_SUCCESS;
 
-    actual = OS_SymbolTableDump("test", 555);
+    actual = OS_SymbolTableDump("test", OSAL_SIZE_C(555));
     UtAssert_True(actual == expected, "OS_SymbolTableDump() (%ld) == OS_SUCCESS", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SymbolTableDump(NULL, 555);
+    actual   = OS_SymbolTableDump(NULL, OSAL_SIZE_C(555));
     UtAssert_True(actual == expected, "OS_SymbolTableDump() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OS_TranslatePath), OS_ERROR);
     expected = OS_ERROR;
-    actual   = OS_SymbolTableDump("test", 555);
+    actual   = OS_SymbolTableDump("test", OSAL_SIZE_C(555));
     UtAssert_True(actual == expected, "OS_SymbolTableDump() (%ld) == OS_ERROR", (long)actual);
 }
 
@@ -232,10 +232,11 @@ void Test_OS_ModuleGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_module_prop_t    module_prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 
+    local_index = UT_INDEX_1;
     memset(&utrec, 0, sizeof(utrec));
     utrec.creator    = UT_OBJID_OTHER;
     utrec.name_entry = "ABC";

--- a/src/unit-test-coverage/shared/src/coveragetest-mutex.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-mutex.c
@@ -139,7 +139,7 @@ void Test_OS_MutSemGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_mut_sem_prop_t   prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-queue.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-queue.c
@@ -56,23 +56,23 @@ void Test_OS_QueueCreate(void)
      */
     int32     expected = OS_SUCCESS;
     osal_id_t objid;
-    int32     actual = OS_QueueCreate(&objid, "UT", 0, 0, 0);
+    int32     actual = OS_QueueCreate(&objid, "UT", OSAL_BLOCKCOUNT_C(0), OSAL_SIZE_C(0), 0);
 
     UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_SUCCESS", (long)actual);
 
     /* test error cases */
     expected = OS_INVALID_POINTER;
-    actual   = OS_QueueCreate(NULL, "UT", 0, 0, 0);
+    actual   = OS_QueueCreate(NULL, "UT", OSAL_BLOCKCOUNT_C(0), OSAL_SIZE_C(0), 0);
     UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     UT_SetForceFail(UT_KEY(OCS_strlen), 2 + OS_MAX_API_NAME);
     expected = OS_ERR_NAME_TOO_LONG;
-    actual   = OS_QueueCreate(&objid, "UT", 0, 0, 0);
+    actual   = OS_QueueCreate(&objid, "UT", OSAL_BLOCKCOUNT_C(0), OSAL_SIZE_C(0), 0);
     UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
     UT_ClearForceFail(UT_KEY(OCS_strlen));
 
     expected = OS_QUEUE_INVALID_SIZE;
-    actual   = OS_QueueCreate(&objid, "UT", 1 + OS_QUEUE_MAX_DEPTH, 0, 0);
+    actual   = OS_QueueCreate(&objid, "UT", OSAL_BLOCKCOUNT_C(1 + OS_QUEUE_MAX_DEPTH), OSAL_SIZE_C(0), 0);
     UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_QUEUE_INVALID_SIZE", (long)actual);
 }
 
@@ -98,7 +98,7 @@ void Test_OS_QueueGet(void)
      */
     int32  expected = OS_SUCCESS;
     int32  actual   = ~OS_SUCCESS;
-    uint32 actual_size;
+    size_t actual_size;
     char   Buf[4];
 
     actual = OS_QueueGet(UT_OBJID_1, Buf, sizeof(Buf), &actual_size, 0);
@@ -170,7 +170,7 @@ void Test_OS_QueueGetInfo(void)
     int32               actual   = ~OS_SUCCESS;
     OS_queue_prop_t     queue_prop;
     osal_id_t           id;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-sockets.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-sockets.c
@@ -150,10 +150,11 @@ void Test_OS_SocketAccept(void)
      */
     int32         expected = OS_SUCCESS;
     int32         actual   = ~OS_SUCCESS;
-    uint32        local_id = 0;
+    osal_index_t  local_id;
     osal_id_t     connsock_id;
     OS_SockAddr_t Addr;
 
+    local_id    = UT_INDEX_0;
     connsock_id = OS_OBJECT_ID_UNDEFINED;
 
     OS_stream_table[local_id].socket_type  = OS_SocketType_STREAM;
@@ -210,10 +211,10 @@ void Test_OS_SocketConnect(void)
     int32         expected = OS_SUCCESS;
     int32         actual   = ~OS_SUCCESS;
     OS_SockAddr_t Addr;
-    uint32        idbuf;
+    osal_index_t  idbuf;
 
     memset(&Addr, 0, sizeof(Addr));
-    idbuf = 1;
+    idbuf = UT_INDEX_1;
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &idbuf, sizeof(idbuf), false);
     OS_stream_table[idbuf].socket_domain = OS_SocketDomain_INET;
     OS_stream_table[idbuf].socket_type   = OS_SocketType_STREAM;
@@ -263,19 +264,20 @@ void Test_OS_SocketRecvFrom(void)
     int32         expected = OS_SUCCESS;
     int32         actual   = ~OS_SUCCESS;
     OS_SockAddr_t Addr;
-    uint32        idbuf;
+    osal_index_t  idbuf;
 
     memset(&Addr, 0, sizeof(Addr));
-    idbuf = 1;
+    idbuf = UT_INDEX_1;
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &idbuf, sizeof(idbuf), false);
     OS_stream_table[idbuf].socket_type  = OS_SocketType_DATAGRAM;
     OS_stream_table[idbuf].stream_state = OS_STREAM_STATE_BOUND;
     actual                              = OS_SocketRecvFrom(UT_OBJID_1, &Buf, 1, &Addr, 0);
+    actual                              = OS_SocketRecvFrom(UT_OBJID_1, &Buf, sizeof(Buf), &Addr, 0);
 
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() (%ld) == OS_SUCCESS", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketRecvFrom(UT_OBJID_1, NULL, 0, NULL, 0);
+    actual   = OS_SocketRecvFrom(UT_OBJID_1, NULL, OSAL_SIZE_C(0), NULL, 0);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom(NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
 
     /*
@@ -283,7 +285,7 @@ void Test_OS_SocketRecvFrom(void)
      */
     OS_stream_table[1].socket_type = OS_SocketType_INVALID;
     expected                       = OS_ERR_INCORRECT_OBJ_TYPE;
-    actual                         = OS_SocketRecvFrom(UT_OBJID_1, &Buf, 1, &Addr, 0);
+    actual                         = OS_SocketRecvFrom(UT_OBJID_1, &Buf, sizeof(Buf), &Addr, 0);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() non-datagram (%ld) == OS_ERR_INCORRECT_OBJ_TYPE",
                   (long)actual);
 
@@ -293,7 +295,7 @@ void Test_OS_SocketRecvFrom(void)
     OS_stream_table[1].socket_type  = OS_SocketType_DATAGRAM;
     OS_stream_table[1].stream_state = 0;
     expected                        = OS_ERR_INCORRECT_OBJ_STATE;
-    actual                          = OS_SocketRecvFrom(UT_OBJID_1, &Buf, 1, &Addr, 0);
+    actual                          = OS_SocketRecvFrom(UT_OBJID_1, &Buf, sizeof(Buf), &Addr, 0);
     UtAssert_True(actual == expected, "OS_SocketRecvFrom() non-bound (%ld) == OS_ERR_INCORRECT_OBJ_STATE",
                   (long)actual);
 }
@@ -313,19 +315,19 @@ void Test_OS_SocketSendTo(void)
     int32         expected = OS_SUCCESS;
     int32         actual   = ~OS_SUCCESS;
     OS_SockAddr_t Addr;
-    uint32        idbuf;
+    osal_index_t  idbuf;
 
     memset(&Addr, 0, sizeof(Addr));
-    idbuf = 1;
+    idbuf = UT_INDEX_1;
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &idbuf, sizeof(idbuf), false);
     OS_stream_table[idbuf].socket_type  = OS_SocketType_DATAGRAM;
     OS_stream_table[idbuf].stream_state = OS_STREAM_STATE_BOUND;
-    actual                              = OS_SocketSendTo(UT_OBJID_1, &Buf, 1, &Addr);
+    actual                              = OS_SocketSendTo(UT_OBJID_1, &Buf, sizeof(Buf), &Addr);
 
     UtAssert_True(actual == expected, "OS_SocketSendTo() (%ld) == OS_SUCCESS", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_SocketSendTo(UT_OBJID_1, NULL, 0, NULL);
+    actual   = OS_SocketSendTo(UT_OBJID_1, NULL, OSAL_SIZE_C(0), NULL);
     UtAssert_True(actual == expected, "OS_SocketSendTo(NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
 
     /*
@@ -333,7 +335,7 @@ void Test_OS_SocketSendTo(void)
      */
     OS_stream_table[1].socket_type = OS_SocketType_INVALID;
     expected                       = OS_ERR_INCORRECT_OBJ_TYPE;
-    actual                         = OS_SocketSendTo(UT_OBJID_1, &Buf, 1, &Addr);
+    actual                         = OS_SocketSendTo(UT_OBJID_1, &Buf, sizeof(Buf), &Addr);
     UtAssert_True(actual == expected, "OS_SocketSendTo() non-datagram (%ld) == OS_ERR_INCORRECT_OBJ_TYPE",
                   (long)actual);
 }
@@ -382,7 +384,7 @@ void Test_OS_SocketGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_socket_prop_t    prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 
@@ -439,7 +441,7 @@ void Test_OS_SocketAddr(void)
     actual = OS_SocketAddrInit(NULL, OS_SocketDomain_INVALID);
     UtAssert_True(actual == expected, "OS_SocketAddrInit() (%ld) == OS_INVALID_POINTER", (long)actual);
 
-    actual = OS_SocketAddrToString(NULL, 0, NULL);
+    actual = OS_SocketAddrToString(NULL, OSAL_SIZE_C(0), NULL);
     UtAssert_True(actual == expected, "OS_SocketAddrToString() (%ld) == OS_INVALID_POINTER", (long)actual);
 
     actual = OS_SocketAddrFromString(NULL, NULL);

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -106,17 +106,23 @@ void Test_OS_TaskCreate(void)
      */
     int32     expected = OS_SUCCESS;
     osal_id_t objid;
-    int32     actual = OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 128, 0, 0);
+    int32     actual;
+
+    actual = OS_TaskCreate(&objid, "UT", UT_TestHook, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(128), OSAL_PRIORITY_C(0), 0);
 
     UtAssert_True(actual == expected, "OS_TaskCreate() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(NULL, NULL, NULL, NULL, 0, 0, 0), OS_INVALID_POINTER);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 0, 0, 0), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 128, 10 + OS_MAX_TASK_PRIORITY, 0),
-                           OS_ERR_INVALID_PRIORITY);
+    OSAPI_TEST_FUNCTION_RC(
+        OS_TaskCreate(NULL, NULL, NULL, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
+        OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(
+        OS_TaskCreate(&objid, "UT", UT_TestHook, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
+        OS_ERROR);
     UT_SetForceFail(UT_KEY(OCS_strlen), 10 + OS_MAX_API_NAME);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate(&objid, "UT", UT_TestHook, NULL, 128, 0, 0), OS_ERR_NAME_TOO_LONG);
+    OSAPI_TEST_FUNCTION_RC(
+        OS_TaskCreate(&objid, "UT", UT_TestHook, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(128), OSAL_PRIORITY_C(0), 0),
+        OS_ERR_NAME_TOO_LONG);
 }
 
 void Test_OS_TaskDelete(void)
@@ -148,7 +154,7 @@ void Test_OS_TaskExit(void)
      * Test Case For:
      * void OS_TaskExit()
      */
-    uint32              local_index = 0;
+    osal_index_t        local_index = UT_INDEX_0;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 
@@ -180,11 +186,9 @@ void Test_OS_TaskSetPriority(void)
      * int32 OS_TaskSetPriority (uint32 task_id, uint32 new_priority)
      */
     int32 expected = OS_SUCCESS;
-    int32 actual   = OS_TaskSetPriority(UT_OBJID_1, 1);
+    int32 actual   = OS_TaskSetPriority(UT_OBJID_1, OSAL_PRIORITY_C(1));
 
     UtAssert_True(actual == expected, "OS_TaskSetPriority() (%ld) == OS_SUCCESS", (long)actual);
-
-    OSAPI_TEST_FUNCTION_RC(OS_TaskSetPriority(UT_OBJID_1, 10 + OS_MAX_TASK_PRIORITY), OS_ERR_INVALID_PRIORITY);
 }
 void Test_OS_TaskRegister(void)
 {
@@ -248,15 +252,15 @@ void Test_OS_TaskGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_task_prop_t      task_prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 
     memset(&utrec, 0, sizeof(utrec));
     utrec.creator               = UT_OBJID_OTHER;
     utrec.name_entry            = "ABC";
-    OS_task_table[1].stack_size = 222;
-    OS_task_table[1].priority   = 333;
+    OS_task_table[1].stack_size = OSAL_SIZE_C(222);
+    OS_task_table[1].priority   = OSAL_PRIORITY_C(133);
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &local_index, sizeof(local_index), false);
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &rptr, sizeof(rptr), false);
     actual = OS_TaskGetInfo(UT_OBJID_1, &task_prop);
@@ -266,10 +270,10 @@ void Test_OS_TaskGetInfo(void)
     UtAssert_True(strcmp(task_prop.name, "ABC") == 0, "task_prop.name (%s) == ABC", task_prop.name);
     UtAssert_True(task_prop.stack_size == 222, "task_prop.stack_size (%lu) == 222",
                   (unsigned long)task_prop.stack_size);
-    UtAssert_True(task_prop.priority == 333, "task_prop.priority (%lu) == 333", (unsigned long)task_prop.priority);
+    UtAssert_True(task_prop.priority == 133, "task_prop.priority (%lu) == 133", (unsigned long)task_prop.priority);
 
-    OS_task_table[1].stack_size = 0;
-    OS_task_table[1].priority   = 0;
+    OS_task_table[1].stack_size = OSAL_SIZE_C(0);
+    OS_task_table[1].priority   = OSAL_PRIORITY_C(0);
 
     OSAPI_TEST_FUNCTION_RC(OS_TaskGetInfo(OS_OBJECT_ID_UNDEFINED, NULL), OS_INVALID_POINTER);
 }

--- a/src/unit-test-coverage/shared/src/coveragetest-time.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-time.c
@@ -116,11 +116,11 @@ void Test_OS_TimerCreate(void)
      * Test Case For:
      * int32 OS_TimerCreate(uint32 *timer_id, const char *timer_name, uint32 *accuracy, OS_TimerCallback_t callback_ptr)
      */
-    int32     expected = OS_SUCCESS;
-    osal_id_t objid    = OS_OBJECT_ID_UNDEFINED;
-    uint32    local_id = 0xFFFFFFFF;
-    uint32    accuracy = 0xFFFFFFFF;
-    int32     actual   = OS_TimerCreate(&objid, "UT", &accuracy, UT_TimerCallback);
+    int32        expected = OS_SUCCESS;
+    osal_id_t    objid    = OS_OBJECT_ID_UNDEFINED;
+    osal_index_t local_id;
+    uint32       accuracy = 0xFFFFFFFF;
+    int32        actual   = OS_TimerCreate(&objid, "UT", &accuracy, UT_TimerCallback);
 
     UtAssert_True(actual == expected, "OS_TimerCreate() (%ld) == OS_SUCCESS", (long)actual);
 
@@ -170,7 +170,7 @@ void Test_OS_TimerSet(void)
     actual   = OS_TimerSet(UT_OBJID_1, 0, 1);
     UtAssert_True(actual == expected, "OS_TimerSet() (%ld) == OS_SUCCESS", (long)actual);
 
-    OS_timecb_table[2].timebase_ref       = 0;
+    OS_timecb_table[2].timebase_ref       = UT_INDEX_0;
     OS_timecb_table[2].flags              = TIMECB_FLAG_DEDICATED_TIMEBASE;
     OS_global_timebase_table[0].active_id = UT_OBJID_2;
     actual                                = OS_TimerSet(UT_OBJID_2, 0, 1);
@@ -199,10 +199,10 @@ void Test_OS_TimerDelete(void)
 
     UtAssert_True(actual == expected, "OS_TimerDelete() (%ld) == OS_SUCCESS", (long)actual);
 
-    OS_timecb_table[1].timebase_ref = 0;
-    OS_timecb_table[2].timebase_ref = 0;
-    OS_timecb_table[2].next_ref     = 1;
-    OS_timecb_table[1].next_ref     = 1;
+    OS_timecb_table[1].timebase_ref = UT_INDEX_0;
+    OS_timecb_table[2].timebase_ref = UT_INDEX_0;
+    OS_timecb_table[2].next_ref     = UT_INDEX_1;
+    OS_timecb_table[1].next_ref     = UT_INDEX_1;
     OS_timebase_table[0].first_cb   = UT_OBJID_2;
     actual                          = OS_TimerDelete(UT_OBJID_2);
     UtAssert_True(actual == expected, "OS_TimerDelete() (%ld) == OS_SUCCESS", (long)actual);
@@ -215,7 +215,7 @@ void Test_OS_TimerDelete(void)
      * these are implicitly created as part of timer creation for API compatibility */
     OS_TimeBaseCreate(&OS_global_timebase_table[0].active_id, "ut", NULL);
     OS_timecb_table[1].flags        = TIMECB_FLAG_DEDICATED_TIMEBASE;
-    OS_timecb_table[1].timebase_ref = 0;
+    OS_timecb_table[1].timebase_ref = UT_INDEX_0;
     actual                          = OS_TimerDelete(UT_OBJID_1);
     UtAssert_True(actual == expected, "OS_TimerDelete() (%ld) == OS_SUCCESS", (long)actual);
     UtAssert_True(UT_GetStubCount(UT_KEY(OS_TimeBaseDelete)) == 1, "OS_TimerDelete() invoked OS_TimeBaseDelete()");
@@ -269,7 +269,7 @@ void Test_OS_TimerGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_timer_prop_t     timer_prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 
@@ -277,7 +277,7 @@ void Test_OS_TimerGetInfo(void)
     utrec.creator                      = UT_OBJID_OTHER;
     utrec.name_entry                   = "ABC";
     OS_timecb_table[1].interval_time   = 2222;
-    OS_timecb_table[1].timebase_ref    = 0;
+    OS_timecb_table[1].timebase_ref    = UT_INDEX_0;
     OS_timebase_table[0].accuracy_usec = 3333;
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &local_index, sizeof(local_index), false);
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &rptr, sizeof(rptr), false);

--- a/src/unit-test-coverage/shared/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-timebase.c
@@ -38,7 +38,7 @@ static uint32 TimerSyncCount  = 0;
 static uint32 TimerSyncRetVal = 0;
 static uint32 TimeCB          = 0;
 
-static uint32 UT_TimerSync(uint32 timer_id)
+static uint32 UT_TimerSync(osal_index_t timer_id)
 {
     ++TimerSyncCount;
     return TimerSyncRetVal;
@@ -192,7 +192,7 @@ void Test_OS_TimeBaseGetInfo(void)
     int32               expected = OS_SUCCESS;
     int32               actual   = ~OS_SUCCESS;
     OS_timebase_prop_t  timebase_prop;
-    uint32              local_index = 1;
+    osal_index_t        local_index = UT_INDEX_1;
     OS_common_record_t  utrec;
     OS_common_record_t *rptr = &utrec;
 
@@ -249,8 +249,9 @@ void Test_OS_TimeBase_CallbackThread(void)
      */
     OS_common_record_t  fake_record;
     OS_common_record_t *recptr = &fake_record;
-    osal_id_t           idbuf;
+    osal_index_t        local_index;
 
+    local_index = UT_INDEX_2;
     memset(&fake_record, 0, sizeof(fake_record));
     fake_record.active_id = UT_OBJID_2;
 
@@ -260,8 +261,7 @@ void Test_OS_TimeBase_CallbackThread(void)
     TimerSyncCount                     = 0;
     TimerSyncRetVal                    = 0;
     TimeCB                             = 0;
-    idbuf                              = UT_OBJID_2;
-    UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &idbuf, sizeof(idbuf), false);
+    UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &local_index, sizeof(local_index), false);
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &recptr, sizeof(recptr), false);
     UT_SetHookFunction(UT_KEY(OS_TimeBaseLock_Impl), ClearObjectsHook, recptr);
     OS_TimeBase_CallbackThread(UT_OBJID_2);
@@ -272,8 +272,7 @@ void Test_OS_TimeBase_CallbackThread(void)
     TimerSyncCount        = 0;
     TimerSyncRetVal       = 1000;
     fake_record.active_id = UT_OBJID_2;
-    idbuf                 = UT_OBJID_2;
-    UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &idbuf, sizeof(idbuf), false);
+    UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &local_index, sizeof(local_index), false);
     UT_SetDataBuffer(UT_KEY(OS_ObjectIdGetById), &recptr, sizeof(recptr), false);
     UT_SetHookFunction(UT_KEY(OS_TimeBaseLock_Impl), ClearObjectsHook, recptr);
     OS_TimeBase_CallbackThread(UT_OBJID_2);

--- a/src/unit-test-coverage/shared/src/os-shared-coveragetest.h
+++ b/src/unit-test-coverage/shared/src/os-shared-coveragetest.h
@@ -74,6 +74,10 @@ typedef union
 #define UT_OBJID_OTHER ((osal_id_t) {0x12345})
 #define UT_OBJID_MAX   ((osal_id_t) {0xFFFFFFFF})
 
+#define UT_INDEX_0 OSAL_INDEX_C(0)
+#define UT_INDEX_1 OSAL_INDEX_C(1)
+#define UT_INDEX_2 OSAL_INDEX_C(2)
+
 /*
  * Setup function prior to every test
  */

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_bsp-impl.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_bsp-impl.h
@@ -70,7 +70,7 @@
 
        Note: This should write the string as-is without buffering.
  ------------------------------------------------------------------*/
-extern void OCS_OS_BSP_ConsoleOutput_Impl(const char *Str, uint32_t DataLen);
+extern void OCS_OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen);
 
 /*----------------------------------------------------------------
    Function: OS_BSP_ConsoleSetMode_Impl

--- a/src/unit-test-coverage/ut-stubs/src/bsp-console-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/bsp-console-impl-stubs.c
@@ -43,7 +43,7 @@
 
        Note: This should write the string as-is without buffering.
  ------------------------------------------------------------------*/
-void OCS_OS_BSP_ConsoleOutput_Impl(const char *Str, uint32_t DataLen)
+void OCS_OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen)
 {
     int32_t retcode = UT_DEFAULT_IMPL(OCS_OS_BSP_ConsoleOutput_Impl);
 

--- a/src/unit-test-coverage/ut-stubs/src/libc-stdio-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/libc-stdio-stubs.c
@@ -45,7 +45,7 @@ int OCS_fclose(OCS_FILE *stream)
 char *OCS_fgets(char *s, int n, OCS_FILE *stream)
 {
     int32  Status;
-    uint32 CopySize;
+    size_t CopySize;
 
     Status = UT_DEFAULT_IMPL_RC(OCS_fgets, OCS_STDIO_MAX_SIZE);
 

--- a/src/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -92,7 +92,7 @@ void *OCS_malloc(size_t sz)
     cpuaddr           PoolEnd;
     cpuaddr           NextBlock;
     size_t            NextSize;
-    uint32            PoolSize;
+    size_t            PoolSize;
     uint32            CallCnt;
     struct MPOOL_REC *Rec;
 
@@ -163,7 +163,7 @@ void OCS_free(void *ptr)
     int32             Status;
     cpuaddr           BlockAddr;
     void *            PoolPtr;
-    uint32            PoolSize;
+    size_t            PoolSize;
     struct MPOOL_REC *Rec;
 
     /*

--- a/src/unit-test-coverage/ut-stubs/src/osapi-binsem-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-binsem-impl-stubs.c
@@ -38,10 +38,10 @@
 ** Semaphore API
 */
 
-UT_DEFAULT_STUB(OS_BinSemCreate_Impl, (uint32 sem_id, uint32 sem_initial_value, uint32 options))
-UT_DEFAULT_STUB(OS_BinSemFlush_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_BinSemGive_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_BinSemTake_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_BinSemTimedWait_Impl, (uint32 sem_id, uint32 msecs))
-UT_DEFAULT_STUB(OS_BinSemDelete_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_BinSemGetInfo_Impl, (uint32 sem_id, OS_bin_sem_prop_t *bin_prop))
+UT_DEFAULT_STUB(OS_BinSemCreate_Impl, (osal_index_t sem_id, uint32 sem_initial_value, uint32 options))
+UT_DEFAULT_STUB(OS_BinSemFlush_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_BinSemGive_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_BinSemTake_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_BinSemTimedWait_Impl, (osal_index_t sem_id, uint32 msecs))
+UT_DEFAULT_STUB(OS_BinSemDelete_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_BinSemGetInfo_Impl, (osal_index_t sem_id, OS_bin_sem_prop_t *bin_prop))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-common-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-common-impl-stubs.c
@@ -34,7 +34,7 @@
 
 #include "os-shared-common.h"
 
-UT_DEFAULT_STUB(OS_API_Impl_Init, (uint32 idtype))
+UT_DEFAULT_STUB(OS_API_Impl_Init, (osal_objtype_t idtype))
 
 void OS_IdleLoop_Impl(void)
 {

--- a/src/unit-test-coverage/ut-stubs/src/osapi-console-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-console-impl-stubs.c
@@ -37,11 +37,11 @@
 /*
 ** Console output API (printf)
 */
-void OS_ConsoleWakeup_Impl(uint32 local_id)
+void OS_ConsoleWakeup_Impl(osal_index_t local_id)
 {
     UT_DEFAULT_IMPL(OS_ConsoleWakeup_Impl);
 }
-int32 OS_ConsoleCreate_Impl(uint32 local_id)
+int32 OS_ConsoleCreate_Impl(osal_index_t local_id)
 {
     return UT_DEFAULT_IMPL(OS_ConsoleCreate_Impl);
 }

--- a/src/unit-test-coverage/ut-stubs/src/osapi-countsem-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-countsem-impl-stubs.c
@@ -38,9 +38,9 @@
 ** Semaphore API
 */
 
-UT_DEFAULT_STUB(OS_CountSemCreate_Impl, (uint32 sem_id, uint32 sem_initial_value, uint32 options))
-UT_DEFAULT_STUB(OS_CountSemGive_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_CountSemTake_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_CountSemTimedWait_Impl, (uint32 sem_id, uint32 msecs))
-UT_DEFAULT_STUB(OS_CountSemDelete_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_CountSemGetInfo_Impl, (uint32 sem_id, OS_count_sem_prop_t *count_prop))
+UT_DEFAULT_STUB(OS_CountSemCreate_Impl, (osal_index_t sem_id, uint32 sem_initial_value, uint32 options))
+UT_DEFAULT_STUB(OS_CountSemGive_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_CountSemTake_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_CountSemTimedWait_Impl, (osal_index_t sem_id, uint32 msecs))
+UT_DEFAULT_STUB(OS_CountSemDelete_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_CountSemGetInfo_Impl, (osal_index_t sem_id, OS_count_sem_prop_t *count_prop))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-file-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-file-impl-stubs.c
@@ -39,27 +39,27 @@
  * File API abstraction layer
  */
 
-UT_DEFAULT_STUB(OS_FileOpen_Impl, (uint32 file_id, const char *local_path, int32 flags, int32 access))
+UT_DEFAULT_STUB(OS_FileOpen_Impl, (osal_index_t file_id, const char *local_path, int32 flags, int32 access))
 UT_DEFAULT_STUB(OS_FileStat_Impl, (const char *local_path, os_fstat_t *filestat))
 UT_DEFAULT_STUB(OS_FileRemove_Impl, (const char *local_path))
 UT_DEFAULT_STUB(OS_FileRename_Impl, (const char *old_path, const char *new_path))
 UT_DEFAULT_STUB(OS_FileChmod_Impl, (const char *local_path, uint32 access))
-UT_DEFAULT_STUB(OS_ShellOutputToFile_Impl, (uint32 file_id, const char *Cmd))
+UT_DEFAULT_STUB(OS_ShellOutputToFile_Impl, (osal_index_t file_id, const char *Cmd))
 
 /*
  * Directory API abstraction layer
  */
 UT_DEFAULT_STUB(OS_DirCreate_Impl, (const char *local_path, uint32 access))
-UT_DEFAULT_STUB(OS_DirOpen_Impl, (uint32 dir_id, const char *local_path))
-UT_DEFAULT_STUB(OS_DirClose_Impl, (uint32 dir_id))
-UT_DEFAULT_STUB(OS_DirRead_Impl, (uint32 dir_id, os_dirent_t *dirent))
-UT_DEFAULT_STUB(OS_DirRewind_Impl, (uint32 dir_id))
+UT_DEFAULT_STUB(OS_DirOpen_Impl, (osal_index_t dir_id, const char *local_path))
+UT_DEFAULT_STUB(OS_DirClose_Impl, (osal_index_t dir_id))
+UT_DEFAULT_STUB(OS_DirRead_Impl, (osal_index_t dir_id, os_dirent_t *dirent))
+UT_DEFAULT_STUB(OS_DirRewind_Impl, (osal_index_t dir_id))
 UT_DEFAULT_STUB(OS_DirRemove_Impl, (const char *local_path))
 
 /*
  * Stream abstraction layer (applies to sockets and files)
  */
-int32 OS_GenericRead_Impl(uint32 stream_id, void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_GenericRead_Impl(osal_index_t local_id, void *buffer, size_t nbytes, int32 timeout)
 {
     int32 Status = UT_DEFAULT_IMPL(OS_GenericRead_Impl);
 
@@ -71,7 +71,7 @@ int32 OS_GenericRead_Impl(uint32 stream_id, void *buffer, uint32 nbytes, int32 t
     return Status;
 }
 
-int32 OS_GenericWrite_Impl(uint32 stream_id, const void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_GenericWrite_Impl(osal_index_t local_id, const void *buffer, size_t nbytes, int32 timeout)
 {
     int32 Status = UT_DEFAULT_IMPL(OS_GenericWrite_Impl);
 
@@ -83,5 +83,5 @@ int32 OS_GenericWrite_Impl(uint32 stream_id, const void *buffer, uint32 nbytes, 
     return Status;
 }
 
-UT_DEFAULT_STUB(OS_GenericSeek_Impl, (uint32 file_id, int32 offset, uint32 whence))
-UT_DEFAULT_STUB(OS_GenericClose_Impl, (uint32 file_id))
+UT_DEFAULT_STUB(OS_GenericSeek_Impl, (osal_index_t file_id, int32 offset, uint32 whence))
+UT_DEFAULT_STUB(OS_GenericClose_Impl, (osal_index_t file_id))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-filesys-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-filesys-impl-stubs.c
@@ -36,14 +36,14 @@
 /*
  * File system abstraction layer
  */
-UT_DEFAULT_STUB(OS_FileSysStartVolume_Impl, (uint32 filesys_id))
-UT_DEFAULT_STUB(OS_FileSysStopVolume_Impl, (uint32 filesys_id))
-UT_DEFAULT_STUB(OS_FileSysFormatVolume_Impl, (uint32 filesys_id))
-UT_DEFAULT_STUB(OS_FileSysCheckVolume_Impl, (uint32 filesys_id, bool repair))
-UT_DEFAULT_STUB(OS_FileSysMountVolume_Impl, (uint32 filesys_id))
-UT_DEFAULT_STUB(OS_FileSysUnmountVolume_Impl, (uint32 filesys_id))
+UT_DEFAULT_STUB(OS_FileSysStartVolume_Impl, (osal_index_t filesys_id))
+UT_DEFAULT_STUB(OS_FileSysStopVolume_Impl, (osal_index_t filesys_id))
+UT_DEFAULT_STUB(OS_FileSysFormatVolume_Impl, (osal_index_t filesys_id))
+UT_DEFAULT_STUB(OS_FileSysCheckVolume_Impl, (osal_index_t filesys_id, bool repair))
+UT_DEFAULT_STUB(OS_FileSysMountVolume_Impl, (osal_index_t filesys_id))
+UT_DEFAULT_STUB(OS_FileSysUnmountVolume_Impl, (osal_index_t filesys_id))
 
-int32 OS_FileSysStatVolume_Impl(uint32 filesys_id, OS_statvfs_t *result)
+int32 OS_FileSysStatVolume_Impl(osal_index_t filesys_id, OS_statvfs_t *result)
 {
     int32 Status = UT_DEFAULT_IMPL(OS_FileSysStatVolume_Impl);
 

--- a/src/unit-test-coverage/ut-stubs/src/osapi-idmap-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-idmap-impl-stubs.c
@@ -38,5 +38,5 @@
  * Table locking and unlocking for global objects can be done at the shared code
  * layer but the actual implementation is OS-specific
  */
-UT_DEFAULT_STUB(OS_Lock_Global_Impl, (uint32 idtype))
-UT_DEFAULT_STUB(OS_Unlock_Global_Impl, (uint32 idtype))
+UT_DEFAULT_STUB(OS_Lock_Global_Impl, (osal_objtype_t idtype))
+UT_DEFAULT_STUB(OS_Unlock_Global_Impl, (osal_objtype_t idtype))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-loader-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-loader-impl-stubs.c
@@ -36,9 +36,9 @@
 /*
  * Module Loader API
  */
-UT_DEFAULT_STUB(OS_ModuleLoad_Impl, (uint32 module_id, const char *translated_path))
-UT_DEFAULT_STUB(OS_ModuleUnload_Impl, (uint32 module_id))
-UT_DEFAULT_STUB(OS_ModuleGetInfo_Impl, (uint32 module_id, OS_module_prop_t *module_prop))
+UT_DEFAULT_STUB(OS_ModuleLoad_Impl, (osal_index_t module_id, const char *translated_path))
+UT_DEFAULT_STUB(OS_ModuleUnload_Impl, (osal_index_t module_id))
+UT_DEFAULT_STUB(OS_ModuleGetInfo_Impl, (osal_index_t module_id, OS_module_prop_t *module_prop))
 UT_DEFAULT_STUB(OS_GlobalSymbolLookup_Impl, (cpuaddr * SymbolAddress, const char *SymbolName))
-UT_DEFAULT_STUB(OS_ModuleSymbolLookup_Impl, (uint32 module_id, cpuaddr * SymbolAddress, const char *SymbolName))
-UT_DEFAULT_STUB(OS_SymbolTableDump_Impl, (const char *filename, uint32 size_limit))
+UT_DEFAULT_STUB(OS_ModuleSymbolLookup_Impl, (osal_index_t module_id, cpuaddr *SymbolAddress, const char *SymbolName))
+UT_DEFAULT_STUB(OS_SymbolTableDump_Impl, (const char *filename, size_t size_limit))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-mutex-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-mutex-impl-stubs.c
@@ -38,8 +38,8 @@
 ** Mutex API
 */
 
-UT_DEFAULT_STUB(OS_MutSemCreate_Impl, (uint32 sem_id, uint32 options))
-UT_DEFAULT_STUB(OS_MutSemGive_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_MutSemTake_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_MutSemDelete_Impl, (uint32 sem_id))
-UT_DEFAULT_STUB(OS_MutSemGetInfo_Impl, (uint32 sem_id, OS_mut_sem_prop_t *mut_prop))
+UT_DEFAULT_STUB(OS_MutSemCreate_Impl, (osal_index_t sem_id, uint32 options))
+UT_DEFAULT_STUB(OS_MutSemGive_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_MutSemTake_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_MutSemDelete_Impl, (osal_index_t sem_id))
+UT_DEFAULT_STUB(OS_MutSemGetInfo_Impl, (osal_index_t sem_id, OS_mut_sem_prop_t *mut_prop))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-network-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-network-impl-stubs.c
@@ -37,23 +37,24 @@
 /*
  * Sockets API abstraction layer
  */
-UT_DEFAULT_STUB(OS_SocketOpen_Impl, (uint32 sock_id))
-UT_DEFAULT_STUB(OS_SocketClose_Impl, (uint32 sock_id))
-UT_DEFAULT_STUB(OS_SocketBind_Impl, (uint32 sock_id, const OS_SockAddr_t *Addr))
-UT_DEFAULT_STUB(OS_SocketAccept_Impl, (uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Addr, int32 timeout))
-UT_DEFAULT_STUB(OS_SocketConnect_Impl, (uint32 sock_id, const OS_SockAddr_t *Addr, int32 timeout))
+UT_DEFAULT_STUB(OS_SocketOpen_Impl, (osal_index_t sock_id))
+UT_DEFAULT_STUB(OS_SocketClose_Impl, (osal_index_t sock_id))
+UT_DEFAULT_STUB(OS_SocketBind_Impl, (osal_index_t sock_id, const OS_SockAddr_t *Addr))
+UT_DEFAULT_STUB(OS_SocketAccept_Impl,
+                (osal_index_t sock_id, osal_index_t connsock_id, OS_SockAddr_t *Addr, int32 timeout))
+UT_DEFAULT_STUB(OS_SocketConnect_Impl, (osal_index_t sock_id, const OS_SockAddr_t *Addr, int32 timeout))
 UT_DEFAULT_STUB(OS_SocketRecvFrom_Impl,
-                (uint32 sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout))
+                (osal_index_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout))
 UT_DEFAULT_STUB(OS_SocketSendTo_Impl,
-                (uint32 sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr))
-UT_DEFAULT_STUB(OS_SocketGetInfo_Impl, (uint32 sock_id, OS_socket_prop_t *sock_prop))
+                (osal_index_t sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr))
+UT_DEFAULT_STUB(OS_SocketGetInfo_Impl, (osal_index_t sock_id, OS_socket_prop_t *sock_prop))
 
 UT_DEFAULT_STUB(OS_SocketAddrInit_Impl, (OS_SockAddr_t * Addr, OS_SocketDomain_t Domain))
-UT_DEFAULT_STUB(OS_SocketAddrToString_Impl, (char *buffer, uint32 buflen, const OS_SockAddr_t *Addr))
+UT_DEFAULT_STUB(OS_SocketAddrToString_Impl, (char *buffer, size_t buflen, const OS_SockAddr_t *Addr))
 UT_DEFAULT_STUB(OS_SocketAddrGetPort_Impl, (uint16 * PortNum, const OS_SockAddr_t *Addr))
 UT_DEFAULT_STUB(OS_SocketAddrFromString_Impl, (OS_SockAddr_t * Addr, const char *string))
 UT_DEFAULT_STUB(OS_SocketAddrSetPort_Impl, (OS_SockAddr_t * Addr, uint16 PortNum))
-UT_DEFAULT_STUB(OS_NetworkGetHostName_Impl, (char *host_name, uint32 name_len))
+UT_DEFAULT_STUB(OS_NetworkGetHostName_Impl, (char *host_name, size_t name_len))
 
 int32 OS_NetworkGetID_Impl(int32 *IdBuf)
 {

--- a/src/unit-test-coverage/ut-stubs/src/osapi-queue-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-queue-impl-stubs.c
@@ -38,8 +38,8 @@
 ** Message Queue API
 */
 
-UT_DEFAULT_STUB(OS_QueueCreate_Impl, (uint32 queue_id, uint32 flags))
-UT_DEFAULT_STUB(OS_QueueDelete_Impl, (uint32 queue_id))
-UT_DEFAULT_STUB(OS_QueueGet_Impl, (uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout))
-UT_DEFAULT_STUB(OS_QueuePut_Impl, (uint32 queue_id, const void *data, uint32 size, uint32 flags))
-UT_DEFAULT_STUB(OS_QueueGetInfo_Impl, (uint32 queue_id, OS_queue_prop_t *queue_prop))
+UT_DEFAULT_STUB(OS_QueueCreate_Impl, (osal_index_t queue_id, uint32 flags))
+UT_DEFAULT_STUB(OS_QueueDelete_Impl, (osal_index_t queue_id))
+UT_DEFAULT_STUB(OS_QueueGet_Impl, (osal_index_t queue_id, void *data, size_t size, size_t *size_copied, int32 timeout))
+UT_DEFAULT_STUB(OS_QueuePut_Impl, (osal_index_t queue_id, const void *data, size_t size, uint32 flags))
+UT_DEFAULT_STUB(OS_QueueGetInfo_Impl, (osal_index_t queue_id, OS_queue_prop_t *queue_prop))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-select-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-select-impl-stubs.c
@@ -33,5 +33,5 @@
 #include "utstubs.h"
 #include "os-shared-select.h"
 
-UT_DEFAULT_STUB(OS_SelectSingle_Impl, (uint32 stream_id, uint32 *SelectFlags, int32 msecs))
+UT_DEFAULT_STUB(OS_SelectSingle_Impl, (osal_index_t stream_id, uint32 *SelectFlags, int32 msecs))
 UT_DEFAULT_STUB(OS_SelectMultiple_Impl, (OS_FdSet * ReadSet, OS_FdSet *WriteSet, int32 msecs))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
@@ -37,16 +37,16 @@
 /*
 ** Task API
 */
-UT_DEFAULT_STUB(OS_TaskMatch_Impl, (uint32 task_id))
-UT_DEFAULT_STUB(OS_TaskCreate_Impl, (uint32 task_id, uint32 flags))
-UT_DEFAULT_STUB(OS_TaskDelete_Impl, (uint32 task_id))
+UT_DEFAULT_STUB(OS_TaskMatch_Impl, (osal_index_t task_id))
+UT_DEFAULT_STUB(OS_TaskCreate_Impl, (osal_index_t task_id, uint32 flags))
+UT_DEFAULT_STUB(OS_TaskDelete_Impl, (osal_index_t task_id))
 void OS_TaskExit_Impl(void)
 {
     UT_DEFAULT_IMPL(OS_TaskExit_Impl);
 }
 
 UT_DEFAULT_STUB(OS_TaskDelay_Impl, (uint32 millisecond))
-UT_DEFAULT_STUB(OS_TaskSetPriority_Impl, (uint32 task_id, uint32 new_priority))
+UT_DEFAULT_STUB(OS_TaskSetPriority_Impl, (osal_index_t task_id, osal_priority_t new_priority))
 osal_id_t OS_TaskGetId_Impl(void)
 {
     int32     status;
@@ -60,12 +60,12 @@ osal_id_t OS_TaskGetId_Impl(void)
 
     return id;
 }
-UT_DEFAULT_STUB(OS_TaskGetInfo_Impl, (uint32 task_id, OS_task_prop_t *task_prop))
+UT_DEFAULT_STUB(OS_TaskGetInfo_Impl, (osal_index_t task_id, OS_task_prop_t *task_prop))
 UT_DEFAULT_STUB(OS_TaskRegister_Impl, (osal_id_t global_task_id))
 
-bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+bool OS_TaskIdMatchSystemData_Impl(void *ref, osal_index_t local_id, const OS_common_record_t *obj)
 {
     return UT_DEFAULT_IMPL(OS_TaskIdMatchSystemData_Impl);
 }
 
-UT_DEFAULT_STUB(OS_TaskValidateSystemData_Impl, (const void *sysdata, uint32 sysdata_size))
+UT_DEFAULT_STUB(OS_TaskValidateSystemData_Impl, (const void *sysdata, size_t sysdata_size))

--- a/src/unit-test-coverage/ut-stubs/src/osapi-timer-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-timer-impl-stubs.c
@@ -38,7 +38,7 @@
 ** OS Time/Tick related API
 */
 UT_DEFAULT_STUB(OS_TimeBaseCreate_Impl, (osal_index_t timer_id))
-UT_DEFAULT_STUB(OS_TimeBaseSet_Impl, (osal_index_t timer_id, int32 start_time, int32 interval_time))
+UT_DEFAULT_STUB(OS_TimeBaseSet_Impl, (osal_index_t timer_id, uint32 start_time, uint32 interval_time))
 UT_DEFAULT_STUB(OS_TimeBaseDelete_Impl, (osal_index_t timer_id))
 void OS_TimeBaseLock_Impl(osal_index_t timebase_id)
 {

--- a/src/unit-test-coverage/ut-stubs/src/osapi-timer-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-timer-impl-stubs.c
@@ -37,22 +37,22 @@
 /*
 ** OS Time/Tick related API
 */
-UT_DEFAULT_STUB(OS_TimeBaseCreate_Impl, (uint32 timer_id))
-UT_DEFAULT_STUB(OS_TimeBaseSet_Impl, (uint32 timer_id, int32 start_time, int32 interval_time))
-UT_DEFAULT_STUB(OS_TimeBaseDelete_Impl, (uint32 timer_id))
-void OS_TimeBaseLock_Impl(uint32 timebase_id)
+UT_DEFAULT_STUB(OS_TimeBaseCreate_Impl, (osal_index_t timer_id))
+UT_DEFAULT_STUB(OS_TimeBaseSet_Impl, (osal_index_t timer_id, int32 start_time, int32 interval_time))
+UT_DEFAULT_STUB(OS_TimeBaseDelete_Impl, (osal_index_t timer_id))
+void OS_TimeBaseLock_Impl(osal_index_t timebase_id)
 {
     UT_DEFAULT_IMPL(OS_TimeBaseLock_Impl);
 }
 
-void OS_TimeBaseUnlock_Impl(uint32 timebase_id)
+void OS_TimeBaseUnlock_Impl(osal_index_t timebase_id)
 {
     UT_DEFAULT_IMPL(OS_TimeBaseUnlock_Impl);
 }
 
-UT_DEFAULT_STUB(OS_TimeBaseGetInfo_Impl, (uint32 timer_id, OS_timebase_prop_t *timer_prop))
+UT_DEFAULT_STUB(OS_TimeBaseGetInfo_Impl, (osal_index_t timer_id, OS_timebase_prop_t *timer_prop))
 
-UT_DEFAULT_STUB(OS_TimeBaseRegister_Impl, (uint32 timebase_id))
+UT_DEFAULT_STUB(OS_TimeBaseRegister_Impl, (osal_index_t timebase_id))
 /*
  * Clock API low-level handlers
  */

--- a/src/unit-test-coverage/ut-stubs/src/portable-console-bsp-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/portable-console-bsp-impl-stubs.c
@@ -37,7 +37,7 @@
 /*
 ** Console output API (printf)
 */
-void OS_ConsoleOutput_Impl(uint32 local_id)
+void OS_ConsoleOutput_Impl(osal_index_t local_id)
 {
     UT_DEFAULT_IMPL(OS_ConsoleOutput_Impl);
 }

--- a/src/unit-test-coverage/ut-stubs/src/posix-unistd-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/posix-unistd-stubs.c
@@ -99,7 +99,7 @@ OCS_off_t OCS_lseek(int fd, OCS_off_t offset, int whence)
 OCS_ssize_t OCS_read(int fd, void *buf, size_t n)
 {
     int32  Status;
-    uint32 CopySize;
+    size_t CopySize;
 
     Status = UT_DEFAULT_IMPL_RC(OCS_read, OCS_MAX_RDWR_SIZE);
 
@@ -159,7 +159,7 @@ long int OCS_sysconf(int name)
 OCS_ssize_t OCS_write(int fd, const void *buf, size_t n)
 {
     int32  Status;
-    uint32 CopySize;
+    size_t CopySize;
 
     Status = UT_DEFAULT_IMPL_RC(OCS_write, OCS_MAX_RDWR_SIZE);
 

--- a/src/unit-test-coverage/ut-stubs/src/vxworks-intLib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/vxworks-intLib-stubs.c
@@ -53,7 +53,7 @@ OCS_VOIDFUNCPTR *OCS_INUM_TO_IVEC(unsigned int ui)
     int32            Status = UT_DEFAULT_IMPL(OCS_INUM_TO_IVEC);
     OCS_VOIDFUNCPTR *VecTbl;
     OCS_VOIDFUNCPTR  DummyVec;
-    uint32           VecTblSize;
+    size_t           VecTblSize;
 
     if (Status == 0)
     {

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-console.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-console.h
@@ -42,6 +42,6 @@ extern void UT_ConsoleTest_TaskEntry(int arg);
 /**
  * Force the "is_async" field to a given state for coverage testing
  */
-extern void UT_ConsoleTest_SetConsoleAsync(uint32 local_id, bool is_async);
+extern void UT_ConsoleTest_SetConsoleAsync(osal_index_t local_id, bool is_async);
 
 #endif /* INCLUDE_UT_ADAPTOR_CONSOLE_H_ */

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-files.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-files.h
@@ -53,6 +53,6 @@ extern int32 UT_Call_OS_VxWorks_StreamAPI_Impl_Init(void);
 unsigned int UT_FileTest_GetSelfEUID(void);
 unsigned int UT_FileTest_GetSelfEGID(void);
 
-void UT_FileTest_Set_Selectable(uint32 local_id, bool is_selectable);
+void UT_FileTest_Set_Selectable(osal_index_t local_id, bool is_selectable);
 
 #endif /* INCLUDE_UT_ADAPTOR_FILES_H_ */

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-filesys.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-filesys.h
@@ -34,6 +34,6 @@
 extern void *const  UT_Ref_OS_impl_filesys_table;
 extern size_t const UT_Ref_OS_impl_filesys_table_SIZE;
 
-void UT_FileSysTest_SetupFileSysEntry(uint32 id, OCS_BLK_DEV *blkdev, OCS_device_t xbddev, uint32 MaxParts);
+void UT_FileSysTest_SetupFileSysEntry(osal_index_t id, OCS_BLK_DEV *blkdev, OCS_device_t xbddev, uint32 MaxParts);
 
 #endif /* INCLUDE_UT_ADAPTOR_FILESYS_H_ */

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-idmap.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-idmap.h
@@ -39,7 +39,7 @@
  * but are not part of the implementation API.
  *
  *****************************************************/
-int32 UT_Call_OS_VxWorks_TableMutex_Init(uint32 idtype);
-void  UT_IdMapTest_SetImplTableMutex(uint32 idtype, OCS_SEM_ID vxid);
+int32 UT_Call_OS_VxWorks_TableMutex_Init(osal_objtype_t idtype);
+void  UT_IdMapTest_SetImplTableMutex(osal_objtype_t idtype, OCS_SEM_ID vxid);
 
 #endif /* INCLUDE_UT_ADAPTOR_IDMAP_H_ */

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-symtab.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-symtab.h
@@ -30,6 +30,6 @@
 
 #include <common_types.h>
 
-int32 UT_SymTabTest_CallIteratorFunc(const char *name, void *val, uint32 TestSize, uint32 SizeLimit);
+int32 UT_SymTabTest_CallIteratorFunc(const char *name, void *val, size_t TestSize, size_t SizeLimit);
 
 #endif /* INCLUDE_UT_ADAPTOR_SYMTAB_H_ */

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-tasks.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-tasks.h
@@ -44,8 +44,8 @@ extern size_t const UT_Ref_OS_impl_task_table_SIZE;
  *****************************************************/
 
 int32         UT_Call_OS_VxWorks_TaskAPI_Impl_Init(void);
-void          UT_TaskTest_SetImplTaskId(uint32 local_id, OCS_TASK_ID TaskId);
+void          UT_TaskTest_SetImplTaskId(osal_index_t local_id, OCS_TASK_ID TaskId);
 int           UT_TaskTest_CallEntryPoint(int arg);
-OCS_WIND_TCB *UT_TaskTest_GetTaskTcb(uint32 local_id);
+OCS_WIND_TCB *UT_TaskTest_GetTaskTcb(osal_index_t local_id);
 
 #endif /* INCLUDE_UT_ADAPTOR_TASKS_H_ */

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-timebase.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-timebase.h
@@ -37,27 +37,27 @@ extern size_t const UT_Ref_OS_impl_timebase_table_SIZE;
 
 int32 UT_Call_OS_VxWorks_TimeBaseAPI_Impl_Init(void);
 
-void UT_TimeBaseTest_Setup(uint32 local_id, int signo, bool reset_flag);
+void UT_TimeBaseTest_Setup(osal_index_t local_id, int signo, bool reset_flag);
 
 /**
  * Invokes OS_VxWorks_SigWait() with the given arguments.
  * This is normally a static function but exposed via a non-static wrapper for UT purposes.
  */
-int32 UT_TimeBaseTest_CallSigWaitFunc(uint32 local_id);
+int32 UT_TimeBaseTest_CallSigWaitFunc(osal_index_t local_id);
 
 /* Invokes the static OS_VxWorks_TimeBaseTask() function with given argument */
 int UT_TimeBaseTest_CallHelperTaskFunc(int arg);
 
 /* Invokes the static OS_VxWorks_RegisterTimer() function with given argument */
-void UT_TimeBaseTest_CallRegisterTimer(uint32 local_id);
+void UT_TimeBaseTest_CallRegisterTimer(osal_index_t local_id);
 
 /* Hook functions which set the timer registration state */
-void UT_TimeBaseTest_SetTimeBaseRegState(uint32 local_id, bool is_success);
-void UT_TimeBaseTest_ClearTimeBaseRegState(uint32 local_id);
+void UT_TimeBaseTest_SetTimeBaseRegState(osal_index_t local_id, bool is_success);
+void UT_TimeBaseTest_ClearTimeBaseRegState(osal_index_t local_id);
 
 /* Hook functions which test the timer registration state */
-bool UT_TimeBaseTest_CheckTimeBaseRegisteredState(uint32 local_id);
-bool UT_TimeBaseTest_CheckTimeBaseErrorState(uint32 local_id);
+bool UT_TimeBaseTest_CheckTimeBaseRegisteredState(osal_index_t local_id);
+bool UT_TimeBaseTest_CheckTimeBaseErrorState(osal_index_t local_id);
 
 /* Invoke the internal UsecToTimespec API */
 void UT_TimeBaseTest_UsecToTimespec(uint32 usecs, struct OCS_timespec *time_spec);

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-console.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-console.c
@@ -40,7 +40,7 @@ void UT_ConsoleTest_TaskEntry(int arg)
     OS_VxWorks_ConsoleTask_Entry(arg);
 }
 
-void UT_ConsoleTest_SetConsoleAsync(uint32 local_id, bool is_async)
+void UT_ConsoleTest_SetConsoleAsync(osal_index_t local_id, bool is_async)
 {
     OS_impl_console_table[local_id].is_async = is_async;
 }

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-files.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-files.c
@@ -53,7 +53,7 @@ unsigned int UT_FileTest_GetSelfEGID(void)
     return OS_IMPL_SELF_EGID;
 }
 
-void UT_FileTest_Set_Selectable(uint32 local_id, bool is_selectable)
+void UT_FileTest_Set_Selectable(osal_index_t local_id, bool is_selectable)
 {
     OS_impl_filehandle_table[local_id].selectable = is_selectable;
 }

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filesys.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filesys.c
@@ -34,7 +34,7 @@
 void *const  UT_Ref_OS_impl_filesys_table      = OS_impl_filesys_table;
 size_t const UT_Ref_OS_impl_filesys_table_SIZE = sizeof(OS_impl_filesys_table);
 
-void UT_FileSysTest_SetupFileSysEntry(uint32 id, OCS_BLK_DEV *blkdev, OCS_device_t xbddev, uint32 MaxParts)
+void UT_FileSysTest_SetupFileSysEntry(osal_index_t id, OCS_BLK_DEV *blkdev, OCS_device_t xbddev, uint32 MaxParts)
 {
     OS_impl_filesys_table[id].blkDev           = blkdev;
     OS_impl_filesys_table[id].xbd              = xbddev;

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filetable-stub.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filetable-stub.c
@@ -31,7 +31,7 @@
 #include <os-vxworks.h>
 #include <os-impl-files.h>
 
-OS_VxWorks_filehandle_entry_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+OS_impl_file_internal_record_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
 
 void *const  UT_FileTableTest_OS_impl_filehandle_table      = OS_impl_filehandle_table;
 size_t const UT_FileTableTest_OS_impl_filehandle_table_SIZE = sizeof(OS_impl_filehandle_table);

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-idmap.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-idmap.c
@@ -32,12 +32,12 @@
 #include <os-vxworks.h>
 #include "ut-adaptor-idmap.h"
 
-int32 UT_Call_OS_VxWorks_TableMutex_Init(uint32 idtype)
+int32 UT_Call_OS_VxWorks_TableMutex_Init(osal_objtype_t idtype)
 {
     return OS_VxWorks_TableMutex_Init(idtype);
 }
 
-void UT_IdMapTest_SetImplTableMutex(uint32 idtype, OCS_SEM_ID vxid)
+void UT_IdMapTest_SetImplTableMutex(osal_objtype_t idtype, OCS_SEM_ID vxid)
 {
     VX_MUTEX_TABLE[idtype].vxid = vxid;
 }

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-symtab.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-symtab.c
@@ -36,7 +36,7 @@
  * A UT-specific wrapper function to invoke the Symbol Table Iterator.
  * This is normally static so it needs this wrapper to call it.
  */
-int32 UT_SymTabTest_CallIteratorFunc(const char *name, void *val, uint32 TestSize, uint32 SizeLimit)
+int32 UT_SymTabTest_CallIteratorFunc(const char *name, void *val, size_t TestSize, size_t SizeLimit)
 {
     OS_VxWorks_SymbolDumpState.Sizelimit = SizeLimit;
     OS_VxWorks_SymbolDumpState.CurrSize  = TestSize;

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-tasks.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-tasks.c
@@ -40,7 +40,7 @@ int32 UT_Call_OS_VxWorks_TaskAPI_Impl_Init(void)
     return OS_VxWorks_TaskAPI_Impl_Init();
 }
 
-void UT_TaskTest_SetImplTaskId(uint32 local_id, OCS_TASK_ID TaskId)
+void UT_TaskTest_SetImplTaskId(osal_index_t local_id, OCS_TASK_ID TaskId)
 {
     OS_impl_task_table[local_id].vxid = TaskId;
 }
@@ -55,7 +55,7 @@ int UT_TaskTest_CallEntryPoint(int arg)
     return OS_VxWorks_TaskEntry(arg);
 }
 
-OCS_WIND_TCB *UT_TaskTest_GetTaskTcb(uint32 local_id)
+OCS_WIND_TCB *UT_TaskTest_GetTaskTcb(osal_index_t local_id)
 {
     return &OS_impl_task_table[local_id].tcb;
 }

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-timebase.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-timebase.c
@@ -40,7 +40,7 @@ int32 UT_Call_OS_VxWorks_TimeBaseAPI_Impl_Init(void)
     return OS_VxWorks_TimeBaseAPI_Impl_Init();
 }
 
-int32 UT_TimeBaseTest_CallSigWaitFunc(uint32 local_id)
+int32 UT_TimeBaseTest_CallSigWaitFunc(osal_index_t local_id)
 {
     return OS_VxWorks_SigWait(local_id);
 }
@@ -50,27 +50,27 @@ int UT_TimeBaseTest_CallHelperTaskFunc(int arg)
     return OS_VxWorks_TimeBaseTask(arg);
 }
 
-void UT_TimeBaseTest_CallRegisterTimer(uint32 local_id)
+void UT_TimeBaseTest_CallRegisterTimer(osal_index_t local_id)
 {
     OS_VxWorks_RegisterTimer(local_id);
 }
 
-bool UT_TimeBaseTest_CheckTimeBaseRegisteredState(uint32 local_id)
+bool UT_TimeBaseTest_CheckTimeBaseRegisteredState(osal_index_t local_id)
 {
     return (OS_impl_timebase_table[local_id].timer_state == OS_TimerRegState_SUCCESS);
 }
 
-bool UT_TimeBaseTest_CheckTimeBaseErrorState(uint32 local_id)
+bool UT_TimeBaseTest_CheckTimeBaseErrorState(osal_index_t local_id)
 {
     return (OS_impl_timebase_table[local_id].timer_state == OS_TimerRegState_ERROR);
 }
 
-void UT_TimeBaseTest_ClearTimeBaseRegState(uint32 local_id)
+void UT_TimeBaseTest_ClearTimeBaseRegState(osal_index_t local_id)
 {
     OS_impl_timebase_table[local_id].timer_state = OS_TimerRegState_INIT;
 }
 
-void UT_TimeBaseTest_SetTimeBaseRegState(uint32 local_id, bool is_success)
+void UT_TimeBaseTest_SetTimeBaseRegState(osal_index_t local_id, bool is_success)
 {
     /* Mimic the setting of the Reg state global, which
      * is typically done by the task after spawning
@@ -90,7 +90,7 @@ void UT_TimeBaseTest_UsecToTimespec(uint32 usecs, struct OCS_timespec *time_spec
     OS_VxWorks_UsecToTimespec(usecs, time_spec);
 }
 
-void UT_TimeBaseTest_Setup(uint32 local_id, int signo, bool reset_flag)
+void UT_TimeBaseTest_Setup(osal_index_t local_id, int signo, bool reset_flag)
 {
     static OCS_WIND_TCB FAKE_TASK;
     static OCS_SEM      FAKE_SEM;

--- a/src/unit-test-coverage/vxworks/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-binsem.c
@@ -50,10 +50,10 @@ void Test_OS_BinSemCreate_Impl(void)
      * Test Case For:
      * int32 OS_BinSemCreate_Impl (uint32 sem_id, uint32 initial_value, uint32 options)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate_Impl(0, 0, 0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate_Impl(UT_INDEX_0, 0, 0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_semBInitialize), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate_Impl(0, 0, 0), OS_SEM_FAILURE);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate_Impl(UT_INDEX_0, 0, 0), OS_SEM_FAILURE);
 }
 
 void Test_OS_BinSemDelete_Impl(void)
@@ -62,7 +62,7 @@ void Test_OS_BinSemDelete_Impl(void)
      * Test Case For:
      * int32 OS_BinSemDelete_Impl (uint32 sem_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemDelete_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemDelete_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_BinSemGive_Impl(void)
@@ -71,10 +71,10 @@ void Test_OS_BinSemGive_Impl(void)
      * Test Case For:
      * int32 OS_BinSemGive_Impl ( uint32 sem_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemGive_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGive_Impl(UT_INDEX_0), OS_SUCCESS);
 
     UT_SetForceFail(UT_StubKey_GenericSemGive, OS_SEM_FAILURE);
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemGive_Impl(0), OS_SEM_FAILURE);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGive_Impl(UT_INDEX_0), OS_SEM_FAILURE);
 }
 
 void Test_OS_BinSemFlush_Impl(void)
@@ -83,10 +83,10 @@ void Test_OS_BinSemFlush_Impl(void)
      * Test Case For:
      * int32 OS_BinSemFlush_Impl (uint32 sem_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemFlush_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemFlush_Impl(UT_INDEX_0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_semFlush), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemFlush_Impl(0), OS_SEM_FAILURE);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemFlush_Impl(UT_INDEX_0), OS_SEM_FAILURE);
 }
 
 void Test_OS_BinSemTake_Impl(void)
@@ -95,7 +95,7 @@ void Test_OS_BinSemTake_Impl(void)
      * Test Case For:
      * int32 OS_BinSemTake_Impl ( uint32 sem_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemTake_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemTake_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_BinSemTimedWait_Impl(void)
@@ -104,13 +104,13 @@ void Test_OS_BinSemTimedWait_Impl(void)
      * Test Case For:
      * int32 OS_BinSemTimedWait_Impl ( uint32 sem_id, uint32 msecs )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(0, 100), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(UT_INDEX_0, 100), OS_SUCCESS);
 
     UT_SetForceFail(UT_StubKey_GenericSemTake, OS_SEM_FAILURE);
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(0, 100), OS_SEM_FAILURE);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(UT_INDEX_0, 100), OS_SEM_FAILURE);
 
     UT_SetForceFail(UT_KEY(OS_Milli2Ticks), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(0, 100), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(UT_INDEX_0, 100), OS_ERROR);
 }
 
 void Test_OS_BinSemGetInfo_Impl(void)
@@ -121,7 +121,7 @@ void Test_OS_BinSemGetInfo_Impl(void)
      */
     OS_bin_sem_prop_t sem_prop;
     memset(&sem_prop, 0xEE, sizeof(sem_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetInfo_Impl(0, &sem_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetInfo_Impl(UT_INDEX_0, &sem_prop), OS_SUCCESS);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/coveragetest-countsem.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-countsem.c
@@ -46,10 +46,10 @@ void Test_OS_CountSemCreate_Impl(void)
      * Test Case For:
      * int32 OS_CountSemCreate_Impl (uint32 sem_id, uint32 sem_initial_value, uint32 options)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate_Impl(0, 0, 0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate_Impl(UT_INDEX_0, 0, 0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_semCInitialize), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate_Impl(0, 0, 0), OS_SEM_FAILURE);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate_Impl(UT_INDEX_0, 0, 0), OS_SEM_FAILURE);
 }
 
 void Test_OS_CountSemDelete_Impl(void)
@@ -58,7 +58,7 @@ void Test_OS_CountSemDelete_Impl(void)
      * Test Case For:
      * int32 OS_CountSemDelete_Impl (uint32 sem_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemDelete_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemDelete_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_CountSemGive_Impl(void)
@@ -67,7 +67,7 @@ void Test_OS_CountSemGive_Impl(void)
      * Test Case For:
      * int32 OS_CountSemGive_Impl ( uint32 sem_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemGive_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemGive_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_CountSemTake_Impl(void)
@@ -76,7 +76,7 @@ void Test_OS_CountSemTake_Impl(void)
      * Test Case For:
      * int32 OS_CountSemTake_Impl ( uint32 sem_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemTake_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemTake_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_CountSemTimedWait_Impl(void)
@@ -85,10 +85,10 @@ void Test_OS_CountSemTimedWait_Impl(void)
      * Test Case For:
      * int32 OS_CountSemTimedWait_Impl ( uint32 sem_id, uint32 msecs )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemTimedWait_Impl(0, 100), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemTimedWait_Impl(UT_INDEX_0, 100), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OS_Milli2Ticks), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemTimedWait_Impl(0, 100), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemTimedWait_Impl(UT_INDEX_0, 100), OS_ERROR);
 }
 
 void Test_OS_CountSemGetInfo_Impl(void)
@@ -99,7 +99,7 @@ void Test_OS_CountSemGetInfo_Impl(void)
      */
     OS_count_sem_prop_t count_prop;
     memset(&count_prop, 0xEE, sizeof(count_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemGetInfo_Impl(0, &count_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemGetInfo_Impl(UT_INDEX_0, &count_prop), OS_SUCCESS);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/coveragetest-dirs.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-dirs.c
@@ -63,9 +63,9 @@ void Test_OS_DirOpen_Impl(void)
      * Test Case For:
      * int32 OS_DirOpen_Impl(uint32 local_id, const char *local_path)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_DirOpen_Impl(0, "dir"), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_DirOpen_Impl(UT_INDEX_0, "dir"), OS_SUCCESS);
     UT_SetForceFail(UT_KEY(OCS_opendir), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_DirOpen_Impl(0, "dir"), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_DirOpen_Impl(UT_INDEX_0, "dir"), OS_ERROR);
 }
 
 void Test_OS_DirClose_Impl(void)
@@ -74,7 +74,7 @@ void Test_OS_DirClose_Impl(void)
      * Test Case For:
      * int32 OS_DirClose_Impl(uint32 local_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_DirClose_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_DirClose_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_DirRead_Impl(void)
@@ -85,10 +85,10 @@ void Test_OS_DirRead_Impl(void)
      */
     os_dirent_t dirent_buff;
 
-    OSAPI_TEST_FUNCTION_RC(OS_DirRead_Impl(0, &dirent_buff), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_DirRead_Impl(UT_INDEX_0, &dirent_buff), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_readdir), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_DirRead_Impl(0, &dirent_buff), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_DirRead_Impl(UT_INDEX_0, &dirent_buff), OS_ERROR);
 }
 
 void Test_OS_DirRewind_Impl(void)
@@ -97,7 +97,7 @@ void Test_OS_DirRewind_Impl(void)
      * Test Case For:
      * int32 OS_DirRewind_Impl(uint32 local_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_DirRewind_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_DirRewind_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_DirRemove_Impl(void)

--- a/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
@@ -50,12 +50,12 @@ void Test_OS_ModuleLoad_Impl(void)
     /* Test Case For:
      * int32 OS_ModuleLoad_Impl ( uint32 module_id, char *translated_path )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(0, "local"), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(UT_INDEX_0, "local"), OS_SUCCESS);
     UT_SetForceFail(UT_KEY(OCS_open), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(0, "local"), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(UT_INDEX_0, "local"), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_open));
     UT_SetForceFail(UT_KEY(OCS_loadModule), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(0, "local"), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(UT_INDEX_0, "local"), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_loadModule));
 }
 
@@ -64,9 +64,9 @@ void Test_OS_ModuleUnload_Impl(void)
     /* Test Case For:
      * int32 OS_ModuleUnload_Impl ( uint32 module_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(UT_INDEX_0), OS_SUCCESS);
     UT_SetForceFail(UT_KEY(OCS_unldByModuleId), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(UT_INDEX_0), OS_ERROR);
     UT_ClearForceFail(UT_KEY(OCS_unldByModuleId));
 }
 
@@ -78,7 +78,7 @@ void Test_OS_ModuleGetInfo_Impl(void)
     OS_module_prop_t module_prop;
 
     memset(&module_prop, 0, sizeof(module_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(0, &module_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(UT_INDEX_0, &module_prop), OS_SUCCESS);
     UtAssert_True(module_prop.addr.valid, "addresses in output valid");
 
     /*
@@ -87,7 +87,7 @@ void Test_OS_ModuleGetInfo_Impl(void)
      */
     memset(&module_prop, 0, sizeof(module_prop));
     UT_SetForceFail(UT_KEY(OCS_moduleInfoGet), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(0, &module_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(UT_INDEX_0, &module_prop), OS_SUCCESS);
     UT_ClearForceFail(UT_KEY(OCS_moduleInfoGet));
     UtAssert_True(!module_prop.addr.valid, "addresses in output not valid");
 }

--- a/src/unit-test-coverage/vxworks/src/coveragetest-mutex.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-mutex.c
@@ -43,10 +43,10 @@ void Test_OS_MutSemCreate_Impl(void)
      * Test Case For:
      * int32 OS_MutSemCreate_Impl (uint32 sem_id, uint32 options)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate_Impl(0, 0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate_Impl(UT_INDEX_0, 0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_semMInitialize), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate_Impl(0, 0), OS_SEM_FAILURE);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate_Impl(UT_INDEX_0, 0), OS_SEM_FAILURE);
 }
 
 void Test_OS_MutSemDelete_Impl(void)
@@ -55,7 +55,7 @@ void Test_OS_MutSemDelete_Impl(void)
      * Test Case For:
      * int32 OS_MutSemDelete_Impl (uint32 sem_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemDelete_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemDelete_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_MutSemGive_Impl(void)
@@ -64,7 +64,7 @@ void Test_OS_MutSemGive_Impl(void)
      * Test Case For:
      * int32 OS_MutSemGive_Impl ( uint32 sem_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemGive_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemGive_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_MutSemTake_Impl(void)
@@ -73,7 +73,7 @@ void Test_OS_MutSemTake_Impl(void)
      * Test Case For:
      * int32 OS_MutSemTake_Impl ( uint32 sem_id )
      */
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemTake_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemTake_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_MutSemGetInfo_Impl(void)
@@ -84,7 +84,7 @@ void Test_OS_MutSemGetInfo_Impl(void)
      */
     OS_mut_sem_prop_t mut_prop;
     memset(&mut_prop, 0xEE, sizeof(mut_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemGetInfo_Impl(0, &mut_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemGetInfo_Impl(UT_INDEX_0, &mut_prop), OS_SUCCESS);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/coveragetest-queues.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-queues.c
@@ -47,10 +47,10 @@ void Test_OS_QueueCreate_Impl(void)
      * Test Case For:
      * int32 OS_QueueCreate_Impl (uint32 queue_id, uint32 flags)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_QueueCreate_Impl(0, 0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueCreate_Impl(UT_INDEX_0, 0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_msgQCreate), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_QueueCreate_Impl(0, 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueCreate_Impl(UT_INDEX_0, 0), OS_ERROR);
 }
 
 void Test_OS_QueueDelete_Impl(void)
@@ -59,10 +59,10 @@ void Test_OS_QueueDelete_Impl(void)
      * Test Case For:
      * int32 OS_QueueDelete_Impl (uint32 queue_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_QueueDelete_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueDelete_Impl(UT_INDEX_0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_msgQDelete), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_QueueDelete_Impl(0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueDelete_Impl(UT_INDEX_0), OS_ERROR);
 }
 
 void Test_OS_QueueGet_Impl(void)
@@ -72,22 +72,22 @@ void Test_OS_QueueGet_Impl(void)
      * int32 OS_QueueGet_Impl (uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
      */
     char   Data[16];
-    uint32 ActSz;
+    size_t ActSz;
 
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, OS_PEND), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, 100), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, OS_PEND), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, 100), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OS_Milli2Ticks), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, 100), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, 100), OS_ERROR);
 
     UT_SetForceFail(UT_KEY(OCS_msgQReceive), OCS_ERROR);
     OCS_errno = OCS_S_objLib_OBJ_TIMEOUT;
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_QUEUE_TIMEOUT);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_QUEUE_TIMEOUT);
     OCS_errno = OCS_S_objLib_OBJ_UNAVAILABLE;
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_QUEUE_EMPTY);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_QUEUE_EMPTY);
     OCS_errno = 0;
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet_Impl(UT_INDEX_0, &Data, sizeof(Data), &ActSz, OS_CHECK), OS_ERROR);
 }
 
 void Test_OS_QueuePut_Impl(void)
@@ -97,13 +97,13 @@ void Test_OS_QueuePut_Impl(void)
      * int32 OS_QueuePut_Impl (uint32 queue_id, const void *data, uint32 size, uint32 flags)
      */
     char Data[16] = "Test";
-    OSAPI_TEST_FUNCTION_RC(OS_QueuePut_Impl(0, Data, sizeof(Data), 0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueuePut_Impl(UT_INDEX_0, Data, sizeof(Data), 0), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_msgQSend), OCS_ERROR);
     OCS_errno = OCS_S_objLib_OBJ_UNAVAILABLE;
-    OSAPI_TEST_FUNCTION_RC(OS_QueuePut_Impl(0, Data, sizeof(Data), 0), OS_QUEUE_FULL);
+    OSAPI_TEST_FUNCTION_RC(OS_QueuePut_Impl(UT_INDEX_0, Data, sizeof(Data), 0), OS_QUEUE_FULL);
     OCS_errno = 0;
-    OSAPI_TEST_FUNCTION_RC(OS_QueuePut_Impl(0, Data, sizeof(Data), 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_QueuePut_Impl(UT_INDEX_0, Data, sizeof(Data), 0), OS_ERROR);
 }
 
 void Test_OS_QueueGetInfo_Impl(void)
@@ -114,7 +114,7 @@ void Test_OS_QueueGetInfo_Impl(void)
      */
     OS_queue_prop_t queue_prop;
     memset(&queue_prop, 0xEE, sizeof(queue_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_QueueGetInfo_Impl(0, &queue_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGetInfo_Impl(UT_INDEX_0, &queue_prop), OS_SUCCESS);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
@@ -47,7 +47,7 @@ void Test_OS_ShellOutputToFile_Impl(void)
      */
     UT_SetDeferredRetcode(UT_KEY(OCS_taskNameToId), 2, -1);
 
-    actual = OS_ShellOutputToFile_Impl(0, "TestCmd");
+    actual = OS_ShellOutputToFile_Impl(UT_INDEX_0, "TestCmd");
 
     UtAssert_True(actual == expected, "OS_ShellOutputToFile_Impl() (%ld) == OS_SUCCESS", (long)actual);
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_shellGenericInit)) == 1, "shellGenericInit() called");
@@ -55,7 +55,7 @@ void Test_OS_ShellOutputToFile_Impl(void)
     /* failure to open the output file */
     UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     expected = OS_ERROR;
-    actual   = OS_ShellOutputToFile_Impl(0, "TestCmd");
+    actual   = OS_ShellOutputToFile_Impl(UT_INDEX_0, "TestCmd");
     UtAssert_True(actual == expected, "OS_ShellOutputToFile_Impl() (%ld) == OS_ERROR", (long)actual);
 }
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
@@ -54,10 +54,10 @@ void Test_OS_ModuleSymbolLookup_Impl(void)
      */
     cpuaddr SymAddr;
 
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(0, &SymAddr, "symname"), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(0, NULL, NULL), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(UT_INDEX_0, &SymAddr, "symname"), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(UT_INDEX_0, NULL, NULL), OS_INVALID_POINTER);
     UT_SetForceFail(UT_KEY(OCS_symFind), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(0, &SymAddr, "symname"), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleSymbolLookup_Impl(UT_INDEX_0, &SymAddr, "symname"), OS_ERROR);
 }
 
 void Test_OS_SymTableIterator_Impl(void)

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -71,10 +71,10 @@ void Test_OS_TaskCreate_Impl(void)
      * The first call checks the failure path and ensures that a malloc failure gets handled */
     OS_task_table[0].stack_size = 250;
     UT_SetForceFail(UT_KEY(OCS_malloc), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(0, 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(UT_INDEX_0, 0), OS_ERROR);
 
     UT_ClearForceFail(UT_KEY(OCS_malloc));
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(0, OS_FP_ENABLED), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(UT_INDEX_0, OS_FP_ENABLED), OS_SUCCESS);
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 2, "malloc() called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 0, "free() not called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskInit)) == 1, "taskInit() called");
@@ -82,7 +82,7 @@ void Test_OS_TaskCreate_Impl(void)
 
     /* create again with smaller stack - this should re-use existing buffer */
     OS_task_table[0].stack_size = 100;
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(0, OS_FP_ENABLED), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(UT_INDEX_0, OS_FP_ENABLED), OS_SUCCESS);
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 2, "malloc() not called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 0, "free() not called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskInit)) == 2, "taskInit() called");
@@ -90,7 +90,7 @@ void Test_OS_TaskCreate_Impl(void)
 
     /* create again with larger stack - this should free existing and malloc() new buffer */
     OS_task_table[0].stack_size = 400;
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(0, OS_FP_ENABLED), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(UT_INDEX_0, OS_FP_ENABLED), OS_SUCCESS);
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 3, "malloc() called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 1, "free() called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskInit)) == 3, "taskInit() called");
@@ -98,7 +98,7 @@ void Test_OS_TaskCreate_Impl(void)
 
     /* other failure modes */
     UT_SetForceFail(UT_KEY(OCS_taskInit), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(0, 0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(UT_INDEX_0, 0), OS_ERROR);
 }
 
 void Test_OS_TaskMatch_Impl(void)
@@ -107,10 +107,10 @@ void Test_OS_TaskMatch_Impl(void)
      * Test Case For:
      * int32 OS_TaskMatch_Impl(uint32 task_id)
      */
-    UT_TaskTest_SetImplTaskId(0, OCS_taskIdSelf());
-    OSAPI_TEST_FUNCTION_RC(OS_TaskMatch_Impl(0), OS_SUCCESS);
-    UT_TaskTest_SetImplTaskId(0, (OCS_TASK_ID)0);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskMatch_Impl(0), OS_ERROR);
+    UT_TaskTest_SetImplTaskId(UT_INDEX_0, OCS_taskIdSelf());
+    OSAPI_TEST_FUNCTION_RC(OS_TaskMatch_Impl(UT_INDEX_0), OS_SUCCESS);
+    UT_TaskTest_SetImplTaskId(UT_INDEX_0, (OCS_TASK_ID)0);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskMatch_Impl(UT_INDEX_0), OS_ERROR);
 }
 
 void Test_OS_TaskDelete_Impl(void)
@@ -119,11 +119,11 @@ void Test_OS_TaskDelete_Impl(void)
      * Test Case For:
      * int32 OS_TaskDelete_Impl (uint32 task_id)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_TaskDelete_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskDelete_Impl(UT_INDEX_0), OS_SUCCESS);
 
     /* failure mode */
     UT_SetForceFail(UT_KEY(OCS_taskDelete), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskDelete_Impl(0), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskDelete_Impl(UT_INDEX_0), OS_ERROR);
 }
 
 void Test_OS_TaskExit_Impl(void)
@@ -157,10 +157,10 @@ void Test_OS_TaskSetPriority_Impl(void)
      * Test Case For:
      * int32 OS_TaskSetPriority_Impl (uint32 task_id, uint32 new_priority)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_TaskSetPriority_Impl(0, 100), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskSetPriority_Impl(UT_INDEX_0, OSAL_PRIORITY_C(100)), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_taskPrioritySet), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskSetPriority_Impl(0, 100), OS_ERROR);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskSetPriority_Impl(UT_INDEX_0, OSAL_PRIORITY_C(100)), OS_ERROR);
 }
 
 void Test_OS_TaskRegister_Impl(void)
@@ -184,7 +184,7 @@ void Test_OS_TaskGetId_Impl(void)
 
     memset(&id1, 0x11, sizeof(osal_id_t));
     OS_global_task_table[1].active_id = id1;
-    TaskTcb                           = UT_TaskTest_GetTaskTcb(1);
+    TaskTcb                           = UT_TaskTest_GetTaskTcb(UT_INDEX_1);
     UT_SetDataBuffer(UT_KEY(OCS_taskTcb), &TaskTcb, sizeof(TaskTcb), false);
     id2 = OS_TaskGetId_Impl();
     UtAssert_MemCmp(&id1, &id2, sizeof(osal_id_t), "OS_TaskGetId_Impl()");
@@ -198,7 +198,7 @@ void Test_OS_TaskGetInfo_Impl(void)
      */
     OS_task_prop_t task_prop;
     memset(&task_prop, 0xEE, sizeof(task_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_TaskGetInfo_Impl(0, &task_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskGetInfo_Impl(UT_INDEX_0, &task_prop), OS_SUCCESS);
 }
 
 void Test_OS_TaskValidateSystemData_Impl(void)
@@ -226,11 +226,11 @@ void Test_OS_TaskIdMatchSystemData_Impl(void)
 
     memset(&test_sys_id, 'x', sizeof(test_sys_id));
 
-    UT_TaskTest_SetImplTaskId(0, test_sys_id);
-    OSAPI_TEST_FUNCTION_RC(OS_TaskIdMatchSystemData_Impl(&test_sys_id, 0, NULL), true);
+    UT_TaskTest_SetImplTaskId(UT_INDEX_0, test_sys_id);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskIdMatchSystemData_Impl(&test_sys_id, UT_INDEX_0, NULL), true);
 
     memset(&test_sys_id, 'y', sizeof(test_sys_id));
-    OSAPI_TEST_FUNCTION_RC(OS_TaskIdMatchSystemData_Impl(&test_sys_id, 0, NULL), false);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskIdMatchSystemData_Impl(&test_sys_id, UT_INDEX_0, NULL), false);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
@@ -50,7 +50,7 @@ void Test_OS_TimeBaseLock_Impl(void)
     /* Test Case For:
      * void OS_TimeBaseLock_Impl(uint32 local_id)
      */
-    OS_TimeBaseLock_Impl(0);
+    OS_TimeBaseLock_Impl(UT_INDEX_0);
 }
 
 void Test_OS_TimeBaseUnlock_Impl(void)
@@ -58,13 +58,13 @@ void Test_OS_TimeBaseUnlock_Impl(void)
     /* Test Case For:
      * void OS_TimeBaseUnlock_Impl(uint32 local_id)
      */
-    OS_TimeBaseUnlock_Impl(0);
+    OS_TimeBaseUnlock_Impl(UT_INDEX_0);
 }
 
 static int32 UT_TimeBaseTest_TimeBaseRegHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
                                              const UT_StubContext_t *Context)
 {
-    UT_TimeBaseTest_SetTimeBaseRegState(0, true);
+    UT_TimeBaseTest_SetTimeBaseRegState(UT_INDEX_0, true);
     return 0;
 }
 
@@ -109,19 +109,19 @@ void Test_OS_TimeBaseCreate_Impl(void)
      */
     memset(&id, 0x01, sizeof(id));
     OS_global_timebase_table[1].active_id = id;
-    UT_TimeBaseTest_Setup(1, OCS_SIGRTMIN, false);
+    UT_TimeBaseTest_Setup(UT_INDEX_1, OCS_SIGRTMIN, false);
     UT_SetForceFail(UT_KEY(OCS_sigismember), true);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(0), OS_TIMER_ERR_UNAVAILABLE);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(UT_INDEX_0), OS_TIMER_ERR_UNAVAILABLE);
     UT_ResetState(UT_KEY(OCS_sigismember));
 
     /* fail to initialize the sem */
     UT_SetForceFail(UT_KEY(OCS_semMInitialize), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(0), OS_TIMER_ERR_INTERNAL);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(UT_INDEX_0), OS_TIMER_ERR_INTERNAL);
     UT_ClearForceFail(UT_KEY(OCS_semMInitialize));
 
     /* fail to spawn the task */
     UT_SetForceFail(UT_KEY(OCS_taskSpawn), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(0), OS_TIMER_ERR_INTERNAL);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(UT_INDEX_0), OS_TIMER_ERR_INTERNAL);
     UT_ClearForceFail(UT_KEY(OCS_taskSpawn));
 
     /*
@@ -129,7 +129,7 @@ void Test_OS_TimeBaseCreate_Impl(void)
      * this mimics the situation where the reg global is never
      * set past OS_TimerRegState_INIT
      */
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(0), OS_TIMER_ERR_INTERNAL);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(UT_INDEX_0), OS_TIMER_ERR_INTERNAL);
 
     /*
      * Do Nominal/success case now.
@@ -137,7 +137,7 @@ void Test_OS_TimeBaseCreate_Impl(void)
      * mimic registration success
      */
     UT_SetHookFunction(UT_KEY(OCS_taskSpawn), UT_TimeBaseTest_TimeBaseRegHook, NULL);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(0), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(UT_INDEX_0), OS_SUCCESS);
 
     /*
      * For coverage, call the  OS_VxWorks_TimeBaseTask() function.
@@ -147,14 +147,14 @@ void Test_OS_TimeBaseCreate_Impl(void)
     /*
      * Check outputs of OS_VxWorks_RegisterTimer() function.
      */
-    UT_TimeBaseTest_ClearTimeBaseRegState(0);
-    UT_TimeBaseTest_CallRegisterTimer(0);
-    UtAssert_True(UT_TimeBaseTest_CheckTimeBaseRegisteredState(0), "timer successfully registered");
+    UT_TimeBaseTest_ClearTimeBaseRegState(UT_INDEX_0);
+    UT_TimeBaseTest_CallRegisterTimer(UT_INDEX_0);
+    UtAssert_True(UT_TimeBaseTest_CheckTimeBaseRegisteredState(UT_INDEX_0), "timer successfully registered");
 
-    UT_TimeBaseTest_ClearTimeBaseRegState(0);
+    UT_TimeBaseTest_ClearTimeBaseRegState(UT_INDEX_0);
     UT_SetForceFail(UT_KEY(OCS_timer_create), -1);
-    UT_TimeBaseTest_CallRegisterTimer(0);
-    UtAssert_True(UT_TimeBaseTest_CheckTimeBaseErrorState(0), "timer registration failure state");
+    UT_TimeBaseTest_CallRegisterTimer(UT_INDEX_0);
+    UtAssert_True(UT_TimeBaseTest_CheckTimeBaseErrorState(UT_INDEX_0), "timer registration failure state");
 }
 
 void Test_OS_VxWorks_SigWait(void)
@@ -175,17 +175,17 @@ void Test_OS_VxWorks_SigWait(void)
     memset(&config_value, 0, sizeof(config_value));
     UT_SetDataBuffer(UT_KEY(OCS_timer_settime), &config_value, sizeof(config_value), false);
     UT_SetDataBuffer(UT_KEY(OCS_timer_gettime), &config_value, sizeof(config_value), false);
-    UT_TimeBaseTest_Setup(0, signo, true);
-    OS_TimeBaseSet_Impl(0, 1111111, 2222222);
+    UT_TimeBaseTest_Setup(UT_INDEX_0, signo, true);
+    OS_TimeBaseSet_Impl(UT_INDEX_0, 1111111, 2222222);
 
     UT_SetDataBuffer(UT_KEY(OCS_sigwait), &signo, sizeof(signo), false);
-    OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(0), 1111111);
+    OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(UT_INDEX_0), 1111111);
     UT_SetDataBuffer(UT_KEY(OCS_sigwait), &signo, sizeof(signo), false);
-    OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(0), 2222222);
+    OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(UT_INDEX_0), 2222222);
     UT_SetDataBuffer(UT_KEY(OCS_sigwait), &signo, sizeof(signo), false);
-    OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(0), 2222222);
+    OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(UT_INDEX_0), 2222222);
 
-    UT_TimeBaseTest_Setup(0, 0, false);
+    UT_TimeBaseTest_Setup(UT_INDEX_0, 0, false);
     OS_global_timebase_table[0].active_id      = OS_OBJECT_ID_UNDEFINED;
     OS_timebase_table[0].nominal_interval_time = 0;
 }
@@ -195,13 +195,13 @@ void Test_OS_TimeBaseSet_Impl(void)
     /* Test Case For:
      * int32 OS_TimeBaseSet_Impl(uint32 timer_id, int32 start_time, int32 interval_time)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(0, 1, 1), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(UT_INDEX_0, 1, 1), OS_ERR_NOT_IMPLEMENTED);
 
-    UT_TimeBaseTest_Setup(0, OCS_SIGRTMIN, false);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(0, 1, 1), OS_SUCCESS);
+    UT_TimeBaseTest_Setup(UT_INDEX_0, OCS_SIGRTMIN, false);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(UT_INDEX_0, 1, 1), OS_SUCCESS);
 
     UT_SetForceFail(UT_KEY(OCS_timer_settime), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(0, 1, 1), OS_TIMER_ERR_INVALID_ARGS);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(UT_INDEX_0, 1, 1), OS_TIMER_ERR_INVALID_ARGS);
 }
 
 void Test_OS_TimeBaseDelete_Impl(void)
@@ -209,8 +209,8 @@ void Test_OS_TimeBaseDelete_Impl(void)
     /* Test Case For:
      * int32 OS_TimeBaseDelete_Impl(uint32 timer_id)
      */
-    UT_TimeBaseTest_Setup(0, OCS_SIGRTMIN, false);
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseDelete_Impl(0), OS_SUCCESS);
+    UT_TimeBaseTest_Setup(UT_INDEX_0, OCS_SIGRTMIN, false);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseDelete_Impl(UT_INDEX_0), OS_SUCCESS);
 }
 
 void Test_OS_TimeBaseGetInfo_Impl(void)
@@ -219,7 +219,7 @@ void Test_OS_TimeBaseGetInfo_Impl(void)
      * int32 OS_TimeBaseGetInfo_Impl (uint32 timer_id, OS_timebase_prop_t *timer_prop)
      */
     OS_timebase_prop_t timer_prop;
-    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseGetInfo_Impl(0, &timer_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseGetInfo_Impl(UT_INDEX_0, &timer_prop), OS_SUCCESS);
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/os-vxworks-coveragetest.h
+++ b/src/unit-test-coverage/vxworks/src/os-vxworks-coveragetest.h
@@ -43,6 +43,10 @@
 
 #define ADD_TEST(test) UtTest_Add((Test_##test), Osapi_Test_Setup, Osapi_Test_Teardown, #test)
 
+#define UT_INDEX_0 OSAL_INDEX_C(0)
+#define UT_INDEX_1 OSAL_INDEX_C(1)
+#define UT_INDEX_2 OSAL_INDEX_C(2)
+
 /* Osapi_Test_Setup
  *
  * Purpose:

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-common-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-common-stubs.c
@@ -31,7 +31,7 @@
 #include <os-shared-common.h>
 #include <OCS_semLib.h>
 
-UT_DEFAULT_STUB(OS_API_Impl_Init, (uint32 idtype))
+UT_DEFAULT_STUB(OS_API_Impl_Init, (osal_objtype_t idtype))
 
 int OS_VxWorks_GenericSemTake(OCS_SEM_ID vxid, int sys_ticks)
 {

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.c
@@ -88,12 +88,14 @@
 *--------------------------------------------------------------------------------*/
 void UT_os_apiinit_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   qId;
-    uint32      qDepth = 10, qSize = 4, qFlags = 0;
-    osal_id_t   semIds[3];
-    uint32      semInitValue = 1, semOptions = 0;
+    int32             res = 0;
+    const char *      testDesc;
+    osal_id_t         qId;
+    osal_blockcount_t qDepth = OSAL_BLOCKCOUNT_C(10);
+    size_t            qSize  = OSAL_SIZE_C(4);
+    uint32            qFlags = 0;
+    osal_id_t         semIds[3];
+    uint32            semInitValue = 1, semOptions = 0;
 
     /*-----------------------------------------------------*/
     testDesc = "#1 Init-not-call-first";

--- a/src/unit-tests/oscore-test/ut_oscore_queue_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_queue_test.c
@@ -83,7 +83,7 @@ void UT_os_queue_create_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    res = OS_QueueCreate(&queue_id, "Good", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "Good", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
@@ -95,7 +95,7 @@ void UT_os_queue_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg-1";
 
-    res = OS_QueueCreate(NULL, "Queue1", 10, 4, 0);
+    res = OS_QueueCreate(NULL, "Queue1", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -104,7 +104,7 @@ void UT_os_queue_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Null-pointer-arg-2";
 
-    res = OS_QueueCreate(&queue_id, NULL, 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, NULL, OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -115,7 +115,7 @@ void UT_os_queue_create_test()
 
     memset(long_queue_name, 'X', sizeof(long_queue_name));
     long_queue_name[sizeof(long_queue_name) - 1] = '\0';
-    res                                          = OS_QueueCreate(&queue_id, long_queue_name, 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, long_queue_name, OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res == OS_ERR_NAME_TOO_LONG)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -129,7 +129,7 @@ void UT_os_queue_create_test()
     {
         memset(queue_name, '\0', sizeof(queue_name));
         UT_os_sprintf(queue_name, "QUEUE%d", i);
-        res = OS_QueueCreate(&queue_id, queue_name, 2, 4, 0);
+        res = OS_QueueCreate(&queue_id, queue_name, OSAL_BLOCKCOUNT_C(2), sizeof(uint32), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#4 No-free-IDs - Queue Create failed";
@@ -141,7 +141,7 @@ void UT_os_queue_create_test()
 
     if (test_setup_invalid == 0)
     {
-        res = OS_QueueCreate(&queue_id, "OneTooMany", 10, 4, 0);
+        res = OS_QueueCreate(&queue_id, "OneTooMany", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
         if (res == OS_ERR_NO_FREE_IDS)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -155,14 +155,14 @@ void UT_os_queue_create_test()
     testDesc = "#5 Duplicate-name";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id2, "DUPLICATE", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id2, "DUPLICATE", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         UT_OS_TEST_RESULT("Queue Create failed", UTASSERT_CASETYPE_TSF);
     }
     else
     {
-        res = OS_QueueCreate(&queue_id, "DUPLICATE", 10, 4, 0);
+        res = OS_QueueCreate(&queue_id, "DUPLICATE", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
         if (res == OS_ERR_NAME_TAKEN)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -180,7 +180,7 @@ void UT_os_queue_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#7 Nominal";
 
-    res = OS_QueueCreate(&queue_id, "Good", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "Good", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res == OS_SUCCESS)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -235,7 +235,7 @@ void UT_os_queue_delete_test()
     testDesc = "#3 Nominal";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "DeleteTest", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "DeleteTest", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Queue Create failed";
@@ -272,13 +272,13 @@ void UT_os_queue_get_test()
     osal_id_t   queue_id;
     uint32      queue_data_out;
     uint32      queue_data_in;
-    uint32      size_copied;
-    uint32      data_size;
+    size_t      size_copied;
+    size_t      data_size;
 
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    res = OS_QueueGet(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_in, 4, &size_copied, OS_CHECK);
+    res = OS_QueueGet(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK);
     if (res == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
@@ -288,7 +288,7 @@ void UT_os_queue_get_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Invalid-ID-arg";
 
-    res = OS_QueueGet(UT_OBJID_INCORRECT, (void *)&queue_data_in, 4, &size_copied, OS_CHECK);
+    res = OS_QueueGet(UT_OBJID_INCORRECT, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK);
     if (res == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -298,7 +298,7 @@ void UT_os_queue_get_test()
     testDesc = "#2 Invalid-pointer-arg-1";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#2 Invalid-pointer-arg-1 - Queue Create failed";
@@ -306,7 +306,7 @@ void UT_os_queue_get_test()
     }
     else
     {
-        res = OS_QueueGet(queue_id, NULL, 4, &size_copied, OS_CHECK);
+        res = OS_QueueGet(queue_id, NULL, sizeof(uint32), &size_copied, OS_CHECK);
         if (res == OS_INVALID_POINTER)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -319,7 +319,7 @@ void UT_os_queue_get_test()
     testDesc = "#3 Invalid-pointer-arg-2";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Invalid-pointer-arg-2 - Queue Create failed";
@@ -327,7 +327,7 @@ void UT_os_queue_get_test()
     }
     else
     {
-        res = OS_QueueGet(queue_id, (void *)&queue_data_in, 4, NULL, OS_CHECK);
+        res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), NULL, OS_CHECK);
         if (res == OS_INVALID_POINTER)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -340,7 +340,7 @@ void UT_os_queue_get_test()
     testDesc = "#4 Queue-empty";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueEmpty", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueEmpty", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#4 Queue-empty - Queue Create failed";
@@ -348,7 +348,7 @@ void UT_os_queue_get_test()
     }
     else
     {
-        res = OS_QueueGet(queue_id, (void *)&queue_data_in, 4, &data_size, OS_CHECK);
+        res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, OS_CHECK);
         if (res == OS_QUEUE_EMPTY)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -361,7 +361,7 @@ void UT_os_queue_get_test()
     testDesc = "#5 Queue-timed-out";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueTimeout", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueTimeout", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#5 Queue-timed-out - Queue Create failed";
@@ -369,7 +369,7 @@ void UT_os_queue_get_test()
     }
     else
     {
-        res = OS_QueueGet(queue_id, (void *)&queue_data_in, 4, &data_size, 2);
+        res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, 2);
         if (res == OS_QUEUE_TIMEOUT)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -382,7 +382,7 @@ void UT_os_queue_get_test()
     testDesc = "#6 Invalid-queue-size";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueuePut", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#6 Invalid-queue-size - Queue Create failed";
@@ -391,7 +391,7 @@ void UT_os_queue_get_test()
     else
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, 2, 0);
+        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, OSAL_SIZE_C(2), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#6 Invalid-queue-size - Queue Put failed";
@@ -399,7 +399,7 @@ void UT_os_queue_get_test()
         }
         else
         {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, 3, &data_size, OS_CHECK);
+            res = OS_QueueGet(queue_id, (void *)&queue_data_in, OSAL_SIZE_C(3), &data_size, OS_CHECK);
             if (res == OS_QUEUE_INVALID_SIZE)
                 UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
             else
@@ -417,7 +417,7 @@ void UT_os_queue_get_test()
     testDesc = "#8 Nominal Pend";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#8 Nominal Pend - Queue Create failed";
@@ -426,7 +426,7 @@ void UT_os_queue_get_test()
     else
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, 4, 0);
+        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#8 Nominal Pend - Queue Put failed";
@@ -434,7 +434,7 @@ void UT_os_queue_get_test()
         }
         else
         {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, 4, &data_size, OS_PEND);
+            res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, OS_PEND);
             if (res == OS_SUCCESS)
                 UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
             else
@@ -447,7 +447,7 @@ void UT_os_queue_get_test()
     testDesc = "#9 Nominal timeout";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#9 Nominal timeout - Queue Create failed";
@@ -456,7 +456,7 @@ void UT_os_queue_get_test()
     else
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, 4, 0);
+        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#9 Nominal timeout - Queue Put failed";
@@ -464,7 +464,7 @@ void UT_os_queue_get_test()
         }
         else
         {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, 4, &data_size, 20);
+            res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, 20);
             if (res == OS_SUCCESS)
                 UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
             else
@@ -477,7 +477,7 @@ void UT_os_queue_get_test()
     testDesc = "#10 Nominal check";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#10 Nominal check - Queue Create failed";
@@ -486,7 +486,7 @@ void UT_os_queue_get_test()
     else
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, 4, 0);
+        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#10 Nominal check - Queue Put failed";
@@ -494,7 +494,7 @@ void UT_os_queue_get_test()
         }
         else
         {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, 4, &data_size, OS_CHECK);
+            res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, OS_CHECK);
             if (res == OS_SUCCESS)
                 UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
             else
@@ -528,7 +528,7 @@ void UT_os_queue_put_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    res = OS_QueuePut(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_out, 4, 0);
+    res = OS_QueuePut(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_out, sizeof(uint32), 0);
     if (res == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
@@ -538,7 +538,7 @@ void UT_os_queue_put_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Invalid-ID-arg";
 
-    res = OS_QueuePut(UT_OBJID_INCORRECT, (void *)&queue_data_out, 4, 0);
+    res = OS_QueuePut(UT_OBJID_INCORRECT, (void *)&queue_data_out, sizeof(uint32), 0);
     if (res == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -548,7 +548,7 @@ void UT_os_queue_put_test()
     testDesc = "#2 Invalid-pointer-arg";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueuePut", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#2 Invalid-pointer-arg - Queue Create failed";
@@ -556,7 +556,7 @@ void UT_os_queue_put_test()
     }
     else
     {
-        res = OS_QueuePut(queue_id, NULL, 4, 0);
+        res = OS_QueuePut(queue_id, NULL, sizeof(uint32), 0);
         if (res == OS_INVALID_POINTER)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -573,7 +573,7 @@ void UT_os_queue_put_test()
     testDesc = "#4 Queue-full";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueuePut", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#4 Queue-full - Queue Create failed";
@@ -584,7 +584,7 @@ void UT_os_queue_put_test()
         queue_data_out = 0x11223344;
         for (i = 0; i < 100; i++)
         {
-            res = OS_QueuePut(queue_id, (void *)&queue_data_out, 4, 0);
+            res = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
             if (res == OS_QUEUE_FULL)
                 break;
         }
@@ -601,7 +601,7 @@ void UT_os_queue_put_test()
     testDesc = "#5 Nominal";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - Queue Create failed";
@@ -610,7 +610,7 @@ void UT_os_queue_put_test()
     else
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, 4, 0);
+        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
         if (res == OS_SUCCESS)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -690,7 +690,7 @@ void UT_os_queue_get_id_by_name_test()
     testDesc = "#5 Nominal";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "GetIDByName", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "GetIDByName", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - Queue Create failed";
@@ -749,7 +749,7 @@ void UT_os_queue_get_info_test()
     testDesc = "#2 Invalid-pointer-arg";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "GetInfo", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "GetInfo", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#2 Invalid-pointer-arg - Queue Create failed";
@@ -770,7 +770,7 @@ void UT_os_queue_get_info_test()
     testDesc = "#3 Nominal";
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "GetInfo", 10, 4, 0);
+    res = OS_QueueCreate(&queue_id, "GetInfo", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Queue Create failed";

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.c
@@ -64,7 +64,7 @@ char *           fsAddrPtr = NULL;
 static osal_id_t setup_file(void)
 {
     osal_id_t id;
-    UT_SETUP(OS_mkfs(fsAddrPtr, "/ramdev3", "RAM3", 512, 20));
+    UT_SETUP(OS_mkfs(fsAddrPtr, "/ramdev3", "RAM3", OSAL_SIZE_C(512), OSAL_BLOCKCOUNT_C(20)));
     UT_SETUP(OS_mount("/ramdev3", "/drive3"));
     UT_SETUP(OS_OpenCreate(&id, "/drive3/select_test.txt", OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE));
     return id;

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -37,9 +37,6 @@
 #define UT_TASK_STACK_SIZE 0x2000
 #define UT_TASK_PRIORITY   111
 
-/* This is not global in the OSAL */
-#define MAX_PRIORITY 255
-
 /*--------------------------------------------------------------------------------*
 ** Data types
 **--------------------------------------------------------------------------------*/
@@ -58,7 +55,10 @@ extern char  g_long_task_name[UT_OS_NAME_BUFF_SIZE];
 uint32    g_task_result = 0;
 osal_id_t g_task_sync_sem;
 osal_id_t g_task_ids[UT_OS_TASK_LIST_LEN];
-uint32    g_task_stacks[UT_OS_TASK_LIST_LEN][UT_TASK_STACK_SIZE];
+struct
+{
+    uint32 words[UT_TASK_STACK_SIZE];
+} g_task_stacks[UT_OS_TASK_LIST_LEN];
 
 /*--------------------------------------------------------------------------------*
 ** External function prototypes
@@ -113,8 +113,8 @@ void UT_os_task_create_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    res = OS_TaskCreate(&g_task_ids[0], g_task_names[0], generic_test_task, g_task_stacks[0], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[0], g_task_names[0], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[0]),
+                        sizeof(g_task_stacks[0]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res == OS_ERR_NOT_IMPLEMENTED)
     {
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
@@ -130,8 +130,8 @@ void UT_os_task_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg-1";
 
-    res = OS_TaskCreate(NULL, g_task_names[1], generic_test_task, g_task_stacks[1], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(NULL, g_task_names[1], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
+                        sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -140,8 +140,8 @@ void UT_os_task_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Null-pointer-arg-2";
 
-    res = OS_TaskCreate(&g_task_ids[2], NULL, generic_test_task, g_task_stacks[2], UT_TASK_STACK_SIZE, UT_TASK_PRIORITY,
-                        0);
+    res = OS_TaskCreate(&g_task_ids[2], NULL, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
+                        sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -150,8 +150,8 @@ void UT_os_task_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#3 Null-pointer-arg-3";
 
-    res =
-        OS_TaskCreate(&g_task_ids[3], g_task_names[3], NULL, g_task_stacks[3], UT_TASK_STACK_SIZE, UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], NULL, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                        sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res == OS_INVALID_POINTER)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -160,19 +160,9 @@ void UT_os_task_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Name-too-long";
 
-    res = OS_TaskCreate(&g_task_ids[4], g_long_task_name, generic_test_task, g_task_stacks[4], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[4], g_long_task_name, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[4]),
+                        sizeof(g_task_stacks[4]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res == OS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Invalid-priority";
-
-    res = OS_TaskCreate(&g_task_ids[5], g_task_names[5], generic_test_task, g_task_stacks[5], UT_TASK_STACK_SIZE,
-                        MAX_PRIORITY + 1, 0);
-    if (res == OS_ERR_INVALID_PRIORITY)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -185,8 +175,8 @@ void UT_os_task_create_test()
     {
         memset(task_name, '\0', sizeof(task_name));
         UT_os_sprintf(task_name, "CREATE_TASK%d", (int)i);
-        res = OS_TaskCreate(&g_task_ids[i], task_name, generic_test_task, g_task_stacks[i], UT_TASK_STACK_SIZE,
-                            UT_TASK_PRIORITY, 0);
+        res = OS_TaskCreate(&g_task_ids[i], task_name, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[i]),
+                            sizeof(g_task_stacks[i]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
         if (res != OS_SUCCESS)
         {
             break;
@@ -211,8 +201,8 @@ void UT_os_task_create_test()
     testDesc = "#7 Duplicate-name";
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[7], g_task_names[7], generic_test_task, g_task_stacks[7], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[7], g_task_names[7], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[7]),
+                        sizeof(g_task_stacks[7]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#7 Duplicate-name - Task-Create failed";
@@ -220,8 +210,8 @@ void UT_os_task_create_test()
     }
     else
     {
-        res = OS_TaskCreate(&g_task_ids[8], g_task_names[7], generic_test_task, g_task_stacks[8], UT_TASK_STACK_SIZE,
-                            UT_TASK_PRIORITY, 0);
+        res = OS_TaskCreate(&g_task_ids[8], g_task_names[7], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[8]),
+                            sizeof(g_task_stacks[8]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
         if (res == OS_ERR_NAME_TAKEN)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -242,8 +232,8 @@ void UT_os_task_create_test()
     /*-----------------------------------------------------*/
     testDesc = "#9 Nominal";
 
-    res = OS_TaskCreate(&g_task_ids[9], g_task_names[9], generic_test_task, g_task_stacks[9], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[9], g_task_names[9], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[9]),
+                        sizeof(g_task_stacks[9]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res == OS_SUCCESS)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -300,8 +290,8 @@ void UT_os_task_delete_test()
     testDesc = "#3 Nominal";
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, g_task_stacks[3], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                        sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Task-Create failed";
@@ -407,8 +397,9 @@ void UT_os_task_install_delete_handler_test(void)
     {
         OS_BinSemTake(g_task_sync_sem);
 
-        res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], delete_handler_test_task, g_task_stacks[2],
-                            UT_TASK_STACK_SIZE, UT_TASK_PRIORITY, 0);
+        res =
+            OS_TaskCreate(&g_task_ids[2], g_task_names[2], delete_handler_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
+                          sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#2 Nominal - Task-Create-failed";
@@ -489,8 +480,8 @@ void UT_os_task_exit_test(void)
     {
         OS_BinSemTake(g_task_sync_sem);
 
-        res = OS_TaskCreate(&g_task_ids[1], g_task_names[1], exit_test_task, g_task_stacks[1], UT_TASK_STACK_SIZE,
-                            UT_TASK_PRIORITY, 0);
+        res = OS_TaskCreate(&g_task_ids[1], g_task_names[1], exit_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
+                            sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#1 Nominal - Task-Create failed";
@@ -579,8 +570,8 @@ void UT_os_task_set_priority_test()
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
 
-    res = OS_TaskCreate(&g_task_ids[0], g_task_names[0], generic_test_task, g_task_stacks[0], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[0], g_task_names[0], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[0]),
+                        sizeof(g_task_stacks[0]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#0 API not implemented - Task-Create failed";
@@ -589,7 +580,7 @@ void UT_os_task_set_priority_test()
     }
     else
     {
-        res = OS_TaskSetPriority(g_task_ids[0], UT_TASK_PRIORITY);
+        res = OS_TaskSetPriority(g_task_ids[0], OSAL_PRIORITY_C(UT_TASK_PRIORITY));
         if (res == OS_ERR_NOT_IMPLEMENTED)
         {
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
@@ -606,7 +597,7 @@ void UT_os_task_set_priority_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Invalid-ID-arg";
 
-    res = OS_TaskSetPriority(UT_OBJID_INCORRECT, 100);
+    res = OS_TaskSetPriority(UT_OBJID_INCORRECT, OSAL_PRIORITY_C(100));
     if (res == OS_ERR_INVALID_ID)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
@@ -615,8 +606,8 @@ void UT_os_task_set_priority_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Invalid-priority";
 
-    res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, g_task_stacks[2], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
+                        sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#2 Invalid-priority - Task-Create failed";
@@ -624,12 +615,6 @@ void UT_os_task_set_priority_test()
     }
     else
     {
-        res = OS_TaskSetPriority(g_task_ids[2], MAX_PRIORITY + 1);
-        if (res == OS_ERR_INVALID_PRIORITY)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
         /* Delay to let child task run */
         OS_TaskDelay(500);
 
@@ -645,8 +630,8 @@ void UT_os_task_set_priority_test()
     /*-----------------------------------------------------*/
     testDesc = "#4 Nominal";
 
-    res = OS_TaskCreate(&g_task_ids[4], g_task_names[4], generic_test_task, g_task_stacks[4], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[4], g_task_names[4], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[4]),
+                        sizeof(g_task_stacks[4]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#4 Nominal - Task-Create failed";
@@ -654,7 +639,7 @@ void UT_os_task_set_priority_test()
     }
     else
     {
-        res = OS_TaskSetPriority(g_task_ids[4], UT_TASK_PRIORITY - 10);
+        res = OS_TaskSetPriority(g_task_ids[4], OSAL_PRIORITY_C(UT_TASK_PRIORITY - 10));
         if (res == OS_SUCCESS)
             UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
         else
@@ -664,7 +649,7 @@ void UT_os_task_set_priority_test()
         OS_TaskDelay(500);
 
         /* Reset test environment */
-        OS_TaskSetPriority(g_task_ids[4], UT_TASK_PRIORITY);
+        OS_TaskSetPriority(g_task_ids[4], OSAL_PRIORITY_C(UT_TASK_PRIORITY));
         OS_TaskDelete(g_task_ids[4]);
     }
 
@@ -750,8 +735,8 @@ void UT_os_task_register_test(void)
     {
         OS_BinSemTake(g_task_sync_sem);
 
-        res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], register_test_task, g_task_stacks[3], UT_TASK_STACK_SIZE,
-                            UT_TASK_PRIORITY, 0);
+        res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], register_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                            sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
         if (res != OS_SUCCESS)
         {
             testDesc = "#3 Nominal - Task-Create failed";
@@ -818,8 +803,8 @@ void UT_os_task_get_id_test()
     testDesc = "#1 Nominal";
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[1], g_task_names[1], getid_test_task, g_task_stacks[1], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[1], g_task_names[1], getid_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
+                        sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#1 Nominal - Task-Create failed";
@@ -902,8 +887,8 @@ void UT_os_task_get_id_by_name_test()
     testDesc = "#5 Nominal";
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[5], g_task_names[5], generic_test_task, g_task_stacks[5], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[5], g_task_names[5], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[5]),
+                        sizeof(g_task_stacks[5]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#5 Nominal - Task-Create failed";
@@ -962,8 +947,8 @@ void UT_os_task_get_info_test()
     testDesc = "#2 Invalid-pointer-arg";
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, g_task_stacks[2], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
+                        sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#2 Invalid-pointer-arg - Task-Create failed";
@@ -988,8 +973,8 @@ void UT_os_task_get_info_test()
     testDesc = "#3 Nominal";
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, g_task_stacks[3], UT_TASK_STACK_SIZE,
-                        UT_TASK_PRIORITY, 0);
+    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                        sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
     if (res != OS_SUCCESS)
     {
         testDesc = "#3 Nominal - Task-Create failed";

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -1037,7 +1037,8 @@ UT_os_writefile_test_exit_tag:
 void UT_os_lseekfile_test()
 {
     const char *testDesc;
-    int32       buffLen = 0, pos1 = 0, pos2 = 0, pos3 = 0;
+    size_t      buffLen;
+    int32       pos1 = 0, pos2 = 0, pos3 = 0;
 
     /*-----------------------------------------------------*/
     testDesc = "API not implemented";
@@ -1101,7 +1102,7 @@ void UT_os_lseekfile_test()
 
     memset(g_writeBuff, '\0', sizeof(g_writeBuff));
     strcpy(g_writeBuff, "THE BROWN FOX JUMPS OVER THE LAZY DOG.");
-    buffLen = (int32)strlen(g_writeBuff);
+    buffLen = strlen(g_writeBuff);
 
     if (OS_write(g_fDescs[0], g_writeBuff, buffLen) != buffLen)
     {

--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -76,7 +76,7 @@ int32 UT_os_setup_fs()
 {
     int32 res;
 
-    res = OS_mkfs(g_fsAddrPtr, g_devName, "RAM3", 512, 64);
+    res = OS_mkfs(g_fsAddrPtr, g_devName, "RAM3", OSAL_SIZE_C(512), OSAL_BLOCKCOUNT_C(64));
     if (res != OS_SUCCESS)
     {
         UT_OS_LOG("OS_mkfs() returns %d\n", (int)res);

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
@@ -44,8 +44,8 @@
 
 extern char *g_fsAddrPtr;
 
-extern int32 g_blkSize;
-extern int32 g_blkCnt;
+extern size_t            g_blkSize;
+extern osal_blockcount_t g_blkCnt;
 
 extern char g_fsLongName[UT_OS_PATH_BUFF_SIZE];
 extern char g_physDriveName[UT_OS_PHYS_NAME_BUFF_SIZE];
@@ -141,8 +141,8 @@ void UT_os_initfs_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_initfs(g_fsAddrPtr, NULL, g_volNames[1], 0, 0) == OS_INVALID_POINTER) &&
-        (OS_initfs(g_fsAddrPtr, g_devNames[1], NULL, 0, 0) == OS_INVALID_POINTER))
+    if ((OS_initfs(g_fsAddrPtr, NULL, g_volNames[1], OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER) &&
+        (OS_initfs(g_fsAddrPtr, g_devNames[1], NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
@@ -274,8 +274,8 @@ void UT_os_makefs_test()
     /*-----------------------------------------------------*/
     testDesc = "#1 Null-pointer-arg";
 
-    if ((OS_mkfs(g_fsAddrPtr, NULL, g_volNames[1], 0, 0) == OS_INVALID_POINTER) &&
-        (OS_mkfs(g_fsAddrPtr, g_devNames[1], NULL, 0, 0) == OS_INVALID_POINTER))
+    if ((OS_mkfs(g_fsAddrPtr, NULL, g_volNames[1], OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER) &&
+        (OS_mkfs(g_fsAddrPtr, g_devNames[1], NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER))
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
     else
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_test.c
@@ -51,8 +51,8 @@
 
 char *g_fsAddrPtr = NULL;
 
-int32 g_blkSize = UT_OS_FS_BLOCK_SIZE;
-int32 g_blkCnt  = UT_OS_FS_MAX_BLOCKS;
+size_t            g_blkSize = {UT_OS_FS_BLOCK_SIZE};
+osal_blockcount_t g_blkCnt  = {UT_OS_FS_MAX_BLOCKS};
 
 char g_fsLongName[UT_OS_PATH_BUFF_SIZE];
 char g_physDriveName[UT_OS_PHYS_NAME_BUFF_SIZE];

--- a/src/ut-stubs/osapi-utstub-dir.c
+++ b/src/ut-stubs/osapi-utstub-dir.c
@@ -143,7 +143,7 @@ int32 OS_DirectoryRead(osal_id_t dir_id, os_dirent_t *dirent)
     UT_Stub_RegisterContext(UT_KEY(OS_DirectoryRead), dirent);
 
     int32  Status;
-    uint32 CopySize;
+    size_t CopySize;
 
     Status = UT_DEFAULT_IMPL(OS_DirectoryRead);
 

--- a/src/ut-stubs/osapi-utstub-file.c
+++ b/src/ut-stubs/osapi-utstub-file.c
@@ -41,10 +41,10 @@ UT_DEFAULT_STUB(OS_FileAPI_Init, (void))
  * Local Stub helper function for reading
  *
  *****************************************************************************/
-static int32 UT_GenericReadStub(const char *fname, UT_EntryKey_t fkey, void *buffer, uint32 bsize)
+static int32 UT_GenericReadStub(const char *fname, UT_EntryKey_t fkey, void *buffer, size_t bsize)
 {
     int32  status;
-    uint32 CopySize;
+    size_t CopySize;
 
     status = UT_DefaultStubImpl(fname, fkey, 0x7FFFFFFF);
 
@@ -79,10 +79,10 @@ static int32 UT_GenericReadStub(const char *fname, UT_EntryKey_t fkey, void *buf
  * Local Stub helper function for writing
  *
  *****************************************************************************/
-static int32 UT_GenericWriteStub(const char *fname, UT_EntryKey_t fkey, const void *buffer, uint32 bsize)
+static int32 UT_GenericWriteStub(const char *fname, UT_EntryKey_t fkey, const void *buffer, size_t bsize)
 {
     int32  status;
-    uint32 CopySize;
+    size_t CopySize;
 
     status = UT_DefaultStubImpl(fname, fkey, 0x7FFFFFFF);
 
@@ -209,7 +209,7 @@ int32 OS_close(osal_id_t filedes)
  * Stub function for OS_StreamRead()
  *
  *****************************************************************************/
-int32 OS_StreamRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_StreamRead(osal_id_t filedes, void *buffer, size_t nbytes, int32 timeout)
 {
     return UT_GenericReadStub(__func__, UT_KEY(OS_StreamRead), buffer, nbytes);
 }
@@ -219,7 +219,7 @@ int32 OS_StreamRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeou
  * Stub function for OS_StreamWrite()
  *
  *****************************************************************************/
-int32 OS_StreamWrite(osal_id_t filedes, const void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_StreamWrite(osal_id_t filedes, const void *buffer, size_t nbytes, int32 timeout)
 {
     return UT_GenericWriteStub(__func__, UT_KEY(OS_StreamWrite), buffer, nbytes);
 }
@@ -229,7 +229,7 @@ int32 OS_StreamWrite(osal_id_t filedes, const void *buffer, uint32 nbytes, int32
  * Stub function for OS_read()
  *
  *****************************************************************************/
-int32 OS_read(osal_id_t filedes, void *buffer, uint32 nbytes)
+int32 OS_read(osal_id_t filedes, void *buffer, size_t nbytes)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_read), filedes);
     UT_Stub_RegisterContext(UT_KEY(OS_read), buffer);
@@ -243,7 +243,7 @@ int32 OS_read(osal_id_t filedes, void *buffer, uint32 nbytes)
  * Stub function for OS_write()
  *
  *****************************************************************************/
-int32 OS_write(osal_id_t filedes, const void *buffer, uint32 nbytes)
+int32 OS_write(osal_id_t filedes, const void *buffer, size_t nbytes)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_write), filedes);
     UT_Stub_RegisterContext(UT_KEY(OS_write), buffer);
@@ -257,7 +257,7 @@ int32 OS_write(osal_id_t filedes, const void *buffer, uint32 nbytes)
  * Stub function for OS_TimedRead()
  *
  *****************************************************************************/
-int32 OS_TimedRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_TimedRead(osal_id_t filedes, void *buffer, size_t nbytes, int32 timeout)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TimedRead), filedes);
     UT_Stub_RegisterContext(UT_KEY(OS_TimedRead), buffer);
@@ -272,7 +272,7 @@ int32 OS_TimedRead(osal_id_t filedes, void *buffer, uint32 nbytes, int32 timeout
  * Stub function for OS_TimedWrite()
  *
  *****************************************************************************/
-int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, uint32 nbytes, int32 timeout)
+int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, size_t nbytes, int32 timeout)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TimedWrite), filedes);
     UT_Stub_RegisterContext(UT_KEY(OS_TimedWrite), buffer);
@@ -416,7 +416,7 @@ int32 OS_FDGetInfo(osal_id_t filedes, OS_file_prop_t *fd_prop)
     UT_Stub_RegisterContext(UT_KEY(OS_FDGetInfo), fd_prop);
 
     int32  status;
-    uint32 CopySize;
+    size_t CopySize;
 
     status = UT_DEFAULT_IMPL(OS_FDGetInfo);
 

--- a/src/ut-stubs/osapi-utstub-filesys.c
+++ b/src/ut-stubs/osapi-utstub-filesys.c
@@ -68,7 +68,7 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
  * Stub function for OS_mkfs()
  *
  *****************************************************************************/
-int32 OS_mkfs(char *address, const char *devname, const char *volname, uint32 blocksize, uint32 numblocks)
+int32 OS_mkfs(char *address, const char *devname, const char *volname, size_t blocksize, osal_blockcount_t numblocks)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_mkfs), address);
     UT_Stub_RegisterContext(UT_KEY(OS_mkfs), devname);
@@ -104,7 +104,7 @@ int32 OS_rmfs(const char *devname)
  * Stub function for OS_initfs()
  *
  *****************************************************************************/
-int32 OS_initfs(char *address, const char *devname, const char *volname, uint32 blocksize, uint32 numblocks)
+int32 OS_initfs(char *address, const char *devname, const char *volname, size_t blocksize, osal_blockcount_t numblocks)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_initfs), address);
     UT_Stub_RegisterContext(UT_KEY(OS_initfs), devname);

--- a/src/ut-stubs/osapi-utstub-heap.c
+++ b/src/ut-stubs/osapi-utstub-heap.c
@@ -51,9 +51,9 @@ int32 OS_HeapGetInfo(OS_heap_prop_t *heap_prop)
         UT_Stub_CopyToLocal(UT_KEY(OS_HeapGetInfo), heap_prop, sizeof(*heap_prop)) < sizeof(*heap_prop))
     {
         /* Return some random data */
-        heap_prop->free_bytes         = (uint32)12345;
-        heap_prop->free_blocks        = (uint32)6789;
-        heap_prop->largest_free_block = (uint32)100;
+        heap_prop->free_bytes         = OSAL_SIZE_C(12345);
+        heap_prop->free_blocks        = OSAL_BLOCKCOUNT_C(6789);
+        heap_prop->largest_free_block = OSAL_SIZE_C(100);
     }
 
     return status;

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -42,11 +42,11 @@
 UT_DEFAULT_STUB(OS_ObjectIdInit, (void))
 
 /* Lock/Unlock for global tables */
-void OS_Lock_Global(uint32 idtype)
+void OS_Lock_Global(osal_objtype_t idtype)
 {
     UT_DEFAULT_IMPL(OS_Lock_Global);
 }
-void OS_Unlock_Global(uint32 idtype)
+void OS_Unlock_Global(osal_objtype_t idtype)
 {
     UT_DEFAULT_IMPL(OS_Unlock_Global);
 }
@@ -56,7 +56,7 @@ void OS_Unlock_Global(uint32 idtype)
  * Stub function for OS_GetMaxForObjectType()
  *
  *****************************************************************************/
-uint32 OS_GetMaxForObjectType(uint32 idtype)
+uint32 OS_GetMaxForObjectType(osal_objtype_t idtype)
 {
     int32 max;
 
@@ -77,7 +77,7 @@ uint32 OS_GetMaxForObjectType(uint32 idtype)
  * Stub function for OS_GetBaseForObjectType()
  *
  *****************************************************************************/
-uint32 OS_GetBaseForObjectType(uint32 idtype)
+uint32 OS_GetBaseForObjectType(osal_objtype_t idtype)
 {
     int32 base;
 
@@ -98,10 +98,11 @@ uint32 OS_GetBaseForObjectType(uint32 idtype)
  * Stub function for OS_ObjectIdToArrayIndex()
  *
  *****************************************************************************/
-int32 OS_ObjectIdToArrayIndex(uint32 idtype, osal_id_t id, uint32 *ArrayIndex)
+int32 OS_ObjectIdToArrayIndex(osal_objtype_t idtype, osal_id_t id, osal_index_t *ArrayIndex)
 {
     int32        Status;
     UT_ObjType_t checktype;
+    uint32       tempserial;
 
     Status = UT_DEFAULT_IMPL(OS_ObjectIdToArrayIndex);
 
@@ -109,7 +110,8 @@ int32 OS_ObjectIdToArrayIndex(uint32 idtype, osal_id_t id, uint32 *ArrayIndex)
         UT_Stub_CopyToLocal(UT_KEY(OS_ObjectIdToArrayIndex), ArrayIndex, sizeof(*ArrayIndex)) < sizeof(*ArrayIndex))
     {
         /* this needs to output something valid or code will break */
-        UT_ObjIdDecompose(id, ArrayIndex, &checktype);
+        UT_ObjIdDecompose(id, &tempserial, &checktype);
+        *ArrayIndex = OSAL_INDEX_C(tempserial);
     }
 
     return Status;
@@ -155,7 +157,7 @@ int32 OS_ObjectIdFinalizeDelete(int32 operation_status, OS_common_record_t *reco
  * Stub function for OS_ObjectIdFindMatch()
  *
  *****************************************************************************/
-int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
+int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
                              OS_common_record_t **record)
 {
     int32                     Status;
@@ -184,7 +186,7 @@ int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, uint32 idtype, OS_ObjectM
  * Stub function for OS_ObjectIdFindByName(, &fake_record.active_id)
  *
  *****************************************************************************/
-int32 OS_ObjectIdFindByName(uint32 idtype, const char *name, osal_id_t *object_id)
+int32 OS_ObjectIdFindByName(osal_objtype_t idtype, const char *name, osal_id_t *object_id)
 {
     int32 Status;
 
@@ -209,7 +211,8 @@ int32 OS_ObjectIdFindByName(uint32 idtype, const char *name, osal_id_t *object_i
  * Stub function for OS_ObjectIdGetByName(,object_id)
  *
  *****************************************************************************/
-int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, uint32 idtype, const char *name, OS_common_record_t **record)
+int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, osal_objtype_t idtype, const char *name,
+                           OS_common_record_t **record)
 {
     int32                     Status;
     OS_common_record_t *      local_record;
@@ -242,11 +245,12 @@ int32 OS_ObjectIdGetByName(OS_lock_mode_t lock_mode, uint32 idtype, const char *
  * Stub function for OS_ObjectIdGetById(, &fake_record.active_id)
  *
  *****************************************************************************/
-int32 OS_ObjectIdGetById(OS_lock_mode_t check_mode, uint32 idtype, osal_id_t id, uint32 *array_index,
+int32 OS_ObjectIdGetById(OS_lock_mode_t check_mode, osal_objtype_t idtype, osal_id_t id, osal_index_t *array_index,
                          OS_common_record_t **record)
 {
     int32                     Status;
-    uint32                    local_id;
+    uint32                    tempserial;
+    osal_index_t              local_id;
     UT_ObjType_t              checktype;
     OS_common_record_t *      local_record;
     static OS_common_record_t fake_record;
@@ -257,7 +261,8 @@ int32 OS_ObjectIdGetById(OS_lock_mode_t check_mode, uint32 idtype, osal_id_t id,
     {
         if (UT_Stub_CopyToLocal(UT_KEY(OS_ObjectIdGetById), &local_id, sizeof(local_id)) < sizeof(local_id))
         {
-            UT_ObjIdDecompose(id, &local_id, &checktype);
+            UT_ObjIdDecompose(id, &tempserial, &checktype);
+            local_id = OSAL_INDEX_C(tempserial);
         }
 
         if (UT_Stub_CopyToLocal(UT_KEY(OS_ObjectIdGetById), &local_record, sizeof(local_record)) < sizeof(local_record))
@@ -300,7 +305,7 @@ int32 OS_ObjectIdRefcountDecr(OS_common_record_t *record)
  * Stub function for OS_ObjectIdGetNext()
  *
  *****************************************************************************/
-int32 OS_ObjectIdGetNext(uint32 idtype, uint32 *curr_index, OS_common_record_t **record)
+int32 OS_ObjectIdGetNext(osal_objtype_t idtype, uint32 *curr_index, OS_common_record_t **record)
 {
     int32                     Status;
     uint32                    local_id;
@@ -350,10 +355,11 @@ int32 OS_ObjectIdGetNext(uint32 idtype, uint32 *curr_index, OS_common_record_t *
  * Stub function for OS_ObjectIdAllocateNew(, &fake_record.active_id)
  *
  *****************************************************************************/
-int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_index, OS_common_record_t **record)
+int32 OS_ObjectIdAllocateNew(osal_objtype_t idtype, const char *name, osal_index_t *array_index,
+                             OS_common_record_t **record)
 {
     int32                     Status;
-    uint32                    local_id;
+    osal_index_t              local_id;
     OS_common_record_t *      local_record;
     static OS_common_record_t fake_record;
 
@@ -389,7 +395,7 @@ int32 OS_ObjectIdAllocateNew(uint32 idtype, const char *name, uint32 *array_inde
 
     returns: status
 ---------------------------------------------------------------------------------------*/
-int32 OS_GetResourceName(osal_id_t object_id, char *buffer, uint32 buffer_size)
+int32 OS_GetResourceName(osal_id_t object_id, char *buffer, size_t buffer_size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_GetResourceName), object_id);
     UT_Stub_RegisterContext(UT_KEY(OS_GetResourceName), buffer);
@@ -421,22 +427,23 @@ int32 OS_GetResourceName(osal_id_t object_id, char *buffer, uint32 buffer_size)
 
     returns: status
 ---------------------------------------------------------------------------------------*/
-int32 OS_ConvertToArrayIndex(osal_id_t object_id, uint32 *ArrayIndex)
+int32 OS_ConvertToArrayIndex(osal_id_t object_id, osal_index_t *ArrayIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_ConvertToArrayIndex), object_id);
     UT_Stub_RegisterContext(UT_KEY(OS_ConvertToArrayIndex), ArrayIndex);
 
-    int32 return_code;
+    int32  return_code;
+    uint32 tempserial;
 
     return_code = UT_DEFAULT_IMPL(OS_ConvertToArrayIndex);
 
     if (return_code == OS_SUCCESS)
     {
         UT_ObjType_t ObjType;
-        UT_ObjIdDecompose(object_id, ArrayIndex, &ObjType);
+        UT_ObjIdDecompose(object_id, &tempserial, &ObjType);
         if (ObjType != UT_OBJTYPE_NONE && ObjType < UT_OBJTYPE_MAX)
         {
-            *ArrayIndex %= UT_MAXOBJS[ObjType];
+            tempserial %= UT_MAXOBJS[ObjType];
         }
     }
     else
@@ -445,8 +452,10 @@ int32 OS_ConvertToArrayIndex(osal_id_t object_id, uint32 *ArrayIndex)
          * If set to fail, then set the output to something bizarre - if the code
          * actually tries to use this, chances are it will segfault and be fixed
          */
-        *ArrayIndex = 0xDEADBEEFU;
+        tempserial = 0xDEADBEEFU;
     }
+
+    *ArrayIndex = OSAL_INDEX_C(tempserial);
 
     return return_code;
 } /* end OS_ConvertToArrayIndex */
@@ -458,7 +467,8 @@ int32 OS_ConvertToArrayIndex(osal_id_t object_id, uint32 *ArrayIndex)
 
     returns: None
 ---------------------------------------------------------------------------------------*/
-void OS_ForEachObjectOfType(uint32 objtype, osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg)
+void OS_ForEachObjectOfType(osal_objtype_t objtype, osal_id_t creator_id, OS_ArgCallback_t callback_ptr,
+                            void *callback_arg)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_ForEachObjectOfType), objtype);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_ForEachObjectOfType), creator_id);
@@ -466,7 +476,7 @@ void OS_ForEachObjectOfType(uint32 objtype, osal_id_t creator_id, OS_ArgCallback
     UT_Stub_RegisterContext(UT_KEY(OS_ForEachObjectOfType), callback_arg);
 
     osal_id_t NextId;
-    uint32    IdSize;
+    size_t    IdSize;
 
     /* Although this is "void", Invoke the default impl to log it and invoke any hooks */
     UT_DEFAULT_IMPL(OS_ForEachObjectOfType);
@@ -497,7 +507,7 @@ void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void 
     UT_Stub_RegisterContext(UT_KEY(OS_ForEachObject), callback_arg);
 
     osal_id_t NextId;
-    uint32    IdSize;
+    size_t    IdSize;
 
     /* Although this is "void", Invoke the default impl to log it and invoke any hooks */
     UT_DEFAULT_IMPL(OS_ForEachObject);
@@ -520,7 +530,7 @@ void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void 
 
    returns: The type of object that the ID represents
 ---------------------------------------------------------------------------------------*/
-uint32 OS_IdentifyObject(osal_id_t object_id)
+osal_objtype_t OS_IdentifyObject(osal_id_t object_id)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_IdentifyObject), object_id);
 
@@ -570,5 +580,7 @@ uint32 OS_IdentifyObject(osal_id_t object_id)
             break;
     }
 
-    return UT_DEFAULT_IMPL_RC(OS_IdentifyObject, DefaultType);
+    DefaultType = UT_DEFAULT_IMPL_RC(OS_IdentifyObject, DefaultType);
+
+    return DefaultType;
 }

--- a/src/ut-stubs/osapi-utstub-module.c
+++ b/src/ut-stubs/osapi-utstub-module.c
@@ -262,7 +262,7 @@ int32 OS_ModuleSymbolLookup(osal_id_t module_id, cpuaddr *symbol_address, const 
  * Stub function for OS_SymbolTableDump()
  *
  *****************************************************************************/
-int32 OS_SymbolTableDump(const char *filename, uint32 size_limit)
+int32 OS_SymbolTableDump(const char *filename, size_t size_limit)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_SymbolTableDump), filename);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_SymbolTableDump), size_limit);

--- a/src/ut-stubs/osapi-utstub-network.c
+++ b/src/ut-stubs/osapi-utstub-network.c
@@ -36,7 +36,7 @@
 
 UT_DEFAULT_STUB(OS_NetworkAPI_Init, (void))
 
-int32 OS_NetworkGetHostName(char *host_name, uint32 name_len)
+int32 OS_NetworkGetHostName(char *host_name, size_t name_len)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_NetworkGetHostName), host_name);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_NetworkGetHostName), name_len);

--- a/src/ut-stubs/osapi-utstub-printf.c
+++ b/src/ut-stubs/osapi-utstub-printf.c
@@ -60,7 +60,7 @@ void OS_printf(const char *string, ...)
     UT_Stub_RegisterContext(UT_KEY(OS_printf), string);
 
     int32   status;
-    int32   length = strlen(string);
+    size_t  length = strlen(string);
     va_list va;
 
     va_start(va, string);

--- a/src/ut-stubs/osapi-utstub-queue.c
+++ b/src/ut-stubs/osapi-utstub-queue.c
@@ -61,7 +61,8 @@ UT_DEFAULT_STUB(OS_QueueAPI_Init, (void))
 **        or OS_SUCCESS.
 **
 ******************************************************************************/
-int32 OS_QueueCreate(osal_id_t *queue_id, const char *queue_name, uint32 queue_depth, uint32 data_size, uint32 flags)
+int32 OS_QueueCreate(osal_id_t *queue_id, const char *queue_name, osal_blockcount_t queue_depth, size_t data_size,
+                     uint32 flags)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_QueueCreate), queue_id);
     UT_Stub_RegisterContext(UT_KEY(OS_QueueCreate), queue_name);
@@ -149,7 +150,7 @@ int32 OS_QueueDelete(osal_id_t queue_id)
 **        or OS_SUCCESS.
 **
 ******************************************************************************/
-int32 OS_QueueGet(osal_id_t queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+int32 OS_QueueGet(osal_id_t queue_id, void *data, size_t size, size_t *size_copied, int32 timeout)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_QueueGet), queue_id);
     UT_Stub_RegisterContext(UT_KEY(OS_QueueGet), data);
@@ -196,7 +197,7 @@ int32 OS_QueueGet(osal_id_t queue_id, void *data, uint32 size, uint32 *size_copi
 **        OS_INVALID_POINTER, OS_QUEUE_FULL, or OS_SUCCESS.
 **
 ******************************************************************************/
-int32 OS_QueuePut(osal_id_t queue_id, const void *data, uint32 size, uint32 flags)
+int32 OS_QueuePut(osal_id_t queue_id, const void *data, size_t size, uint32 flags)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_QueuePut), queue_id);
     UT_Stub_RegisterContext(UT_KEY(OS_QueuePut), data);

--- a/src/ut-stubs/osapi-utstub-sockets.c
+++ b/src/ut-stubs/osapi-utstub-sockets.c
@@ -115,7 +115,7 @@ int32 OS_SocketConnect(osal_id_t sock_id, const OS_SockAddr_t *Addr, int32 timeo
  * Stub function for OS_SocketRecvFrom()
  *
  *****************************************************************************/
-int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
+int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_SocketRecvFrom), sock_id);
     UT_Stub_RegisterContext(UT_KEY(OS_SocketRecvFrom), buffer);
@@ -124,7 +124,7 @@ int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockA
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_SocketRecvFrom), timeout);
 
     int32  status;
-    uint32 CopySize;
+    size_t CopySize;
 
     status = UT_DEFAULT_IMPL(OS_SocketRecvFrom);
 
@@ -159,7 +159,7 @@ int32 OS_SocketRecvFrom(osal_id_t sock_id, void *buffer, uint32 buflen, OS_SockA
  * Stub function for OS_SocketSendTo()
  *
  *****************************************************************************/
-int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, uint32 buflen, const OS_SockAddr_t *RemoteAddr)
+int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_SocketSendTo), sock_id);
     UT_Stub_RegisterContext(UT_KEY(OS_SocketSendTo), buffer);
@@ -167,7 +167,7 @@ int32 OS_SocketSendTo(osal_id_t sock_id, const void *buffer, uint32 buflen, cons
     UT_Stub_RegisterContext(UT_KEY(OS_SocketSendTo), RemoteAddr);
 
     int32  status;
-    uint32 CopySize;
+    size_t CopySize;
 
     status = UT_DEFAULT_IMPL_RC(OS_SocketSendTo, 0x7FFFFFFF);
 
@@ -225,7 +225,7 @@ int32 OS_SocketGetInfo(osal_id_t sock_id, OS_socket_prop_t *sock_prop)
     UT_Stub_RegisterContext(UT_KEY(OS_SocketGetInfo), sock_prop);
 
     int32  status;
-    uint32 CopySize;
+    size_t CopySize;
 
     status = UT_DEFAULT_IMPL(OS_SocketGetInfo);
 
@@ -260,7 +260,7 @@ int32 OS_SocketAddrInit(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
     return status;
 }
 
-int32 OS_SocketAddrToString(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr)
+int32 OS_SocketAddrToString(char *buffer, size_t buflen, const OS_SockAddr_t *Addr)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_SocketAddrToString), buffer);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_SocketAddrToString), buflen);

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -52,13 +52,13 @@ UT_DEFAULT_STUB(OS_TaskAPI_Init, (void))
 **        Returns either OS_SUCCESS or OS_ERROR.
 **
 ******************************************************************************/
-int32 OS_TaskCreate(osal_id_t *task_id, const char *task_name, osal_task_entry function_pointer, uint32 *stack_pointer,
-                    uint32 stack_size, uint32 priority, uint32 flags)
+int32 OS_TaskCreate(osal_id_t *task_id, const char *task_name, osal_task_entry function_pointer,
+                    osal_stackptr_t stack_pointer, size_t stack_size, osal_priority_t priority, uint32 flags)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_TaskCreate), task_id);
     UT_Stub_RegisterContext(UT_KEY(OS_TaskCreate), task_name);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskCreate), function_pointer);
-    UT_Stub_RegisterContext(UT_KEY(OS_TaskCreate), stack_pointer);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskCreate), stack_pointer);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskCreate), stack_size);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskCreate), priority);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskCreate), flags);
@@ -165,7 +165,7 @@ int32 OS_TaskDelay(uint32 millisecond)
  * Stub function for OS_TaskSetPriority()
  *
  *****************************************************************************/
-int32 OS_TaskSetPriority(osal_id_t task_id, uint32 new_priority)
+int32 OS_TaskSetPriority(osal_id_t task_id, osal_priority_t new_priority)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskSetPriority), task_id);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_TaskSetPriority), new_priority);
@@ -281,8 +281,8 @@ int32 OS_TaskGetInfo(osal_id_t task_id, OS_task_prop_t *task_prop)
         UT_Stub_CopyToLocal(UT_KEY(OS_TaskGetInfo), task_prop, sizeof(*task_prop)) < sizeof(*task_prop))
     {
         UT_ObjIdCompose(1, UT_OBJTYPE_TASK, &task_prop->creator);
-        task_prop->stack_size = 100;
-        task_prop->priority   = 150;
+        task_prop->stack_size = OSAL_SIZE_C(100);
+        task_prop->priority   = OSAL_PRIORITY_C(150);
         strncpy(task_prop->name, "UnitTest", OS_MAX_API_NAME - 1);
         task_prop->name[OS_MAX_API_NAME - 1] = '\0';
     }

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -161,7 +161,7 @@ void UT_SetDeferredRetcode(UT_EntryKey_t FuncKey, int32 Count, int32 Retcode);
  *      is false then the DataBuffer pointer is used directly, and must remain valid for the duration
  *      of the current test case.
  */
-void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, uint32 BufferSize, bool AllocateCopy);
+void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, size_t BufferSize, bool AllocateCopy);
 
 /**
  * Gets the data buffer for a given stub function
@@ -177,7 +177,7 @@ void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, uint32 BufferSize
  * \param BufferSize Set to Maximum Size of data buffer (output)
  * \param Position Set to current position in data buffer (output)
  */
-void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, uint32 *MaxSize, uint32 *Position);
+void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, size_t *MaxSize, size_t *Position);
 
 /**
  * Enable or disable the forced failure mode for the given stub function
@@ -314,7 +314,7 @@ bool UT_Stub_CheckForceFail(UT_EntryKey_t FuncKey, int32 *Value);
  * \returns The actual size of data copied.  If no data buffer is
  *      supplied by the test harness this will return 0.
  */
-uint32 UT_Stub_CopyToLocal(UT_EntryKey_t FuncKey, void *LocalBuffer, uint32 MaxSize);
+size_t UT_Stub_CopyToLocal(UT_EntryKey_t FuncKey, void *LocalBuffer, size_t MaxSize);
 
 /**
  * Copies data from a local buffer to the test-supplied buffer
@@ -328,7 +328,7 @@ uint32 UT_Stub_CopyToLocal(UT_EntryKey_t FuncKey, void *LocalBuffer, uint32 MaxS
  * \returns The actual size of data copied.  If no data buffer is
  *      supplied by the test harness this will return 0.
  */
-uint32 UT_Stub_CopyFromLocal(UT_EntryKey_t FuncKey, const void *LocalBuffer, uint32 MaxSize);
+size_t UT_Stub_CopyFromLocal(UT_EntryKey_t FuncKey, const void *LocalBuffer, size_t MaxSize);
 
 /**
  * Registers a single context element for the hook callback

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -69,8 +69,8 @@ typedef struct
 
 typedef struct
 {
-    uint32 Position;
-    uint32 TotalSize;
+    size_t Position;
+    size_t TotalSize;
     uint8 *BasePtr;
 } UT_BufferEntry_t;
 
@@ -401,7 +401,7 @@ bool UT_Stub_CheckForceFail(UT_EntryKey_t FuncKey, int32 *Value)
     return (Result);
 }
 
-void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, uint32 BufferSize, bool AllocateCopy)
+void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, size_t BufferSize, bool AllocateCopy)
 {
     UT_StubTableEntry_t *StubPtr;
 
@@ -441,12 +441,12 @@ void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, uint32 BufferSize
     }
 }
 
-void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, uint32 *MaxSize, uint32 *Position)
+void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, size_t *MaxSize, size_t *Position)
 {
     UT_StubTableEntry_t *StubPtr;
     void *               ResultDataBuffer;
-    uint32               ResultMaxSize;
-    uint32               ResultPosition;
+    size_t               ResultMaxSize;
+    size_t               ResultPosition;
 
     StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_DATA_BUFFER);
 
@@ -477,9 +477,9 @@ void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, uint32 *MaxSize,
     }
 }
 
-uint32 UT_Stub_CopyToLocal(UT_EntryKey_t FuncKey, void *LocalBuffer, uint32 MaxSize)
+size_t UT_Stub_CopyToLocal(UT_EntryKey_t FuncKey, void *LocalBuffer, size_t MaxSize)
 {
-    uint32               ActualCopy;
+    size_t               ActualCopy;
     UT_StubTableEntry_t *StubPtr;
 
     ActualCopy = 0;
@@ -510,9 +510,9 @@ uint32 UT_Stub_CopyToLocal(UT_EntryKey_t FuncKey, void *LocalBuffer, uint32 MaxS
     return ActualCopy;
 }
 
-uint32 UT_Stub_CopyFromLocal(UT_EntryKey_t FuncKey, const void *LocalBuffer, uint32 MaxSize)
+size_t UT_Stub_CopyFromLocal(UT_EntryKey_t FuncKey, const void *LocalBuffer, size_t MaxSize)
 {
-    uint32               ActualCopy;
+    size_t               ActualCopy;
     UT_StubTableEntry_t *StubPtr;
 
     ActualCopy = 0;


### PR DESCRIPTION
**Describe the contribution**

Scrub all uses of `uint32` type across OSAL, and replace most usage of this generic type with more appropriate, purpose-specific typedefs.

All use of `uint32` to store an object size is now replaced with `size_t`.

Adds proper typedefs for:
    
- `osal_priority_t` - used for indicating a task priority
- `osal_stackptr_t` - for indicating a task stack pointer
- `osal_index_t` - for indicating a table position/array index of all internal tables
- `osal_objtype_t` - for indicating the type of an object
    
Fixes #635 

**Testing performed**
Build and sanity test OSAL on supported platforms
Run all unit tests

**Expected behavior changes**
None.  This is mainly a scrub of all APIs to use the proper type, but keeps it as `uint32` most of the time, so it really shouldn't change anything.  Except for sizes which are now `size_t` - so they will be 64 bits on a 64 bit platform.

**System(s) tested on**
Ubuntu 20.04
RTEMS 4.11


**Additional context**
This does expose another API problem with functions that return a size as an `int32` (e.g. OS_read, OS_write, etc) .... as an `int32` cannot represent the full range of possible values.  We may need a type to correlate with POSIX `ssize_t` to address this.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
