### PR TITLE
Fix #655, use 3 argument form of open

### DIFF
--- a/src/os/portable/os-impl-posix-files.c
+++ b/src/os/portable/os-impl-posix-files.c
@@ -199,7 +199,7 @@ int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
     int         fd;
 
     /* Open file to avoid filename race potential */
-    fd = open(local_path, O_RDONLY);
+    fd = open(local_path, O_RDONLY, 0);
     if (fd < 0)
     {
         return OS_ERROR;


### PR DESCRIPTION
**Describe the contribution**
VxWorks only provides the 3 argument form of `open()`.  Passing 0 as the mode solves the build issue.  This parameter is ignored when not creating a file.

Fixes #655 

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
No behavior change.  Fixes build issue on VxWorks 6.9

**System(s) tested on**
VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
