### PR TITLE
Fix #608 - Add RTEMS 5.x support

### DIFF
--- a/src/bsp/pc-rtems/CMakeLists.txt
+++ b/src/bsp/pc-rtems/CMakeLists.txt
@@ -9,6 +9,13 @@ add_library(osal_pc-rtems_impl OBJECT
 	src/bsp_console.c
 )
 
+# This definition is needed for the gethostname call
+# By defining this, it avoids the need to use the -std=gnu99
+#  instead of the preferred -std=c99 GCC switch
+target_compile_definitions(osal_pc-rtems_impl PUBLIC
+   _BSD_SOURCE
+)
+
 # This BSP only works with "rtems" OS layer.
 # Confirming this reduces risk of accidental misconfiguration
 set(OSAL_EXPECTED_OSTYPE    "rtems" PARENT_SCOPE)

--- a/src/bsp/pc-rtems/src/bsp_start.c
+++ b/src/bsp/pc-rtems/src/bsp_start.c
@@ -83,10 +83,10 @@ void OS_BSP_Setup(void)
     cmdlinestr = bsp_cmdline();
 
     printf("\n\n*** RTEMS Info ***\n");
-    printf("%s", _Copyright_Notice);
-    printf("%s\n\n", _RTEMS_version);
-    printf(" Stack size=%d\n", (int)Configuration.stack_space_size);
-    printf(" Workspace size=%d\n", (int)Configuration.work_space_size);
+    printf("%s", OSAL_BSP_COPYRIGHT_NOTICE);
+    printf("%s\n\n", rtems_get_version_string());
+    printf(" Stack size=%d\n", (int)rtems_configuration_get_stack_space_size());
+    printf(" Workspace size=%d\n", (int)rtems_configuration_get_work_space_size());
     if (cmdlinestr != NULL)
     {
         printf(" Bootloader Command Line: %s\n", cmdlinestr);
@@ -374,9 +374,13 @@ rtems_task Init(rtems_task_argument ignored)
 #define CONFIGURE_MAXIMUM_TIMERS                 (OS_MAX_TIMERS + 2)
 #define CONFIGURE_MAXIMUM_SEMAPHORES             (OS_MAX_BIN_SEMAPHORES + OS_MAX_COUNT_SEMAPHORES + OS_MAX_MUTEXES + 16)
 #define CONFIGURE_MAXIMUM_MESSAGE_QUEUES         (OS_MAX_QUEUES + 4)
-#define CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS (OS_MAX_NUM_OPEN_FILES + 8)
 #define CONFIGURE_MAXIMUM_DRIVERS                10
 #define CONFIGURE_MAXIMUM_POSIX_KEYS             4
+#ifdef _RTEMS_5_
+   #define CONFIGURE_MAXIMUM_FILE_DESCRIPTORS        (OS_MAX_NUM_OPEN_FILES + 8)
+#else
+   #define CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS  (OS_MAX_NUM_OPEN_FILES + 8)
+#endif
 
 #define CONFIGURE_RTEMS_INIT_TASKS_TABLE
 #define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER

--- a/src/bsp/pc-rtems/src/pcrtems_bsp_internal.h
+++ b/src/bsp/pc-rtems/src/pcrtems_bsp_internal.h
@@ -41,6 +41,15 @@
 #define RTEMS_MAX_CMDLINE      256
 
 /*
+ * Handle the differences between RTEMS 5 and 4.11 copyright notice
+ */
+#ifdef _RTEMS_5_
+    #define OSAL_BSP_COPYRIGHT_NOTICE           rtems_get_copyright_notice()
+#else
+    #define OSAL_BSP_COPYRIGHT_NOTICE           _Copyright_Notice
+#endif
+
+/*
  * The location which the general purpose file system will be mounted
  */
 #define RTEMS_USER_FS_MOUNTPOINT "/mnt"

--- a/src/os/rtems/inc/os-rtems.h
+++ b/src/os/rtems/inc/os-rtems.h
@@ -52,6 +52,20 @@
 /****************************************************************************************
                                      DEFINES
  ***************************************************************************************/
+/*
+ * Handle the data structure and API name changes between RTEMS 4.11 and RTEMS 5.1
+ */
+#ifdef _RTEMS_5_
+    #define OSAL_HEAP_INFO_BLOCK    Heap_Information_block
+    #define OSAL_UNRESOLV_REC_TYPE  rtems_rtl_unresolv_rec
+    #define OSAL_UNRESOLVED_SYMBOL  rtems_rtl_unresolved_symbol
+    #define OSAL_UNRESOLVED_ITERATE rtems_rtl_unresolved_iterate
+#else
+    #define OSAL_HEAP_INFO_BLOCK    region_information_block
+    #define OSAL_UNRESOLV_REC_TYPE  rtems_rtl_unresolv_rec_t
+    #define OSAL_UNRESOLVED_SYMBOL  rtems_rtl_unresolved_name
+    #define OSAL_UNRESOLVED_ITERATE rtems_rtl_unresolved_interate
+#endif
 
 /****************************************************************************************
                                     TYPEDEFS

--- a/src/os/rtems/src/os-impl-heap.c
+++ b/src/os/rtems/src/os-impl-heap.c
@@ -46,8 +46,8 @@
  *-----------------------------------------------------------------*/
 int32 OS_HeapGetInfo_Impl(OS_heap_prop_t *heap_prop)
 {
-    region_information_block info;
-    int                      status;
+    OSAL_HEAP_INFO_BLOCK info;
+    int                  status;
 
     status = malloc_info(&info);
 

--- a/src/os/rtems/src/os-impl-loader.c
+++ b/src/os/rtems/src/os-impl-loader.c
@@ -73,14 +73,14 @@ int32 OS_Rtems_ModuleAPI_Impl_Init(void)
  * This could be fine-tuned later.
  *
  *-----------------------------------------------------------------*/
-static bool OS_rtems_rtl_check_unresolved(rtems_rtl_unresolv_rec_t *rec, void *data)
+static bool OS_rtems_rtl_check_unresolved(OSAL_UNRESOLV_REC_TYPE *rec, void *data)
 {
     int32 *status = data;
 
     switch (rec->type)
     {
-        case rtems_rtl_unresolved_name:
-            OS_DEBUG("unresolved name: %s\n", rec->rec.name.name);
+        case OSAL_UNRESOLVED_SYMBOL:
+            OS_DEBUG("unresolved symbol: %s\n", rec->rec.name.name);
             *status = OS_ERROR;
             break;
         case rtems_rtl_unresolved_reloc:
@@ -142,7 +142,7 @@ int32 OS_ModuleLoad_Impl(uint32 module_id, const char *translated_path)
 
         OS_DEBUG("module has has unresolved externals\n");
         status = OS_SUCCESS; /* note - not final, probably overridden */
-        rtems_rtl_unresolved_interate(OS_rtems_rtl_check_unresolved, &status);
+        OSAL_UNRESOLVED_ITERATE(OS_rtems_rtl_check_unresolved, &status);
     }
     else
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #608

This change adds support for RTEMS 5.1 in the OSAL.
The change provides defines and necessary ifdefs so RTEMS 4.11 can continue to be supported.

**Testing performed**
Following the instructions in the pc-rtems PSP:
https://github.com/nasa/PSP/blob/main/fsw/pc-rtems/README.txt
and the updated README_RTEMS_5.txt from PSP pull request 197, I built the RTEMS toolchains, the pc686 BSPs and cFS bundle for both RTEMS 4.11 and RTEMS 5.x. I then ran the bundle on both RTEMS 5.1 and RTEMS 4.11 on QEMU x86.
Note, that for RTEMS 5, the latest RTEMS 5.x git repository has to be used, since there was an RFS file system bug that prevented the bundle from working on the pc-rtems platform.

I did not run the complete set of tests yet on RTEMS 5.1.

**Expected behavior changes**
For RTEMS 4.11 there should be no behavior changes at all.
For RTEMS 5.1 there should be no behavior changes as well.

**System(s) tested on**
 - Hardware: QEMU x86
 - OS: RTEMS
 - Versions: RTEMS 4.11 and RTEMS 5.1

**Additional context**
This change requires cFE Pull request 1031.
It is associated with PSP pull request 220, but since that contains readme files, it is not required to build.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Cudmore NASA/GSFC Code 582.0
