### PR TITLE
fix #650 OS_chmod uses read or write access.

### DIFF
--- a/src/os/portable/os-impl-posix-files.c
+++ b/src/os/portable/os-impl-posix-files.c
@@ -202,7 +202,11 @@ int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
     fd = open(local_path, O_RDONLY, 0);
     if (fd < 0)
     {
-        return OS_ERROR;
+        fd = open(local_path, O_WRONLY, 0);
+        if (fd < 0)
+        {
+            return OS_ERROR;
+        }        
     }
 
     /*


### PR DESCRIPTION
**Describe the contribution**
Fixes #650 by checking for either read or write access instead of just read access 

**Testing performed**
Used the Chmod tests I am building in another branch that found this issue in the first place. 

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
-No changes 

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
