### PR TITLE
Fix #120, Exit console loop on shutdown

### DIFF
--- a/src/os/posix/src/os-impl-console.c
+++ b/src/os/posix/src/os-impl-console.c
@@ -34,6 +34,7 @@
 
 #include "os-shared-idmap.h"
 #include "os-shared-printf.h"
+#include "os-shared-common.h"
 
 /*
  * By default the console output is always asynchronous
@@ -96,7 +97,9 @@ static void *OS_ConsoleTask_Entry(void *arg)
     if (OS_ObjectIdGetById(OS_LOCK_MODE_REFCOUNT, OS_OBJECT_TYPE_OS_CONSOLE, local_arg.id, &token) == OS_SUCCESS)
     {
         local = OS_OBJECT_TABLE_GET(OS_impl_console_table, token);
-        while (true)
+
+        /* Loop forever (unless shutdown is set) */
+        while (OS_SharedGlobalVars.ShutdownFlag != OS_SHUTDOWN_MAGIC_NUMBER)
         {
             OS_ConsoleOutput_Impl(&token);
             sem_wait(&local->data_sem);

--- a/src/os/rtems/src/os-impl-console.c
+++ b/src/os/rtems/src/os-impl-console.c
@@ -38,6 +38,7 @@
 #include "os-rtems.h"
 #include "os-shared-printf.h"
 #include "os-shared-idmap.h"
+#include "os-shared-common.h"
 
 /****************************************************************************************
                                      DEFINES
@@ -120,7 +121,9 @@ static void OS_ConsoleTask_Entry(rtems_task_argument arg)
         OS_SUCCESS)
     {
         local = OS_OBJECT_TABLE_GET(OS_impl_console_table, token);
-        while (true)
+
+        /* Loop forever (unless shutdown is set) */
+        while (OS_SharedGlobalVars.ShutdownFlag != OS_SHUTDOWN_MAGIC_NUMBER)
         {
             OS_ConsoleOutput_Impl(&token);
             rtems_semaphore_obtain(local->data_sem, RTEMS_WAIT, RTEMS_NO_TIMEOUT);

--- a/src/os/vxworks/src/os-impl-console.c
+++ b/src/os/vxworks/src/os-impl-console.c
@@ -33,6 +33,7 @@
 
 #include "os-shared-printf.h"
 #include "os-shared-idmap.h"
+#include "os-shared-common.h"
 
 /****************************************************************************************
                                      DEFINES
@@ -104,7 +105,9 @@ int OS_VxWorks_ConsoleTask_Entry(int arg)
         OS_SUCCESS)
     {
         local = OS_OBJECT_TABLE_GET(OS_impl_console_table, token);
-        while (true)
+
+        /* Loop forever (unless shutdown is set) */
+        while (OS_SharedGlobalVars.ShutdownFlag != OS_SHUTDOWN_MAGIC_NUMBER)
         {
             OS_ConsoleOutput_Impl(&token);
             if (semTake(local->datasem, WAIT_FOREVER) == ERROR)


### PR DESCRIPTION
**Describe the contribution**
Fix #120 

Replaced condition on forever loops to end on shutdown. 

**Testing performed**
Built and ran unit tests for posix, built on vxworks (planning to build on RTEMs using the latest setup instructions...)

**Expected behavior changes**
- Loop will exit on shutdown

**System(s) tested on**
 - Hardware: cFS Dev server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this change

**Additional context**
What about also checking for a semaphore error on posix/rtems (or at least non-interrupt)?  Would make it consistent with vxworks.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC