### PR TITLE
type mismatch

### DIFF
--- a/src/os/shared/src/osapi-errors.c
+++ b/src/os/shared/src/osapi-errors.c
@@ -98,7 +98,7 @@ static const OS_ErrorTable_Entry_t OS_GLOBAL_ERROR_NAME_TABLE[] = {
  *-----------------------------------------------------------------*/
 int32 OS_GetErrorName(int32 error_num, os_err_name_t *err_name)
 {
-    uint32                       return_code;
+    int32                        return_code;
     const OS_ErrorTable_Entry_t *Error;
 
     if (err_name == NULL)

--- a/src/os/shared/src/osapi-network.c
+++ b/src/os/shared/src/osapi-network.c
@@ -65,7 +65,7 @@ int32 OS_NetworkAPI_Init(void)
  *-----------------------------------------------------------------*/
 int32 OS_NetworkGetHostName(char *host_name, size_t name_len)
 {
-    uint32 return_code;
+    int32 return_code;
 
     if (host_name == NULL)
     {


### PR DESCRIPTION
Variable return_code should be of type int32.
