### PR TITLE
Fix #642, synchronous task delete on POSIX

### DIFF
--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -386,7 +386,7 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
          */
         for (idx = 0; idx < OS_MAX_TIMEBASES; ++idx)
         {
-            if (OS_ObjectIdDefined(OS_global_timebase_table[idx].active_id) &&
+            if (OS_ObjectIdIsValid(OS_global_timebase_table[idx].active_id) &&
                 OS_impl_timebase_table[idx].assigned_signal != 0)
             {
                 sigaddset(&local->sigset, OS_impl_timebase_table[idx].assigned_signal);

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -173,6 +173,20 @@ int32 OS_TaskDelete_Impl(const OS_object_token_t *token)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_TaskDetach_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token)
+{
+    /* No-op on RTEMS */
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_TaskExit_Impl
  *
  *  Purpose: Implemented per internal OSAL API

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -30,8 +30,6 @@
 
 #include <os-shared-globaldefs.h>
 
-#define OS_OBJECT_EXCL_REQ_FLAG 0x0001
-
 #define OS_OBJECT_ID_RESERVED ((osal_id_t) {0xFFFFFFFF})
 
 /*
@@ -43,7 +41,6 @@ struct OS_common_record
     osal_id_t   active_id;
     osal_id_t   creator;
     uint16      refcount;
-    uint16      flags;
 };
 
 /*
@@ -212,6 +209,26 @@ static inline osal_objtype_t OS_ObjectIdToType_Impl(osal_id_t id)
 static inline void OS_ObjectIdCompose_Impl(osal_objtype_t idtype, uint32 idserial, osal_id_t *result)
 {
     *result = OS_ObjectIdFromInteger((idtype << OS_OBJECT_TYPE_SHIFT) | idserial);
+}
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Check if an object ID represents a valid/active value.
+ *
+ * This tests that the ID value is within the range specifically used by
+ * valid OSAL IDs. This is smaller than the set of defined IDs.
+ *
+ * For example, the value of OS_OBJECT_ID_RESERVED is defined but not valid.
+ * So while OS_ObjectIdDefined() will match entries being actively created or
+ * deleted, OS_ObjectIdIsValid() will not.
+ *
+ * @param[in]   object_id The object ID
+ * @returns     true if table entry is valid
+ */
+static inline bool OS_ObjectIdIsValid(osal_id_t object_id)
+{
+    osal_objtype_t objtype = OS_ObjectIdToType_Impl(object_id);
+    return (objtype > OS_OBJECT_TYPE_UNDEFINED && objtype < OS_OBJECT_TYPE_USER);
 }
 
 /*----------------------------------------------------------------

--- a/src/os/shared/inc/os-shared-task.h
+++ b/src/os/shared/inc/os-shared-task.h
@@ -95,6 +95,16 @@ int32 OS_TaskMatch_Impl(const OS_object_token_t *token);
 int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags);
 
 /*----------------------------------------------------------------
+   Function: OS_TaskDetach_Impl
+
+    Purpose: Sets the thread so that the OS resources associated with the task
+             will be released when the thread exits itself
+
+    Returns: OS_SUCCESS on success, or relevant error code
+ ------------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token);
+
+/*----------------------------------------------------------------
    Function: OS_TaskDelete_Impl
 
     Purpose: Free the OS resources associated with the specified task

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -354,74 +354,73 @@ void OS_ObjectIdTransactionCancel(OS_object_token_t *token)
  *-----------------------------------------------------------------*/
 int32 OS_ObjectIdConvertToken(OS_object_token_t *token)
 {
-    int32  return_code    = OS_ERROR;
-    uint32 exclusive_bits = 0;
-    uint32 attempts       = 0;
+    int32               return_code = OS_ERROR;
+    uint32              attempts    = 0;
+    OS_common_record_t *obj;
+    osal_id_t           expected_id;
 
-    OS_common_record_t *obj = OS_ObjectIdGlobalFromToken(token);
+    obj         = OS_ObjectIdGlobalFromToken(token);
+    expected_id = OS_ObjectIdFromToken(token);
+
+    /*
+     * Upon entry the ID must be valid
+     */
+    if (!OS_ObjectIdIsValid(expected_id))
+    {
+        return OS_ERR_INCORRECT_OBJ_STATE;
+    }
 
     while (true)
     {
         /* Validate the integrity of the ID.  As the "active_id" is a single
          * integer, we can do this check regardless of whether global is locked or not. */
-        if (!OS_ObjectIdEqual(obj->active_id, OS_ObjectIdFromToken(token)))
-        {
-            /* The ID does not match, so unlock and return error.
-             * This basically means the ID was stale or otherwise no longer invalid */
-            return_code = OS_ERR_INVALID_ID;
-            break;
-        }
-
-        /*
-         * The REFCOUNT and EXCLUSIVE lock modes require additional
-         * conditions on before they can be successful.
-         */
-        if (token->lock_mode == OS_LOCK_MODE_REFCOUNT)
-        {
-            /* As long as no exclusive request is pending, we can increment the
-             * refcount and good to go. */
-            if ((obj->flags & OS_OBJECT_EXCL_REQ_FLAG) == 0)
-            {
-                ++obj->refcount;
-                return_code = OS_SUCCESS;
-                break;
-            }
-        }
-        else if (token->lock_mode == OS_LOCK_MODE_EXCLUSIVE)
+        if (OS_ObjectIdEqual(obj->active_id, expected_id))
         {
             /*
-             * Set the exclusive request flag -- this will prevent anyone else from
-             * incrementing the refcount while we are waiting.  However we can only
-             * do this if there are no OTHER exclusive requests.
+             * Got an ID match...
              */
-            if (exclusive_bits != 0 || (obj->flags & OS_OBJECT_EXCL_REQ_FLAG) == 0)
+            if (token->lock_mode == OS_LOCK_MODE_EXCLUSIVE)
             {
                 /*
-                 * As long as nothing is referencing this object, we are good to go.
-                 * The global table will be left in a locked state in this case.
+                 * For EXCLUSIVE mode, overwrite the ID to be RESERVED now -- this
+                 * makes any future ID checks or lock attempts in other tasks fail to match.
+                 */
+                if (!OS_ObjectIdEqual(expected_id, OS_OBJECT_ID_RESERVED))
+                {
+                    expected_id    = OS_OBJECT_ID_RESERVED;
+                    obj->active_id = expected_id;
+                }
+
+                /*
+                 * Also confirm that reference count is zero
+                 * If not zero, will need to wait for other tasks to release.
                  */
                 if (obj->refcount == 0)
                 {
                     return_code = OS_SUCCESS;
                     break;
                 }
-
-                exclusive_bits = OS_OBJECT_EXCL_REQ_FLAG;
-                obj->flags |= exclusive_bits;
+            }
+            else
+            {
+                /*
+                 * Nothing else to test for this lock type
+                 */
+                return_code = OS_SUCCESS;
+                break;
             }
         }
-        else
+        else if (token->lock_mode == OS_LOCK_MODE_NONE || !OS_ObjectIdEqual(obj->active_id, OS_OBJECT_ID_RESERVED))
         {
-            /* No fanciness required - move on. */
-            return_code = OS_SUCCESS;
+            /* Not an ID match and not RESERVED - fail out */
+            return_code = OS_ERR_INVALID_ID;
             break;
         }
 
         /*
          * If we get this far, it means there is contention for access to the object.
-         *  a) we want to increment refcount but an exclusive is pending
-         *  b) we want exclusive but refcount is nonzero
-         *  c) we want exclusive but another exclusive is pending
+         *  a) we want to some type of lock but the ID is currently RESERVED
+         *  b) the refcount is too high - need to wait for release
          *
          * In this case we will UNLOCK the global object again so that the holder
          * can relinquish it.  We'll try again a few times before giving up hope.
@@ -446,20 +445,36 @@ int32 OS_ObjectIdConvertToken(OS_object_token_t *token)
      */
     if (token->lock_mode != OS_LOCK_MODE_NONE)
     {
-        /*
-         * In case any exclusive bits were set locally, unset them now
-         * before the lock is (maybe) released.
-         */
-        obj->flags &= ~exclusive_bits;
-
-        /*
-         * On a successful operation, the global is unlocked if it is a REFCOUNT
-         * style lock.  For other styles (GLOBAL or EXCLUSIVE) the global lock
-         * should be maintained and returned to the caller.
-         */
-        if (return_code == OS_SUCCESS && token->lock_mode == OS_LOCK_MODE_REFCOUNT)
+        if (return_code == OS_SUCCESS)
         {
-            OS_Unlock_Global(token->obj_type);
+            /* always increment the refcount, which means a task is actively
+             * using or modifying this record. */
+            ++obj->refcount;
+
+            /*
+             * On a successful operation, the global is unlocked if it is
+             * a REFCOUNT or EXCLUSIVE lock.  Note for EXCLUSIVE, because the ID
+             * was overwritten to OS_OBJECT_ID_RESERVED, other tasks will not be
+             * able to access the object because the ID will not match, so the
+             * table can be unlocked while the remainder of the create/delete process
+             * continues.
+             *
+             * For OS_LOCK_MODE_GLOBAL the global lock should be maintained and
+             * returned to the caller.
+             */
+            if (token->lock_mode == OS_LOCK_MODE_REFCOUNT || token->lock_mode == OS_LOCK_MODE_EXCLUSIVE)
+            {
+                OS_Unlock_Global(token->obj_type);
+            }
+        }
+        else if (OS_ObjectIdEqual(expected_id, OS_OBJECT_ID_RESERVED))
+        {
+            /*
+             * On failure, if the active_id was overwritten, then set
+             * it back to the original value which is in the token.
+             * (note it had to match initially before overwrite)
+             */
+            obj->active_id = OS_ObjectIdFromToken(token);
         }
     }
 
@@ -638,7 +653,7 @@ void OS_Lock_Global(osal_objtype_t idtype)
              * This is done after successfully locking, so this has exclusive access
              * to the state object.
              */
-            if (!OS_ObjectIdDefined(self_task_id))
+            if (!OS_ObjectIdIsValid(self_task_id))
             {
                 /*
                  * This just means the calling context is not an OSAL-created task.
@@ -696,7 +711,7 @@ void OS_Unlock_Global(osal_objtype_t idtype)
          * This is done before unlocking, while this has exclusive access
          * to the state object.
          */
-        if (!OS_ObjectIdDefined(self_task_id))
+        if (!OS_ObjectIdIsValid(self_task_id))
         {
             /*
              * This just means the calling context is not an OSAL-created task.
@@ -787,7 +802,7 @@ int32 OS_ObjectIdFinalizeNew(int32 operation_status, OS_object_token_t *token, o
 } /* end OS_ObjectIdFinalizeNew(, &token, ) */
 
 /*----------------------------------------------------------------
-   Function: OS_ObjectIdFinalizeDelete(, &token)
+   Function: OS_ObjectIdFinalizeDelete
 
     Purpose: Helper routine, not part of OSAL public API.
              See description in prototype
@@ -851,7 +866,7 @@ int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS
          */
         return_code = OS_ObjectIdConvertToken(token);
     }
-    else if (lock_mode != OS_LOCK_MODE_NONE)
+    else
     {
         OS_ObjectIdTransactionCancel(token);
     }
@@ -999,14 +1014,14 @@ void OS_ObjectIdTransactionFinish(OS_object_token_t *token, osal_id_t *final_id)
     record = OS_ObjectIdGlobalFromToken(token);
 
     /* re-acquire global table lock to adjust refcount */
-    if (token->lock_mode == OS_LOCK_MODE_REFCOUNT)
+    if (token->lock_mode == OS_LOCK_MODE_EXCLUSIVE || token->lock_mode == OS_LOCK_MODE_REFCOUNT)
     {
         OS_Lock_Global(token->obj_type);
+    }
 
-        if (record->refcount > 0)
-        {
-            --record->refcount;
-        }
+    if (record->refcount > 0)
+    {
+        --record->refcount;
     }
 
     /*
@@ -1020,6 +1035,15 @@ void OS_ObjectIdTransactionFinish(OS_object_token_t *token, osal_id_t *final_id)
     if (final_id != NULL)
     {
         record->active_id = *final_id;
+    }
+    else if (token->lock_mode == OS_LOCK_MODE_EXCLUSIVE)
+    {
+        /*
+         * If the lock type was EXCLUSIVE, it means that the ID in the record
+         * was reset to OS_OBJECT_ID_RESERVED.  This must restore the original
+         * object ID from the token.
+         */
+        record->active_id = token->obj_id;
     }
 
     /* always unlock (this also covers OS_LOCK_MODE_GLOBAL case) */
@@ -1118,16 +1142,28 @@ int32 OS_ObjectIdAllocateNew(osal_objtype_t idtype, const char *name, OS_object_
         return_code = OS_ObjectIdFindNextFree(token);
     }
 
+    /* If allocation failed, abort the operation now - no ID was allocated.
+     * After this point, if a future step fails, the allocated ID must be
+     * released. */
+    if (return_code != OS_SUCCESS)
+    {
+        OS_ObjectIdTransactionCancel(token);
+        return return_code;
+    }
+
     if (return_code == OS_SUCCESS)
     {
         return_code = OS_NotifyEvent(OS_EVENT_RESOURCE_ALLOCATED, token->obj_id, NULL);
     }
 
-    /* If allocation failed for any reason, unlock the global.
-     * otherwise the global should stay locked so remaining initialization can be done */
+    if (return_code == OS_SUCCESS)
+    {
+        return_code = OS_ObjectIdConvertToken(token);
+    }
+
     if (return_code != OS_SUCCESS)
     {
-        OS_ObjectIdTransactionCancel(token);
+        return_code = OS_ObjectIdFinalizeNew(return_code, token, NULL);
     }
 
     return return_code;
@@ -1322,7 +1358,7 @@ void OS_ForEachObjectOfType(osal_objtype_t idtype, osal_id_t creator_id, OS_ArgC
                 obj_id = OS_OBJECT_ID_UNDEFINED;
             }
 
-            if (OS_ObjectIdDefined(obj_id))
+            if (OS_ObjectIdIsValid(obj_id))
             {
                 /*
                  * Invoke Callback for the object, which must be done

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -174,7 +174,7 @@ int32 OS_SocketBind(osal_id_t sock_id, const OS_SockAddr_t *Addr)
         return OS_INVALID_POINTER;
     }
 
-    return_code = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, sock_id, &token);
+    return_code = OS_ObjectIdGetById(OS_LOCK_MODE_EXCLUSIVE, LOCAL_OBJID_TYPE, sock_id, &token);
     if (return_code == OS_SUCCESS)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_stream_table, token);
@@ -185,7 +185,7 @@ int32 OS_SocketBind(osal_id_t sock_id, const OS_SockAddr_t *Addr)
             /* Not a socket */
             return_code = OS_ERR_INCORRECT_OBJ_TYPE;
         }
-        else if (record->refcount != 0 || (stream->stream_state & (OS_STREAM_STATE_BOUND | OS_STREAM_STATE_CONNECTED)) != 0)
+        else if ((stream->stream_state & (OS_STREAM_STATE_BOUND | OS_STREAM_STATE_CONNECTED)) != 0)
         {
             /* Socket must be neither bound nor connected */
             return_code = OS_ERR_INCORRECT_OBJ_STATE;

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -279,6 +279,8 @@ void OS_TaskExit()
     task_id = OS_TaskGetId_Impl();
     if (OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, task_id, &token) == OS_SUCCESS)
     {
+        OS_TaskDetach_Impl(&token);
+
         /* Complete the operation via the common routine */
         OS_ObjectIdFinalizeDelete(OS_SUCCESS, &token);
     }

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -289,6 +289,20 @@ int32 OS_TaskDelete_Impl(const OS_object_token_t *token)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_TaskDetach_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token)
+{
+    /* No-op on VxWorks */
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_TaskExit_Impl
  *
  *  Purpose: Implemented per internal OSAL API

--- a/src/os/vxworks/src/os-impl-timebase.c
+++ b/src/os/vxworks/src/os-impl-timebase.c
@@ -377,7 +377,7 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
 
         for (idx = 0; idx < OS_MAX_TIMEBASES; ++idx)
         {
-            if (OS_ObjectIdDefined(OS_global_timebase_table[idx].active_id) &&
+            if (OS_ObjectIdIsValid(OS_global_timebase_table[idx].active_id) &&
                 OS_impl_timebase_table[idx].assigned_signal > 0)
             {
                 /* mark signal as in-use */

--- a/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
@@ -38,6 +38,7 @@
 ** Task API
 */
 UT_DEFAULT_STUB(OS_TaskMatch_Impl, (const OS_object_token_t *token))
+UT_DEFAULT_STUB(OS_TaskDetach_Impl, (const OS_object_token_t *token))
 UT_DEFAULT_STUB(OS_TaskCreate_Impl, (const OS_object_token_t *token, uint32 flags))
 UT_DEFAULT_STUB(OS_TaskDelete_Impl, (const OS_object_token_t *token))
 void OS_TaskExit_Impl(void)


### PR DESCRIPTION
**Describe the contribution**
Make OS_TaskDelete actually wait for the task to exit, not simply a cancellation request.

Fix #642

**Testing performed**
Build and run CFE and all unit tests
Test the CFE "reload app" command as documented in nasa/cfe#952 which depends on having OS_TaskDelete actually exit the task

**Expected behavior changes**
No impact to external API/observed behavior.

Internally, the global tables are now _unlocked_ when using an EXCLUSIVE lock type, which is used for create and delete ops.  Instead of holding the global lock, the ID is set to "RESERVED" (FFFFFFFF) which effectively prevents any other task from obtaining a reference to that object.  This way OSAL can more safely call C library functions which block, including (but not limited to) pthread_join, while allowing ops on other records to proceed.

**System(s) tested on**
Ubuntu 20.04
RTEMS 4.11

**Additional context**
Required as part of the fix for CFE requirement documented in nasa/cfe#952.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
