### PR TITLE
Fix #673 and #677, update global locks

### DIFF
--- a/src/os/rtems/src/os-impl-idmap.c
+++ b/src/os/rtems/src/os-impl-idmap.c
@@ -146,6 +146,32 @@ int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
     return OS_SUCCESS;
 } /* end OS_Unlock_Global_Impl */
 
+/*----------------------------------------------------------------
+ *
+ *  Function: OS_WaitForStateChange_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_WaitForStateChange_Impl(osal_objtype_t idtype, uint32 attempts)
+{
+    uint32 wait_ms;
+
+    if (attempts <= 10)
+    {
+        wait_ms = attempts * attempts * 10;
+    }
+    else
+    {
+        wait_ms = 1000;
+    }
+
+    OS_Unlock_Global_Impl(idtype);
+    OS_TaskDelay(wait_ms);
+    OS_Lock_Global_Impl(idtype);
+}
+
 /****************************************************************************************
                                 INITIALIZATION FUNCTION
  ***************************************************************************************/

--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -127,4 +127,20 @@ void OS_IdleLoop_Impl(void);
  ------------------------------------------------------------------*/
 void OS_ApplicationShutdown_Impl(void);
 
+/*----------------------------------------------------------------
+
+   Function: OS_WaitForStateChange_Impl
+
+   Purpose: Block the caller until some sort of change event
+   has occurred for the given object type, such as a record changing
+   state i.e. the acquisition or release of a lock/refcount from
+   another thread.
+
+   It is not guaranteed what, if any, state change has actually
+   occured when this function returns.  This may be implement as
+   a simple OS_TaskDelay().
+
+ ------------------------------------------------------------------*/
+void OS_WaitForStateChange_Impl(osal_objtype_t objtype, uint32 attempts);
+
 #endif /* INCLUDE_OS_SHARED_COMMON_H_ */

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -176,6 +176,19 @@ void OS_Unlock_Global(osal_objtype_t idtype);
  ------------------------------------------------------------------*/
 int32 OS_Unlock_Global_Impl(osal_objtype_t idtype);
 
+/*----------------------------------------------------------------
+
+   Function: OS_WaitForStateChange
+
+    Purpose: Waits for a change in the global table identified by "idtype"
+
+   NOTE: The table must be already "owned" (via OS_Lock_Global) by the calling
+   at the time this function is invoked.  The lock is released and re-acquired
+   before returning from this function.
+
+  -----------------------------------------------------------------*/
+void OS_WaitForStateChange(osal_objtype_t idtype, uint32 attempts);
+
 /*
    Function prototypes for routines implemented in common layers but private to OSAL
 

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -187,7 +187,10 @@ void Test_OS_ObjectIdConvertToken(void)
                   (long)actual, (long)expected);
 
     /* should have delayed 4 times, on the 5th try it returns error */
-    UtAssert_STUB_COUNT(OS_TaskDelay_Impl, 4);
+    UtAssert_STUB_COUNT(OS_WaitForStateChange_Impl, 4);
+
+    /* It should also have preserved the original ID */
+    UtAssert_True(OS_ObjectIdEqual(record->active_id, objid), "OS_ObjectIdConvertLock(EXCLUSIVE) objid restored");
 
     /*
      * Use mode OS_LOCK_MODE_EXCLUSIVE with matching ID and no other refs.

--- a/src/unit-test-coverage/ut-stubs/src/osapi-common-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-common-impl-stubs.c
@@ -45,3 +45,8 @@ void OS_ApplicationShutdown_Impl(void)
 {
     UT_DEFAULT_IMPL(OS_ApplicationShutdown_Impl);
 }
+
+void OS_WaitForStateChange_Impl(osal_objtype_t objtype, uint32 attempts)
+{
+    UT_DEFAULT_IMPL(OS_WaitForStateChange_Impl);
+}


### PR DESCRIPTION
**Describe the contribution**
Reworks the POSIX global lock implementation.

- Does not change the POSIX signal mask when locking/unlocking the global.  Aside from being unnecessary, there was also a race condition in here (Fixes #673)

- Adds a condition variable to the global lock structure.  In the event that there is more than task competing for access to the same object, this allows the second task to be woken immediately instead of polling for a change (Fixes #677).

**Testing performed**
Build and run all unit tests
Build and sanity check CFE

**Expected behavior changes**
No longer changing signal masks repeatedly/unexpectedly.  (may be relevant to some BSP/driver developers)

**System(s) tested on**
Ubuntu 20.04
RTEMS 4.11

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.