### PR TITLE
Fix #542, Avoid UT failure if SEM_VALUE_MAX >= UINT32_MAX

### DIFF
--- a/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
@@ -125,7 +125,7 @@ void UT_os_count_sem_create_test()
      * The OSAL should define this for itself, but it currently does not.
      *  (This macro is not currently defined in RTEMS)
      */
-#ifdef SEM_VALUE_MAX
+#if defined SEM_VALUE_MAX && SEM_VALUE_MAX < UINT32_MAX
     res = OS_CountSemCreate(&count_sem_ids[0], "CountSem1", ((uint32)SEM_VALUE_MAX) + 1, 0);
     if (res == OS_INVALID_SEM_VALUE)
         UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);


### PR DESCRIPTION
**Describe the contribution**
Fix #542 - avoids a potential unit test failure if an invalid semaphore value can not be passed in

**Testing performed**
Build and run unit tests, passed

**Expected behavior changes**
None.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Unable to reproduce error from issue (requires feedback from @mbenson1) but this fix avoids a potential error case.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC