### PR TITLE
Fix #569, Check and report sysconf error return

### DIFF
--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -206,6 +206,7 @@ static bool OS_Posix_GetSchedulerParams(int sched_policy, POSIX_PriorityLimits_t
 int32 OS_Posix_TaskAPI_Impl_Init(void)
 {
     int                    ret;
+    long                   ret_long;
     int                    sig;
     struct sched_param     sched_param;
     int                    sched_policy;
@@ -417,7 +418,13 @@ int32 OS_Posix_TaskAPI_Impl_Init(void)
     }
 #endif
 
-    POSIX_GlobalVars.PageSize = sysconf(_SC_PAGESIZE);
+    ret_long = sysconf(_SC_PAGESIZE);
+    if (ret_long < 0)
+    {
+       OS_DEBUG("Could not get page size via sysconf: %s\n", strerror(errno));
+       return OS_ERROR;
+    }
+    POSIX_GlobalVars.PageSize = ret_long;
 
     return OS_SUCCESS;
 } /* end OS_Posix_TaskAPI_Impl_Init */


### PR DESCRIPTION
**Describe the contribution**
Fix #569 - Checks return of sysconf for error and if so reports, only sets PageSize on success.

**Testing performed**
Build and run unit tests

**Expected behavior changes**
None since sysconf should never fail, but if it does provides mechanism to avoid error propagation

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC