### PR TITLE
Fix #686, Use errno in clock_getres error reporting

### DIFF
--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -225,7 +225,7 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
         status = clock_getres(OS_PREFERRED_CLOCK, &clock_resolution);
         if (status != 0)
         {
-            OS_DEBUG("failed in clock_getres: %s\n", strerror(status));
+            OS_DEBUG("failed in clock_getres: %s\n", strerror(errno));
             return_code = OS_ERROR;
             break;
         }


### PR DESCRIPTION
**Describe the contribution**
Fix #686 - Now uses errno instead of status return  from clock_getres with strerror reporting

**Testing performed**
Built and ran unit tests on linux, which doesn't mean much since it doesn't include this code in functional or coverage testing.
Requesting retest from @ericgilligan-nasa

**Expected behavior changes**
Fixed error message

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC