### PR TITLE
Fix #591, add test teardown failure to test summary

### DIFF
--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -79,12 +79,13 @@ void UtAssert_DoTestSegmentReport(const char *SegmentName, const UtAssert_TestCo
     char ReportBuffer[144];
 
     snprintf(ReportBuffer, sizeof(ReportBuffer),
-             "%02u %-20s TOTAL::%-4u  PASS::%-4u  FAIL::%-4u   MIR::%-4u   TSF::%-4u   N/A::%-4u\n",
+             "%02u %-20s TOTAL::%-4u  PASS::%-4u  FAIL::%-4u  MIR::%-4u  TSF::%-4u  TTF::%-4u  N/A::%-4u\n",
              (unsigned int)TestCounters->TestSegmentCount, SegmentName, (unsigned int)TestCounters->TotalTestCases,
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_PASS],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_FAILURE],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_MIR],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_TSF],
+             (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_TTF],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_NA]);
 
     UT_BSP_DoText(UTASSERT_CASETYPE_END, ReportBuffer);

--- a/ut_assert/src/utbsp.c
+++ b/ut_assert/src/utbsp.c
@@ -132,6 +132,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
                 Prefix       = "TSF";
                 break;
             case UTASSERT_CASETYPE_TTF:
+                TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_RED | OS_BSP_CONSOLEMODE_BLUE;
                 Prefix = "TTF";
                 break;
             case UTASSERT_CASETYPE_NA:


### PR DESCRIPTION
**Describe the contribution**
Fixes #591
added test teardown failures to the test summary 
also changed the print out to use the same style as startup failures. 

**Testing performed**
Used a test that always fails teardown and verified that it was reported in the test summary. 

**Expected behavior changes**
N/A

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
