### PR TITLE
Fix #697, use VERSION_LESS instead of VERSION_GREATER_EQUAL

### DIFF
--- a/src/os/vxworks/CMakeLists.txt
+++ b/src/os/vxworks/CMakeLists.txt
@@ -45,13 +45,13 @@ else ()
     )
 endif ()
 
-if (CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL 7.0)
+if (CMAKE_SYSTEM_VERSION VERSION_LESS 7.0)
     list(APPEND VXWORKS_IMPL_SRCLIST
-        ../portable/os-impl-posix-dirs.c
+        src/os-impl-dirs.c
     )
 else ()
     list(APPEND VXWORKS_IMPL_SRCLIST
-        src/os-impl-dirs.c
+        ../portable/os-impl-posix-dirs.c
     )
 endif ()
 # If some form of module loading is configured,


### PR DESCRIPTION
**Describe the contribution**
The VERSION_GREATER/LESS_EQUAL comparisons wer not introduced until CMake 3.7.  However, the basic VERSION_GREATER/LESS (no equal) comparison is much older, and 2.8.12 has no complaint about it.  So use VERSION_LESS and invert the condition.

Fixes #697 

**Testing performed**
Build for VxWorks 6.9 on RHEL 7.9

**Expected behavior changes**
Makefiles are generated and build succeeds.

**System(s) tested on**
VxWorks 6.9 using RHEL 7.9 host

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
