### PR TITLE
Fix #642, 645, 701, 702, 703 - OSAL global table management

### DIFF
--- a/src/os/posix/inc/os-impl-idmap.h
+++ b/src/os/posix/inc/os-impl-idmap.h
@@ -19,30 +19,26 @@
  */
 
 /**
- * \file     osapi-idmap-impl-stubs.c
- * \ingroup  ut-stubs
+ * \file     os-impl-idmap.h
+ * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdarg.h>
+#ifndef OS_IMPL_IDMAP_H
+#define OS_IMPL_IDMAP_H
 
-#include "utstubs.h"
+#include "osconfig.h"
+#include "osapi-idmap.h"
+#include <pthread.h>
 
-#include "os-shared-idmap.h"
-
-/*
- * Table locking and unlocking for global objects can be done at the shared code
- * layer but the actual implementation is OS-specific
- */
-void OS_Lock_Global_Impl(osal_objtype_t idtype)
+typedef struct
 {
-    UT_DEFAULT_IMPL(OS_Lock_Global_Impl);
-}
-void OS_Unlock_Global_Impl(osal_objtype_t idtype)
-{
-    UT_DEFAULT_IMPL(OS_Unlock_Global_Impl);
-}
+    pthread_mutex_t mutex;
+    pthread_cond_t  cond;
+} OS_impl_objtype_lock_t;
+
+/* Tables where the lock state information is stored */
+extern OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER];
+
+#endif  /* OS_IMPL_IDMAP_H  */

--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -34,45 +34,36 @@
 #include <sched.h>
 
 #include "os-shared-idmap.h"
+#include "os-impl-idmap.h"
 
-typedef struct
+static OS_impl_objtype_lock_t OS_global_task_table_lock;
+static OS_impl_objtype_lock_t OS_queue_table_lock;
+static OS_impl_objtype_lock_t OS_bin_sem_table_lock;
+static OS_impl_objtype_lock_t OS_mutex_table_lock;
+static OS_impl_objtype_lock_t OS_count_sem_table_lock;
+static OS_impl_objtype_lock_t OS_stream_table_lock;
+static OS_impl_objtype_lock_t OS_dir_table_lock;
+static OS_impl_objtype_lock_t OS_timebase_table_lock;
+static OS_impl_objtype_lock_t OS_timecb_table_lock;
+static OS_impl_objtype_lock_t OS_module_table_lock;
+static OS_impl_objtype_lock_t OS_filesys_table_lock;
+static OS_impl_objtype_lock_t OS_console_lock;
+
+OS_impl_objtype_lock_t * const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] =
 {
-    pthread_mutex_t mutex;
-    pthread_cond_t  cond;
-} POSIX_GlobalLock_t;
-
-static POSIX_GlobalLock_t OS_global_task_table_mut;
-static POSIX_GlobalLock_t OS_queue_table_mut;
-static POSIX_GlobalLock_t OS_bin_sem_table_mut;
-static POSIX_GlobalLock_t OS_mutex_table_mut;
-static POSIX_GlobalLock_t OS_count_sem_table_mut;
-static POSIX_GlobalLock_t OS_stream_table_mut;
-static POSIX_GlobalLock_t OS_dir_table_mut;
-static POSIX_GlobalLock_t OS_timebase_table_mut;
-static POSIX_GlobalLock_t OS_timecb_table_mut;
-static POSIX_GlobalLock_t OS_module_table_mut;
-static POSIX_GlobalLock_t OS_filesys_table_mut;
-static POSIX_GlobalLock_t OS_console_mut;
-
-static POSIX_GlobalLock_t *const MUTEX_TABLE[] = {
     [OS_OBJECT_TYPE_UNDEFINED]   = NULL,
-    [OS_OBJECT_TYPE_OS_TASK]     = &OS_global_task_table_mut,
-    [OS_OBJECT_TYPE_OS_QUEUE]    = &OS_queue_table_mut,
-    [OS_OBJECT_TYPE_OS_COUNTSEM] = &OS_count_sem_table_mut,
-    [OS_OBJECT_TYPE_OS_BINSEM]   = &OS_bin_sem_table_mut,
-    [OS_OBJECT_TYPE_OS_MUTEX]    = &OS_mutex_table_mut,
-    [OS_OBJECT_TYPE_OS_STREAM]   = &OS_stream_table_mut,
-    [OS_OBJECT_TYPE_OS_DIR]      = &OS_dir_table_mut,
-    [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_mut,
-    [OS_OBJECT_TYPE_OS_TIMECB]   = &OS_timecb_table_mut,
-    [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_mut,
-    [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_mut,
-    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_mut,
-};
-
-enum
-{
-    MUTEX_TABLE_SIZE = (sizeof(MUTEX_TABLE) / sizeof(MUTEX_TABLE[0]))
+    [OS_OBJECT_TYPE_OS_TASK]     = &OS_global_task_table_lock,
+    [OS_OBJECT_TYPE_OS_QUEUE]    = &OS_queue_table_lock,
+    [OS_OBJECT_TYPE_OS_COUNTSEM] = &OS_count_sem_table_lock,
+    [OS_OBJECT_TYPE_OS_BINSEM]   = &OS_bin_sem_table_lock,
+    [OS_OBJECT_TYPE_OS_MUTEX]    = &OS_mutex_table_lock,
+    [OS_OBJECT_TYPE_OS_STREAM]   = &OS_stream_table_lock,
+    [OS_OBJECT_TYPE_OS_DIR]      = &OS_dir_table_lock,
+    [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_lock,
+    [OS_OBJECT_TYPE_OS_TIMECB]   = &OS_timecb_table_lock,
+    [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_lock,
+    [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_lock,
+    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_lock,
 };
 
 /*---------------------------------------------------------------------------------------
@@ -92,31 +83,19 @@ void OS_Posix_ReleaseTableMutex(void *mut)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
+void OS_Lock_Global_Impl(osal_objtype_t idtype)
 {
-    POSIX_GlobalLock_t *mut;
+    OS_impl_objtype_lock_t *impl;
     int                 ret;
 
-    if (idtype < MUTEX_TABLE_SIZE)
+    impl = OS_impl_objtype_lock_table[idtype];
+
+    ret = pthread_mutex_lock(&impl->mutex);
+    if (ret != 0)
     {
-        mut = MUTEX_TABLE[idtype];
-    }
-    else
-    {
-        mut = NULL;
+        OS_DEBUG("pthread_mutex_lock(&impl->mutex): %s", strerror(ret));
     }
 
-    if (mut != NULL)
-    {
-        ret = pthread_mutex_lock(&mut->mutex);
-        if (ret != 0)
-        {
-            OS_DEBUG("pthread_mutex_lock(&mut->mutex): %s", strerror(ret));
-            return OS_ERROR;
-        }
-    }
-
-    return OS_SUCCESS;
 } /* end OS_Lock_Global_Impl */
 
 /*----------------------------------------------------------------
@@ -127,39 +106,27 @@ int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
+void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 {
-    POSIX_GlobalLock_t *mut;
+    OS_impl_objtype_lock_t *impl;
     int                 ret;
 
-    if (idtype < MUTEX_TABLE_SIZE)
-    {
-        mut = MUTEX_TABLE[idtype];
-    }
-    else
-    {
-        mut = NULL;
-    }
+    impl = OS_impl_objtype_lock_table[idtype];
 
-    if (mut != NULL)
+    /* Notify any waiting threads that the state _may_ have changed */
+    ret = pthread_cond_broadcast(&impl->cond);
+    if (ret != 0)
     {
-        /* Notify any waiting threads that the state _may_ have changed */
-        ret = pthread_cond_broadcast(&mut->cond);
-        if (ret != 0)
-        {
-            OS_DEBUG("pthread_cond_broadcast(&mut->cond): %s", strerror(ret));
-            /* unexpected but keep going (not critical) */
-        }
-
-        ret = pthread_mutex_unlock(&mut->mutex);
-        if (ret != 0)
-        {
-            OS_DEBUG("pthread_mutex_unlock(&mut->mutex): %s", strerror(ret));
-            return OS_ERROR;
-        }
+        OS_DEBUG("pthread_cond_broadcast(&impl->cond): %s", strerror(ret));
+        /* unexpected but keep going (not critical) */
     }
 
-    return OS_SUCCESS;
+    ret = pthread_mutex_unlock(&impl->mutex);
+    if (ret != 0)
+    {
+        OS_DEBUG("pthread_mutex_unlock(&impl->mutex): %s", strerror(ret));
+    }
+
 } /* end OS_Unlock_Global_Impl */
 
 /*----------------------------------------------------------------
@@ -172,42 +139,39 @@ int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
  *-----------------------------------------------------------------*/
 void OS_WaitForStateChange_Impl(osal_objtype_t idtype, uint32 attempts)
 {
-    POSIX_GlobalLock_t *impl;
+    OS_impl_objtype_lock_t *impl;
     struct timespec     ts;
 
-    impl = MUTEX_TABLE[idtype];
+    impl = OS_impl_objtype_lock_table[idtype];
 
-    if (impl != NULL)
+    /*
+     * because pthread_cond_timedwait() is also a cancellation point,
+     * this pushes a cleanup handler to ensure that if canceled during this call,
+     * the mutex will be released.
+     */
+    pthread_cleanup_push(OS_Posix_ReleaseTableMutex, &impl->mutex);
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+
+    if (attempts <= 10)
     {
-        /*
-         * because pthread_cond_timedwait() is also a cancellation point,
-         * this pushes a cleanup handler to ensure that if canceled during this call,
-         * the mutex will be released.
-         */
-        pthread_cleanup_push(OS_Posix_ReleaseTableMutex, &impl->mutex);
-
-        clock_gettime(CLOCK_REALTIME, &ts);
-
-        if (attempts <= 10)
+        /* Wait an increasing amount of time, starting at 10ms */
+        ts.tv_nsec += attempts * attempts * 10000000;
+        if (ts.tv_nsec >= 1000000000)
         {
-            /* Wait an increasing amount of time, starting at 10ms */
-            ts.tv_nsec += attempts * attempts * 10000000;
-            if (ts.tv_nsec >= 1000000000)
-            {
-                ts.tv_nsec -= 1000000000;
-                ++ts.tv_sec;
-            }
-        }
-        else
-        {
-            /* wait 1 second (max for polling) */
+            ts.tv_nsec -= 1000000000;
             ++ts.tv_sec;
         }
-
-        pthread_cond_timedwait(&impl->cond, &impl->mutex, &ts);
-
-        pthread_cleanup_pop(false);
     }
+    else
+    {
+        /* wait 1 second (max for polling) */
+        ++ts.tv_sec;
+    }
+
+    pthread_cond_timedwait(&impl->cond, &impl->mutex, &ts);
+
+    pthread_cleanup_pop(false);
 }
 
 /*---------------------------------------------------------------------------------------
@@ -222,23 +186,16 @@ int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
     int                 ret;
     int32               return_code = OS_SUCCESS;
     pthread_mutexattr_t mutex_attr;
-    POSIX_GlobalLock_t *impl;
+    OS_impl_objtype_lock_t *impl;
+
+    impl = OS_impl_objtype_lock_table[idtype];
+    if (impl == NULL)
+    {
+        return OS_SUCCESS;
+    }
 
     do
     {
-        if (idtype >= MUTEX_TABLE_SIZE)
-        {
-            break;
-        }
-
-        impl = MUTEX_TABLE[idtype];
-
-        /* Initialize the table mutex for the given idtype */
-        if (impl == NULL)
-        {
-            break;
-        }
-
         /*
          * initialize the pthread mutex attribute structure with default values
          */

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -485,6 +485,16 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority
     }
 
     /*
+    ** Set the thread to be joinable by default
+    */
+    return_code = pthread_attr_setdetachstate(&custom_attr, PTHREAD_CREATE_JOINABLE);
+    if (return_code != 0)
+    {
+        OS_DEBUG("pthread_attr_setdetachstate error in OS_TaskCreate: %s\n", strerror(return_code));
+        return (OS_ERROR);
+    }
+
+    /*
     ** Test to see if the original main task scheduling priority worked.
     ** If so, then also set the attributes for this task.  Otherwise attributes
     ** are left at default.
@@ -548,12 +558,6 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority
      ** Do not treat anything bad that happens after this point as fatal.
      ** The task is running, after all - better to leave well enough alone.
      */
-    return_code = pthread_detach(*pthr);
-    if (return_code != 0)
-    {
-        OS_DEBUG("pthread_detach error in OS_TaskCreate: %s\n", strerror(return_code));
-    }
-
     return_code = pthread_attr_destroy(&custom_attr);
     if (return_code != 0)
     {
@@ -592,6 +596,33 @@ int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_TaskDetach_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token)
+{
+    OS_impl_task_internal_record_t *impl;
+    int                             ret;
+
+    impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
+
+    ret = pthread_detach(impl->id);
+
+    if (ret != 0)
+    {
+        OS_DEBUG("pthread_detach: Failed on Task ID = %lu, err = %s\n",
+                 OS_ObjectIdToInteger(OS_ObjectIdFromToken(token)), strerror(ret));
+        return OS_ERROR;
+    }
+
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_TaskMatch_Impl
  *
  *  Purpose: Implemented per internal OSAL API
@@ -623,6 +654,8 @@ int32 OS_TaskMatch_Impl(const OS_object_token_t *token)
 int32 OS_TaskDelete_Impl(const OS_object_token_t *token)
 {
     OS_impl_task_internal_record_t *impl;
+    void *                          retval;
+    int                             ret;
 
     impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
 
@@ -632,7 +665,35 @@ int32 OS_TaskDelete_Impl(const OS_object_token_t *token)
     ** to cancel here is that the thread ID is invalid because it already exited itself,
     ** and if that is true there is nothing wrong - everything is OK to continue normally.
     */
-    pthread_cancel(impl->id);
+    ret = pthread_cancel(impl->id);
+    if (ret != 0)
+    {
+        OS_DEBUG("pthread_cancel: Failed on Task ID = %lu, err = %s\n",
+                 OS_ObjectIdToInteger(OS_ObjectIdFromToken(token)), strerror(ret));
+
+        /* fall through (will still return OS_SUCCESS) */
+    }
+    else
+    {
+        /*
+         * Note that "pthread_cancel" is a request - and successful return above
+         * only means that the cancellation request is pending.
+         *
+         * pthread_join() will wait until the thread has actually exited.
+         *
+         * This is important for CFE, as task deletion often occurs in
+         * conjunction with an application reload - which means the next
+         * call is likely to be OS_ModuleUnload().  So is critical that all
+         * tasks potentially executing code within that module have actually
+         * been stopped - not just pending cancellation.
+         */
+        ret = pthread_join(impl->id, &retval);
+        if (ret != 0)
+        {
+            OS_DEBUG("pthread_join: Failed on Task ID = %lu, err = %s\n",
+                     OS_ObjectIdToInteger(OS_ObjectIdFromToken(token)), strerror(ret));
+        }
+    }
     return OS_SUCCESS;
 
 } /* end OS_TaskDelete_Impl */
@@ -738,6 +799,17 @@ int32 OS_TaskRegister_Impl(osal_id_t global_task_id)
 {
     int32                return_code;
     OS_U32ValueWrapper_t arg;
+    int                  old_state;
+    int                  old_type;
+
+    /*
+     * Set cancel state=ENABLED, type=DEFERRED
+     * This should be the default for new threads, but
+     * setting explicitly to be sure that a pthread_join()
+     * will work as expected in case this thread is deleted.
+     */
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
+    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &old_type);
 
     arg.opaque_arg = 0;
     arg.id         = global_task_id;

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -387,7 +387,7 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
          */
         for (idx = 0; idx < OS_MAX_TIMEBASES; ++idx)
         {
-            if (OS_ObjectIdDefined(OS_global_timebase_table[idx].active_id) &&
+            if (OS_ObjectIdIsValid(OS_global_timebase_table[idx].active_id) &&
                 OS_impl_timebase_table[idx].assigned_signal != 0)
             {
                 sigaddset(&local->sigset, OS_impl_timebase_table[idx].assigned_signal);

--- a/src/os/rtems/inc/os-impl-idmap.h
+++ b/src/os/rtems/inc/os-impl-idmap.h
@@ -19,30 +19,25 @@
  */
 
 /**
- * \file     osapi-idmap-impl-stubs.c
- * \ingroup  ut-stubs
+ * \file     os-impl-idmap.h
+ * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdarg.h>
+#ifndef OS_IMPL_IDMAP_H
+#define OS_IMPL_IDMAP_H
 
-#include "utstubs.h"
+#include "osconfig.h"
+#include "osapi-idmap.h"
+#include <rtems.h>
 
-#include "os-shared-idmap.h"
-
-/*
- * Table locking and unlocking for global objects can be done at the shared code
- * layer but the actual implementation is OS-specific
- */
-void OS_Lock_Global_Impl(osal_objtype_t idtype)
+typedef struct
 {
-    UT_DEFAULT_IMPL(OS_Lock_Global_Impl);
-}
-void OS_Unlock_Global_Impl(osal_objtype_t idtype)
-{
-    UT_DEFAULT_IMPL(OS_Unlock_Global_Impl);
-}
+    rtems_id id;
+} OS_impl_objtype_lock_t;
+
+/* Tables where the lock state information is stored */
+extern OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER];
+
+#endif  /* OS_IMPL_IDMAP_H  */

--- a/src/os/rtems/src/os-impl-idmap.c
+++ b/src/os/rtems/src/os-impl-idmap.c
@@ -33,6 +33,7 @@
 
 #include "os-rtems.h"
 #include "os-shared-idmap.h"
+#include "os-impl-idmap.h"
 
 /****************************************************************************************
                                      DEFINES
@@ -44,38 +45,34 @@
                                      GLOBALS
  ***************************************************************************************/
 
-rtems_id OS_task_table_sem;
-rtems_id OS_queue_table_sem;
-rtems_id OS_bin_sem_table_sem;
-rtems_id OS_mutex_table_sem;
-rtems_id OS_count_sem_table_sem;
-rtems_id OS_stream_table_mut;
-rtems_id OS_dir_table_mut;
-rtems_id OS_timebase_table_mut;
-rtems_id OS_timecb_table_mut;
-rtems_id OS_module_table_mut;
-rtems_id OS_filesys_table_mut;
-rtems_id OS_console_mut;
+static OS_impl_objtype_lock_t OS_task_table_lock;
+static OS_impl_objtype_lock_t OS_queue_table_lock;
+static OS_impl_objtype_lock_t OS_bin_sem_table_lock;
+static OS_impl_objtype_lock_t OS_mutex_table_lock;
+static OS_impl_objtype_lock_t OS_count_sem_table_lock;
+static OS_impl_objtype_lock_t OS_stream_table_lock;
+static OS_impl_objtype_lock_t OS_dir_table_lock;
+static OS_impl_objtype_lock_t OS_timebase_table_lock;
+static OS_impl_objtype_lock_t OS_timecb_table_lock;
+static OS_impl_objtype_lock_t OS_module_table_lock;
+static OS_impl_objtype_lock_t OS_filesys_table_lock;
+static OS_impl_objtype_lock_t OS_console_lock;
 
-static rtems_id *const MUTEX_TABLE[] = {
-    [OS_OBJECT_TYPE_UNDEFINED]   = NULL,
-    [OS_OBJECT_TYPE_OS_TASK]     = &OS_task_table_sem,
-    [OS_OBJECT_TYPE_OS_QUEUE]    = &OS_queue_table_sem,
-    [OS_OBJECT_TYPE_OS_COUNTSEM] = &OS_count_sem_table_sem,
-    [OS_OBJECT_TYPE_OS_BINSEM]   = &OS_bin_sem_table_sem,
-    [OS_OBJECT_TYPE_OS_MUTEX]    = &OS_mutex_table_sem,
-    [OS_OBJECT_TYPE_OS_STREAM]   = &OS_stream_table_mut,
-    [OS_OBJECT_TYPE_OS_DIR]      = &OS_dir_table_mut,
-    [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_mut,
-    [OS_OBJECT_TYPE_OS_TIMECB]   = &OS_timecb_table_mut,
-    [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_mut,
-    [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_mut,
-    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_mut,
-};
-
-enum
+OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] =
 {
-    MUTEX_TABLE_SIZE = (sizeof(MUTEX_TABLE) / sizeof(MUTEX_TABLE[0]))
+    [OS_OBJECT_TYPE_UNDEFINED]   = NULL,
+    [OS_OBJECT_TYPE_OS_TASK]     = &OS_task_table_lock,
+    [OS_OBJECT_TYPE_OS_QUEUE]    = &OS_queue_table_lock,
+    [OS_OBJECT_TYPE_OS_COUNTSEM] = &OS_count_sem_table_lock,
+    [OS_OBJECT_TYPE_OS_BINSEM]   = &OS_bin_sem_table_lock,
+    [OS_OBJECT_TYPE_OS_MUTEX]    = &OS_mutex_table_lock,
+    [OS_OBJECT_TYPE_OS_STREAM]   = &OS_stream_table_lock,
+    [OS_OBJECT_TYPE_OS_DIR]      = &OS_dir_table_lock,
+    [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_lock,
+    [OS_OBJECT_TYPE_OS_TIMECB]   = &OS_timecb_table_lock,
+    [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_lock,
+    [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_lock,
+    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_lock,
 };
 
 /*----------------------------------------------------------------
@@ -86,30 +83,19 @@ enum
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
+void OS_Lock_Global_Impl(osal_objtype_t idtype)
 {
-    rtems_id *mut;
+    OS_impl_objtype_lock_t *impl;
+    rtems_status_code rtems_sc;
 
-    if (idtype < MUTEX_TABLE_SIZE)
-    {
-        mut = MUTEX_TABLE[idtype];
-    }
-    else
-    {
-        mut = NULL;
-    }
+    impl = OS_impl_objtype_lock_table[idtype];
 
-    if (mut == NULL)
+    rtems_sc = rtems_semaphore_obtain(impl->id, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
+    if (rtems_sc != RTEMS_SUCCESSFUL)
     {
-        return OS_ERROR;
+        OS_DEBUG("OS_Lock_Global_Impl: rtems_semaphore_obtain failed: %s\n", rtems_status_text(rtems_sc));
     }
 
-    if (rtems_semaphore_obtain(*mut, RTEMS_WAIT, RTEMS_NO_TIMEOUT) != 0)
-    {
-        return OS_ERROR;
-    }
-
-    return OS_SUCCESS;
 } /* end OS_Lock_Global_Impl */
 
 /*----------------------------------------------------------------
@@ -120,30 +106,19 @@ int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
+void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 {
-    rtems_id *mut;
+    OS_impl_objtype_lock_t *impl;
+    rtems_status_code rtems_sc;
 
-    if (idtype < MUTEX_TABLE_SIZE)
-    {
-        mut = MUTEX_TABLE[idtype];
-    }
-    else
-    {
-        mut = NULL;
-    }
+    impl = OS_impl_objtype_lock_table[idtype];
 
-    if (mut == NULL)
+    rtems_sc = rtems_semaphore_release(impl->id);
+    if (rtems_sc != RTEMS_SUCCESSFUL)
     {
-        return OS_ERROR;
+        OS_DEBUG("OS_Unlock_Global_Impl: rtems_semaphore_release failed: %s\n", rtems_status_text(rtems_sc));
     }
 
-    if (rtems_semaphore_release(*mut) != 0)
-    {
-        return OS_ERROR;
-    }
-
-    return OS_SUCCESS;
 } /* end OS_Unlock_Global_Impl */
 
 /*----------------------------------------------------------------
@@ -156,19 +131,19 @@ int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
  *-----------------------------------------------------------------*/
 void OS_WaitForStateChange_Impl(osal_objtype_t idtype, uint32 attempts)
 {
-    uint32 wait_ms;
+    rtems_interval wait_ticks;
 
     if (attempts <= 10)
     {
-        wait_ms = attempts * attempts * 10;
+        wait_ticks = attempts * attempts;
     }
     else
     {
-        wait_ms = 1000;
+        wait_ticks = 100;
     }
 
     OS_Unlock_Global_Impl(idtype);
-    OS_TaskDelay(wait_ms);
+    rtems_task_wake_after(wait_ticks);
     OS_Lock_Global_Impl(idtype);
 }
 
@@ -186,20 +161,22 @@ void OS_WaitForStateChange_Impl(osal_objtype_t idtype, uint32 attempts)
 ---------------------------------------------------------------------------------------*/
 int32 OS_Rtems_TableMutex_Init(osal_objtype_t idtype)
 {
-    int32             return_code = OS_SUCCESS;
+    OS_impl_objtype_lock_t *impl;
     rtems_status_code rtems_sc;
 
-    /* Initialize the table mutex for the given idtype */
-    if (idtype < MUTEX_TABLE_SIZE && MUTEX_TABLE[idtype] != NULL)
+    impl = OS_impl_objtype_lock_table[idtype];
+    if (impl == NULL)
     {
-        rtems_sc = rtems_semaphore_create(idtype, 1, OSAL_TABLE_MUTEX_ATTRIBS, 0, MUTEX_TABLE[idtype]);
-
-        if (rtems_sc != RTEMS_SUCCESSFUL)
-        {
-            OS_DEBUG("Error: rtems_semaphore_create failed: %s\n", rtems_status_text(rtems_sc));
-            return_code = OS_ERROR;
-        }
+        return OS_SUCCESS;
     }
 
-    return (return_code);
+    /* Initialize the table mutex for the given idtype */
+    rtems_sc = rtems_semaphore_create(idtype, 1, OSAL_TABLE_MUTEX_ATTRIBS, 0, &impl->id);
+    if (rtems_sc != RTEMS_SUCCESSFUL)
+    {
+        OS_DEBUG("Error: rtems_semaphore_create failed: %s\n", rtems_status_text(rtems_sc));
+        return OS_ERROR;
+    }
+
+    return OS_SUCCESS;
 } /* end OS_Rtems_TableMutex_Init */

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -175,6 +175,20 @@ int32 OS_TaskDelete_Impl(const OS_object_token_t *token)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_TaskDetach_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token)
+{
+    /* No-op on RTEMS */
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_TaskExit_Impl
  *
  *  Purpose: Implemented per internal OSAL API

--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -128,20 +128,4 @@ void OS_IdleLoop_Impl(void);
  ------------------------------------------------------------------*/
 void OS_ApplicationShutdown_Impl(void);
 
-/*----------------------------------------------------------------
-
-   Function: OS_WaitForStateChange_Impl
-
-   Purpose: Block the caller until some sort of change event
-   has occurred for the given object type, such as a record changing
-   state i.e. the acquisition or release of a lock/refcount from
-   another thread.
-
-   It is not guaranteed what, if any, state change has actually
-   occured when this function returns.  This may be implement as
-   a simple OS_TaskDelay().
-
- ------------------------------------------------------------------*/
-void OS_WaitForStateChange_Impl(osal_objtype_t objtype, uint32 attempts);
-
 #endif  /* OS_SHARED_COMMON_H  */

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -540,6 +540,7 @@ int32 OS_ObjectIdIteratorProcessEntry(OS_object_iter_t *iter, int32 (*func)(osal
  * These are not normally called outside this unit, but need
  * to be exposed for unit testing.
  */
+bool  OS_ObjectFilterActive(void *ref, const OS_object_token_t *token, const OS_common_record_t *obj);
 bool  OS_ObjectNameMatch(void *ref, const OS_object_token_t *token, const OS_common_record_t *obj);
 int32 OS_ObjectIdFindNextMatch(OS_ObjectMatchFunc_t MatchFunc, void *arg, OS_object_token_t *token);
 int32 OS_ObjectIdFindNextFree(OS_object_token_t *token);

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -31,8 +31,6 @@
 #include "osapi-idmap.h"
 #include <os-shared-globaldefs.h>
 
-#define OS_OBJECT_EXCL_REQ_FLAG 0x0001
-
 #define OS_OBJECT_ID_RESERVED ((osal_id_t) {0xFFFFFFFF})
 
 /*
@@ -44,7 +42,6 @@ struct OS_common_record
     osal_id_t   active_id;
     osal_id_t   creator;
     uint16      refcount;
-    uint16      flags;
 };
 
 /*
@@ -52,10 +49,11 @@ struct OS_common_record
  */
 typedef enum
 {
-    OS_LOCK_MODE_NONE,      /**< Do not lock global table at all (use with caution) */
-    OS_LOCK_MODE_GLOBAL,    /**< Lock during operation, and if successful, leave global table locked */
-    OS_LOCK_MODE_EXCLUSIVE, /**< Like OS_LOCK_MODE_GLOBAL but must be exclusive (refcount == zero)  */
-    OS_LOCK_MODE_REFCOUNT,  /**< If operation succeeds, increment refcount and unlock global table */
+    OS_LOCK_MODE_NONE,      /**< Quick ID validity check, does not lock global table at all (use with caution) */
+    OS_LOCK_MODE_GLOBAL,    /**< Confirm ID match, and if successful, leave global table locked */
+    OS_LOCK_MODE_REFCOUNT,  /**< Confirm ID match, increment refcount, and unlock global table.  ID is not changed. */
+    OS_LOCK_MODE_EXCLUSIVE, /**< Confirm ID match AND refcount equal zero, then change ID to RESERVED value and unlock global. */
+    OS_LOCK_MODE_RESERVED   /**< Confirm ID is already set to RESERVED, otherwise like OS_LOCK_MODE_GLOBAL. */
 } OS_lock_mode_t;
 
 /*

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -228,6 +228,26 @@ static inline void OS_ObjectIdCompose_Impl(osal_objtype_t idtype, uint32 idseria
     *result = OS_ObjectIdFromInteger((idtype << OS_OBJECT_TYPE_SHIFT) | idserial);
 }
 
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Check if an object ID represents a valid/active value.
+ *
+ * This tests that the ID value is within the range specifically used by
+ * valid OSAL IDs. This is smaller than the set of defined IDs.
+ *
+ * For example, the value of OS_OBJECT_ID_RESERVED is defined but not valid.
+ * So while OS_ObjectIdDefined() will match entries being actively created or
+ * deleted, OS_ObjectIdIsValid() will not.
+ *
+ * @param[in]   object_id The object ID
+ * @returns     true if table entry is valid
+ */
+static inline bool OS_ObjectIdIsValid(osal_id_t object_id)
+{
+    osal_objtype_t objtype = OS_ObjectIdToType_Impl(object_id);
+    return (objtype > OS_OBJECT_TYPE_UNDEFINED && objtype < OS_OBJECT_TYPE_USER);
+}
+
 /*----------------------------------------------------------------
    Function: OS_GetMaxForObjectType
 
@@ -488,7 +508,7 @@ static inline const OS_object_token_t *OS_ObjectIdIteratorRef(OS_object_iter_t *
 
     Returns: None
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdIteratorProcessEntry(OS_object_iter_t *iter, int32 (*func)(osal_id_t));
+int32 OS_ObjectIdIteratorProcessEntry(OS_object_iter_t *iter, int32 (*func)(osal_id_t,void*));
 
 /*
  * Internal helper functions

--- a/src/os/shared/inc/os-shared-task.h
+++ b/src/os/shared/inc/os-shared-task.h
@@ -96,6 +96,16 @@ int32 OS_TaskMatch_Impl(const OS_object_token_t *token);
 int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags);
 
 /*----------------------------------------------------------------
+   Function: OS_TaskDetach_Impl
+
+    Purpose: Sets the thread so that the OS resources associated with the task
+             will be released when the thread exits itself
+
+    Returns: OS_SUCCESS on success, or relevant error code
+ ------------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token);
+
+/*----------------------------------------------------------------
    Function: OS_TaskDelete_Impl
 
     Purpose: Free the OS resources associated with the specified task

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -68,6 +68,16 @@ enum
 
 OS_stream_internal_record_t OS_stream_table[OS_MAX_NUM_OPEN_FILES];
 
+/*----------------------------------------------------------------
+ *
+ * Helper function to close a file from an iterator
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileIteratorClose(osal_id_t filedes, void *arg)
+{
+    return OS_close(filedes);
+}
+
 /****************************************************************************************
                                   FILE API
  ***************************************************************************************/
@@ -669,7 +679,7 @@ int32 OS_CloseFileByName(const char *Filename)
         if (stream->socket_domain == OS_SocketDomain_INVALID && (strcmp(stream->stream_name, Filename) == 0))
         {
             /* call OS_close() on the entry referred to by the iterator */
-            close_code = OS_ObjectIdIteratorProcessEntry(&iter, OS_close);
+            close_code = OS_ObjectIdIteratorProcessEntry(&iter, OS_FileIteratorClose);
 
             if (return_code == OS_FS_ERR_PATH_INVALID || close_code != OS_SUCCESS)
             {
@@ -705,7 +715,7 @@ int32 OS_CloseAllFiles(void)
     while (OS_ObjectIdIteratorGetNext(&iter))
     {
         /* call OS_close() on the entry referred to by the iterator */
-        close_code = OS_ObjectIdIteratorProcessEntry(&iter, OS_close);
+        close_code = OS_ObjectIdIteratorProcessEntry(&iter, OS_FileIteratorClose);
         if (close_code != OS_SUCCESS)
         {
             return_code = close_code;

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -65,6 +65,21 @@ const char OS_FILESYS_RAMDISK_VOLNAME_PREFIX[] = "RAM";
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_FileSysFilterFree
+ *
+ *  Purpose: Local helper routine, not part of OSAL API.
+ *           Iterator function to match only the free/open entries
+ *
+ *  Returns: true if the entry is free, false if it is in use
+ *
+ *-----------------------------------------------------------------*/
+bool OS_FileSysFilterFree(void *ref, const OS_object_token_t *token, const OS_common_record_t *obj)
+{
+    return !OS_ObjectIdDefined(obj->active_id);
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_FileSys_FindVirtMountPoint
  *
  *  Purpose: Local helper routine, not part of OSAL API.
@@ -688,7 +703,7 @@ int32 OS_FS_GetPhysDriveName(char *PhysDriveName, const char *MountPoint)
  *-----------------------------------------------------------------*/
 int32 OS_GetFsInfo(os_fsinfo_t *filesys_info)
 {
-    osal_index_t idx;
+    OS_object_iter_t iter;
 
     /* Check parameters */
     OS_CHECK_POINTER(filesys_info);
@@ -698,29 +713,19 @@ int32 OS_GetFsInfo(os_fsinfo_t *filesys_info)
     filesys_info->MaxFds     = OS_MAX_NUM_OPEN_FILES;
     filesys_info->MaxVolumes = OS_MAX_FILE_SYSTEMS;
 
-    OS_Lock_Global(OS_OBJECT_TYPE_OS_STREAM);
-
-    for (idx = 0; idx < OS_MAX_NUM_OPEN_FILES; idx++)
+    OS_ObjectIdIteratorInit(OS_FileSysFilterFree, NULL, OS_OBJECT_TYPE_OS_STREAM, &iter);
+    while (OS_ObjectIdIteratorGetNext(&iter))
     {
-        if (!OS_ObjectIdDefined(OS_global_stream_table[idx].active_id))
-        {
-            filesys_info->FreeFds++;
-        }
+        ++filesys_info->FreeFds;
     }
+    OS_ObjectIdIteratorDestroy(&iter);
 
-    OS_Unlock_Global(OS_OBJECT_TYPE_OS_STREAM);
-
-    OS_Lock_Global(OS_OBJECT_TYPE_OS_FILESYS);
-
-    for (idx = 0; idx < OS_MAX_FILE_SYSTEMS; idx++)
+    OS_ObjectIdIteratorInit(OS_FileSysFilterFree, NULL, OS_OBJECT_TYPE_OS_FILESYS, &iter);
+    while (OS_ObjectIdIteratorGetNext(&iter))
     {
-        if (!OS_ObjectIdDefined(OS_global_filesys_table[idx].active_id))
-        {
-            filesys_info->FreeVolumes++;
-        }
+        ++filesys_info->FreeVolumes;
     }
-
-    OS_Unlock_Global(OS_OBJECT_TYPE_OS_FILESYS);
+    OS_ObjectIdIteratorDestroy(&iter);
 
     return (OS_SUCCESS);
 } /* end OS_GetFsInfo */

--- a/src/os/shared/src/osapi-module.c
+++ b/src/os/shared/src/osapi-module.c
@@ -452,6 +452,7 @@ int32 OS_SymbolTableDump(const char *filename, size_t SizeLimit)
 {
     int32 return_code;
     char  translated_path[OS_MAX_LOCAL_PATH_LEN];
+    OS_object_token_t token;
 
     /*
     ** Check parameters
@@ -476,11 +477,15 @@ int32 OS_SymbolTableDump(const char *filename, size_t SizeLimit)
      * underlying implementation may safely use globals for
      * state storage.
      */
-    OS_Lock_Global(LOCAL_OBJID_TYPE);
+    return_code = OS_ObjectIdTransactionInit(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, &token);
+    if (return_code != OS_SUCCESS)
+    {
+        return (return_code);
+    }
 
     return_code = OS_SymbolTableDump_Impl(translated_path, SizeLimit);
 
-    OS_Unlock_Global(LOCAL_OBJID_TYPE);
+    OS_ObjectIdTransactionCancel(&token);
 
     return (return_code);
 

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -295,7 +295,7 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
 
     if (conn_record != NULL)
     {
-        OS_Lock_Global(LOCAL_OBJID_TYPE);
+        OS_Lock_Global(&conn_token);
 
         if (return_code == OS_SUCCESS)
         {
@@ -312,7 +312,7 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
 
         /* Decrement both ref counters that were increased earlier */
         --conn_record->refcount;
-        OS_Unlock_Global(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(&conn_token);
     }
 
     OS_ObjectIdRelease(&sock_token);
@@ -365,13 +365,13 @@ int32 OS_SocketConnect(osal_id_t sock_id, const OS_SockAddr_t *Addr, int32 Timeo
     {
         return_code = OS_SocketConnect_Impl(&token, Addr, Timeout);
 
-        OS_Lock_Global(LOCAL_OBJID_TYPE);
+        OS_Lock_Global(&token);
         if (return_code == OS_SUCCESS)
         {
             stream->stream_state |= OS_STREAM_STATE_CONNECTED | OS_STREAM_STATE_READABLE | OS_STREAM_STATE_WRITABLE;
         }
         --record->refcount;
-        OS_Unlock_Global(LOCAL_OBJID_TYPE);
+        OS_Unlock_Global(&token);
     }
 
     return return_code;

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -265,6 +265,8 @@ void OS_TaskExit()
     task_id = OS_TaskGetId_Impl();
     if (OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, task_id, &token) == OS_SUCCESS)
     {
+        OS_TaskDetach_Impl(&token);
+
         /* Complete the operation via the common routine */
         OS_ObjectIdFinalizeDelete(OS_SUCCESS, &token);
     }

--- a/src/os/vxworks/inc/os-impl-idmap.h
+++ b/src/os/vxworks/inc/os-impl-idmap.h
@@ -19,30 +19,26 @@
  */
 
 /**
- * \file     osapi-idmap-impl-stubs.c
- * \ingroup  ut-stubs
+ * \file     os-impl-idmap.h
+ * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdarg.h>
+#ifndef OS_IMPL_IDMAP_H
+#define OS_IMPL_IDMAP_H
 
-#include "utstubs.h"
+#include "osconfig.h"
+#include "osapi-idmap.h"
+#include <semLib.h>
 
-#include "os-shared-idmap.h"
-
-/*
- * Table locking and unlocking for global objects can be done at the shared code
- * layer but the actual implementation is OS-specific
- */
-void OS_Lock_Global_Impl(osal_objtype_t idtype)
+typedef struct
 {
-    UT_DEFAULT_IMPL(OS_Lock_Global_Impl);
-}
-void OS_Unlock_Global_Impl(osal_objtype_t idtype)
-{
-    UT_DEFAULT_IMPL(OS_Unlock_Global_Impl);
-}
+    void *const mem;
+    SEM_ID      vxid;
+} OS_impl_objtype_lock_t;
+
+/* Tables where the lock state information is stored */
+extern OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER];
+
+#endif  /* OS_IMPL_IDMAP_H  */

--- a/src/os/vxworks/inc/os-vxworks.h
+++ b/src/os/vxworks/inc/os-vxworks.h
@@ -51,12 +51,6 @@
                                     TYPEDEFS
 ****************************************************************************************/
 
-typedef struct
-{
-    void *const mem;
-    SEM_ID      vxid;
-} VxWorks_GlobalMutex_t;
-
 /*
  * Union to facilitate passing an osal_id_t through
  * a function/api designed to take an "int"
@@ -72,8 +66,6 @@ typedef union
 /****************************************************************************************
                                    GLOBAL DATA
 ****************************************************************************************/
-
-extern VxWorks_GlobalMutex_t VX_MUTEX_TABLE[];
 
 /****************************************************************************************
                        VXWORKS IMPLEMENTATION FUNCTION PROTOTYPES

--- a/src/os/vxworks/inc/os-vxworks.h
+++ b/src/os/vxworks/inc/os-vxworks.h
@@ -51,18 +51,6 @@
                                     TYPEDEFS
 ****************************************************************************************/
 
-/*
- * Union to facilitate passing an osal_id_t through
- * a function/api designed to take an "int"
- *
- * This relies on sizeof(int) >= sizeof(osal_id_t)
- */
-typedef union
-{
-    osal_id_t id;
-    int       arg;
-} VxWorks_ID_Buffer_t;
-
 /****************************************************************************************
                                    GLOBAL DATA
 ****************************************************************************************/

--- a/src/os/vxworks/src/os-impl-idmap.c
+++ b/src/os/vxworks/src/os-impl-idmap.c
@@ -29,12 +29,15 @@
 ****************************************************************************************/
 
 #include "os-vxworks.h"
+#include "os-impl-idmap.h"
 #include "os-shared-idmap.h"
 
+#include <taskLib.h>
 #include <errnoLib.h>
 #include <objLib.h>
 #include <semLib.h>
 #include <sysLib.h>
+#include <taskLib.h>
 
 /****************************************************************************************
                                      DEFINES
@@ -55,27 +58,72 @@ VX_MUTEX_SEMAPHORE(OS_timebase_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_timecb_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_module_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_filesys_table_mut_mem);
-VX_MUTEX_SEMAPHORE(OS_console_mut_mem);
+VX_MUTEX_SEMAPHORE(OS_console_table_mut_mem);
 
-VxWorks_GlobalMutex_t VX_MUTEX_TABLE[] = {
-    [OS_OBJECT_TYPE_UNDEFINED]   = {NULL},
-    [OS_OBJECT_TYPE_OS_TASK]     = {.mem = OS_task_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_QUEUE]    = {.mem = OS_queue_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_COUNTSEM] = {.mem = OS_count_sem_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_BINSEM]   = {.mem = OS_bin_sem_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_MUTEX]    = {.mem = OS_mutex_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_STREAM]   = {.mem = OS_stream_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_DIR]      = {.mem = OS_dir_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_TIMEBASE] = {.mem = OS_timebase_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_TIMECB]   = {.mem = OS_timecb_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_MODULE]   = {.mem = OS_module_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_FILESYS]  = {.mem = OS_filesys_table_mut_mem},
-    [OS_OBJECT_TYPE_OS_CONSOLE]  = {.mem = OS_console_mut_mem},
+static OS_impl_objtype_lock_t OS_task_table_lock =
+{
+    .mem = OS_task_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_queue_table_lock =
+{
+    .mem = OS_queue_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_bin_sem_table_lock =
+{
+    .mem = OS_bin_sem_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_mutex_table_lock =
+{
+    .mem = OS_mutex_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_count_sem_table_lock =
+{
+    .mem = OS_count_sem_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_stream_table_lock =
+{
+    .mem = OS_stream_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_dir_table_lock =
+{
+    .mem = OS_dir_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_timebase_table_lock =
+{
+    .mem = OS_timebase_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_timecb_table_lock =
+{
+    .mem = OS_timecb_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_module_table_lock =
+{
+    .mem = OS_module_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_filesys_table_lock =
+{
+    .mem = OS_filesys_table_mut_mem
+};
+static OS_impl_objtype_lock_t OS_console_table_lock =
+{
+    .mem = OS_console_table_mut_mem
 };
 
-enum
+OS_impl_objtype_lock_t * const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] =
 {
-    VX_MUTEX_TABLE_SIZE = (sizeof(VX_MUTEX_TABLE) / sizeof(VX_MUTEX_TABLE[0]))
+    [OS_OBJECT_TYPE_UNDEFINED]   = NULL,
+    [OS_OBJECT_TYPE_OS_TASK]     = &OS_task_table_lock,
+    [OS_OBJECT_TYPE_OS_QUEUE]    = &OS_queue_table_lock,
+    [OS_OBJECT_TYPE_OS_COUNTSEM] = &OS_count_sem_table_lock,
+    [OS_OBJECT_TYPE_OS_BINSEM]   = &OS_bin_sem_table_lock,
+    [OS_OBJECT_TYPE_OS_MUTEX]    = &OS_mutex_table_lock,
+    [OS_OBJECT_TYPE_OS_STREAM]   = &OS_stream_table_lock,
+    [OS_OBJECT_TYPE_OS_DIR]      = &OS_dir_table_lock,
+    [OS_OBJECT_TYPE_OS_TIMEBASE] = &OS_timebase_table_lock,
+    [OS_OBJECT_TYPE_OS_TIMECB]   = &OS_timecb_table_lock,
+    [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_lock,
+    [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_lock,
+    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_table_lock
 };
 
 /*----------------------------------------------------------------
@@ -86,28 +134,17 @@ enum
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
+void OS_Lock_Global_Impl(osal_objtype_t idtype)
 {
-    VxWorks_GlobalMutex_t *mut;
+    OS_impl_objtype_lock_t *impl;
 
-    if (idtype >= VX_MUTEX_TABLE_SIZE)
-    {
-        return OS_ERROR;
-    }
+    impl = OS_impl_objtype_lock_table[idtype];
 
-    mut = &VX_MUTEX_TABLE[idtype];
-    if (mut->vxid == (SEM_ID)0)
-    {
-        return OS_ERROR;
-    }
-
-    if (semTake(mut->vxid, WAIT_FOREVER) != OK)
+    if (semTake(impl->vxid, WAIT_FOREVER) != OK)
     {
         OS_DEBUG("semTake() - vxWorks errno %d\n", errno);
-        return OS_ERROR;
     }
 
-    return OS_SUCCESS;
 } /* end OS_Lock_Global_Impl */
 
 /*----------------------------------------------------------------
@@ -118,29 +155,45 @@ int32 OS_Lock_Global_Impl(osal_objtype_t idtype)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
+void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 {
-    VxWorks_GlobalMutex_t *mut;
+    OS_impl_objtype_lock_t *impl;
 
-    if (idtype >= VX_MUTEX_TABLE_SIZE)
-    {
-        return OS_ERROR;
-    }
+    impl = OS_impl_objtype_lock_table[idtype];
 
-    mut = &VX_MUTEX_TABLE[idtype];
-    if (mut->vxid == (SEM_ID)0)
-    {
-        return OS_ERROR;
-    }
-
-    if (semGive(mut->vxid) != OK)
+    if (semGive(impl->vxid) != OK)
     {
         OS_DEBUG("semGive() - vxWorks errno %d\n", errno);
-        return OS_ERROR;
     }
 
-    return OS_SUCCESS;
 } /* end OS_Unlock_Global_Impl */
+
+/*----------------------------------------------------------------
+ *
+ *  Function: OS_WaitForStateChange_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_WaitForStateChange_Impl(osal_objtype_t idtype, uint32 attempts)
+{
+    int wait_ticks;
+
+    if (attempts <= 10)
+    {
+        wait_ticks = attempts * attempts;
+    }
+    else
+    {
+        wait_ticks = 100;
+    }
+
+    OS_Unlock_Global_Impl(idtype);
+	taskDelay(wait_ticks);
+	OS_Lock_Global_Impl(idtype);
+}
+
 
 /****************************************************************************************
                                 INITIALIZATION FUNCTION
@@ -156,24 +209,26 @@ int32 OS_Unlock_Global_Impl(osal_objtype_t idtype)
  *-----------------------------------------------------------------*/
 int32 OS_VxWorks_TableMutex_Init(osal_objtype_t idtype)
 {
-    int32  return_code = OS_SUCCESS;
+    OS_impl_objtype_lock_t *impl;
     SEM_ID semid;
 
-    /* Initialize the table mutex for the given idtype */
-    if (idtype < VX_MUTEX_TABLE_SIZE && VX_MUTEX_TABLE[idtype].mem != NULL)
+    impl = OS_impl_objtype_lock_table[idtype];
+    if (impl == NULL)
     {
-        semid = semMInitialize(VX_MUTEX_TABLE[idtype].mem, SEM_Q_PRIORITY | SEM_INVERSION_SAFE);
-
-        if (semid == (SEM_ID)0)
-        {
-            OS_DEBUG("Error: semMInitialize() failed - vxWorks errno %d\n", errno);
-            return_code = OS_ERROR;
-        }
-        else
-        {
-            VX_MUTEX_TABLE[idtype].vxid = semid;
-        }
+        return OS_SUCCESS;
     }
 
-    return (return_code);
+    /* Initialize the table mutex for the given idtype */
+    semid = semMInitialize(impl->mem, SEM_Q_PRIORITY | SEM_INVERSION_SAFE);
+
+    if (semid == (SEM_ID)0)
+    {
+        OS_DEBUG("Error: semMInitialize() failed - vxWorks errno %d\n", errno);
+        return OS_ERROR;
+    }
+
+    impl->vxid = semid;
+
+    return OS_SUCCESS;
+
 } /* end OS_VxWorks_TableMutex_Init */

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -289,6 +289,20 @@ int32 OS_TaskDelete_Impl(const OS_object_token_t *token)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_TaskDetach_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDetach_Impl(const OS_object_token_t *token)
+{
+    /* No-op on VxWorks */
+    return OS_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_TaskExit_Impl
  *
  *  Purpose: Implemented per internal OSAL API

--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -714,7 +714,7 @@ void TestGenericQueries(void)
     UtAssert_StrCmp(ResourceName, "q 0", "Output value correct");
 
     status = OS_GetResourceName(OS_OBJECT_ID_UNDEFINED, ResourceName, sizeof(ResourceName));
-    UtAssert_True(status == OS_ERR_INVALID_ID, "OS_GetResourceName (%lx,%ld) == OS_ERR_INVALID_ID",
+    UtAssert_True(status == OS_ERR_INCORRECT_OBJ_TYPE, "OS_GetResourceName (%lx,%ld) == OS_ERR_INCORRECT_OBJ_TYPE",
                   OS_ObjectIdToInteger(OS_OBJECT_ID_UNDEFINED), (long)status);
 
     status = OS_GetResourceName(bin_0, ResourceName, OSAL_SIZE_C(1));

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -404,6 +404,10 @@ void Test_OS_GetFsInfo(void)
     int32       actual   = ~OS_SUCCESS;
     os_fsinfo_t filesys_info;
 
+    UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdIteratorGetNext), 1);
+    UT_SetDeferredRetcode(UT_KEY(OS_ObjectIdIteratorGetNext), 3, 0);
+    UT_SetDeferredRetcode(UT_KEY(OS_ObjectIdIteratorGetNext), 4, 0);
+
     actual = OS_GetFsInfo(&filesys_info);
 
     UtAssert_True(actual == expected, "OS_FileSysInfo() (%ld) == OS_SUCCESS", (long)actual);
@@ -414,11 +418,11 @@ void Test_OS_GetFsInfo(void)
                   "filesys_info.MaxVolumes (%lu) == OS_MAX_FILE_SYSTEMS", (unsigned long)filesys_info.MaxVolumes);
 
     /* since there are no open files, the free fd count should match the max */
-    UtAssert_True(filesys_info.FreeFds == OS_MAX_NUM_OPEN_FILES, "filesys_info.FreeFds (%lu) == OS_MAX_NUM_OPEN_FILES",
+    UtAssert_True(filesys_info.FreeFds == 2, "filesys_info.FreeFds (%lu) == 2",
                   (unsigned long)filesys_info.FreeFds);
 
-    UtAssert_True(filesys_info.FreeVolumes == OS_MAX_FILE_SYSTEMS,
-                  "filesys_info.FreeVolumes (%lu) == OS_MAX_FILE_SYSTEMS", (unsigned long)filesys_info.FreeVolumes);
+    UtAssert_True(filesys_info.FreeVolumes == 3, "filesys_info.FreeVolumes (%lu) == 3",
+                    (unsigned long)filesys_info.FreeVolumes);
 
     expected = OS_INVALID_POINTER;
     actual   = OS_GetFsInfo(NULL);

--- a/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-task-impl-stubs.c
@@ -39,6 +39,7 @@
 ** Task API
 */
 UT_DEFAULT_STUB(OS_TaskMatch_Impl, (const OS_object_token_t *token))
+UT_DEFAULT_STUB(OS_TaskDetach_Impl, (const OS_object_token_t *token))
 UT_DEFAULT_STUB(OS_TaskCreate_Impl, (const OS_object_token_t *token, uint32 flags))
 UT_DEFAULT_STUB(OS_TaskDelete_Impl, (const OS_object_token_t *token))
 void OS_TaskExit_Impl(void)

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-idmap.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-idmap.c
@@ -30,6 +30,7 @@
 #include <string.h>
 
 #include <os-vxworks.h>
+#include "os-impl-idmap.h"
 #include "ut-adaptor-idmap.h"
 
 int32 UT_Call_OS_VxWorks_TableMutex_Init(osal_objtype_t idtype)
@@ -39,5 +40,5 @@ int32 UT_Call_OS_VxWorks_TableMutex_Init(osal_objtype_t idtype)
 
 void UT_IdMapTest_SetImplTableMutex(osal_objtype_t idtype, OCS_SEM_ID vxid)
 {
-    VX_MUTEX_TABLE[idtype].vxid = vxid;
+    OS_impl_objtype_lock_table[idtype]->vxid = vxid;
 }

--- a/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
@@ -41,22 +41,13 @@ void Test_OS_Lock_Global_Impl(void)
      * Test Case For:
      * int32 OS_Lock_Global_Impl(uint32 idtype)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_Lock_Global_Impl(10000), OS_ERROR);
-
-    /*
-     * Confirm that if vxid is 0/NULL that the function returns error
-     * and does not call semTake.
-     */
-    UT_IdMapTest_SetImplTableMutex(OS_OBJECT_TYPE_OS_TASK, (OCS_SEM_ID)0);
-    OSAPI_TEST_FUNCTION_RC(OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK), OS_ERROR);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_semTake)) == 0, "semTake() NOT called");
 
     UT_IdMapTest_SetImplTableMutex(OS_OBJECT_TYPE_OS_TASK, &TestGlobalSem);
-    OSAPI_TEST_FUNCTION_RC(OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK), OS_SUCCESS);
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_semTake)) == 1, "semTake() called");
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_semTake), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK), OS_ERROR);
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK); /* for coverage of error path */
 }
 
 void Test_OS_Unlock_Global_Impl(void)
@@ -65,11 +56,13 @@ void Test_OS_Unlock_Global_Impl(void)
      * Test Case For:
      * int32 OS_Unlock_Global_Impl(uint32 idtype)
      */
-    OSAPI_TEST_FUNCTION_RC(OS_Unlock_Global_Impl(10000), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_Unlock_Global_Impl(0), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK), OS_SUCCESS);
+
+    UT_IdMapTest_SetImplTableMutex(OS_OBJECT_TYPE_OS_TASK, &TestGlobalSem);
+    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_semGive)) == 1, "semTake() called");
+
     UT_SetDefaultReturnValue(UT_KEY(OCS_semGive), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK), OS_ERROR);
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK); /* for coverage of error path */
 }
 
 void Test_OS_API_Impl_Init(void)

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -573,7 +573,7 @@ void OS_ObjectIdIteratorDestroy(OS_object_iter_t *iter)
     UT_DEFAULT_IMPL(OS_ObjectIdIteratorDestroy);
 }
 
-int32 OS_ObjectIdIteratorProcessEntry(OS_object_iter_t *iter, int32 (*func)(osal_id_t))
+int32 OS_ObjectIdIteratorProcessEntry(OS_object_iter_t *iter, int32 (*func)(osal_id_t, void*))
 {
     int32 Status;
 

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -54,11 +54,11 @@ static void UT_TokenCompose(uint32 lock_mode, uint32 indx, UT_ObjType_t objtype,
 UT_DEFAULT_STUB(OS_ObjectIdInit, (void))
 
 /* Lock/Unlock for global tables */
-void OS_Lock_Global(osal_objtype_t idtype)
+void OS_Lock_Global(OS_object_token_t *token)
 {
     UT_DEFAULT_IMPL(OS_Lock_Global);
 }
-void OS_Unlock_Global(osal_objtype_t idtype)
+void OS_Unlock_Global(OS_object_token_t *token)
 {
     UT_DEFAULT_IMPL(OS_Unlock_Global);
 }
@@ -210,6 +210,36 @@ int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS
     }
 
     return Status;
+}
+
+/*****************************************************************************
+ *
+ * Stub function for OS_ObjectIdTransactionInit()
+ *
+ *****************************************************************************/
+int32 OS_ObjectIdTransactionInit(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS_object_token_t *token)
+{
+    int32 Status;
+
+    Status = UT_DEFAULT_IMPL(OS_ObjectIdTransactionInit);
+
+    if (Status == OS_SUCCESS &&
+        UT_Stub_CopyToLocal(UT_KEY(OS_ObjectIdTransactionInit), token, sizeof(*token)) < sizeof(*token))
+    {
+        memset(&token, 0, sizeof(token));
+    }
+
+    return Status;
+}
+
+/*****************************************************************************
+ *
+ * Stub function for OS_ObjectIdTransactionCancel()
+ *
+ *****************************************************************************/
+void OS_ObjectIdTransactionCancel(OS_object_token_t *token)
+{
+    UT_DEFAULT_IMPL(OS_ObjectIdTransactionCancel);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
**Describe the contribution**
Address multiple issues with the OSAL global table management - general cleanup and bug fixes.

Fixes #702 - use iterators whenever possible
Fixes #645 - use an unlock key rather than task ID so OS_TaskExit() doesn't trigger a warning
Fixes #701 - general cleanup of lock/unlock impl and remove redundant logic
Fixes #703 - unlock global tables during create/delete 
Fixes #642 - keep threads "attached" in POSIX, so they can be joined when deleted.

**Testing performed**
Build and run all tests for all platforms
Sanity check CFE and also confirmed RELOAD/RESTART commands are working correctly.

**Expected behavior changes**
No longer triggers warning with OS_TaskExit() on VxWorks (see #645)
OS_TaskDelete() on POSIX does not return until the task has actually exited (see #642)

Most other changes are internal only and do not change behavior.

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11.3 + pc686
VxWorks 6.9 + mcp750

**Additional context**
Noted other issues when running some unit tests on VxWorks target that are not related to this change / preexisting issues.  Will file separate bugs about those.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
