### PR TITLE
Fix #580, improve FS_BASED mounts on VxWorks

### DIFF
--- a/src/os/inc/osapi-filesys.h
+++ b/src/os/inc/osapi-filesys.h
@@ -56,6 +56,16 @@ typedef struct
  * This mimics the behavior of a "FS_BASED" entry in the VolumeTable but is registered
  * at runtime.  It is intended to be called by the PSP/BSP prior to starting the application.
  *
+ * @note OSAL virtual mount points are required to be a single, non-empty top-level directory
+ * name.  Virtual path names always follow the form /<virt_mount_point>/<relative_path>/<file>.
+ * Only the relative path may be omitted/empty (i.e. /<virt_mount_point>/<file>) but the
+ * virtual mount point must be present and not an empty string.  In particular this means
+ * it is not possible to directly refer to files in the "root" of the native file system
+ * from OSAL.  However it is possible to create a virtual map to the root, such as by calling:
+ *
+ *      OS_FileSysAddFixedMap(&fs_id, "/", "/root");
+ *
+ *
  * @param[out]  filesys_id  A non-zero OSAL ID reflecting the file system
  * @param[in]   phys_path   The native system directory (an existing mount point)
  * @param[in]   virt_path   The virtual mount point of this filesystem


### PR DESCRIPTION
**Describe the contribution**
The mount/unmount implementation was not adequately checking for and handling the `FS_BASED` (pass -through) mapping type - which should be mostly a no-op.  But to be consistent with POSIX it should also create a mount point directory if it does not already exist when using this mapping type.

Adds a documentation note to `OS_FileSysAddFixedMap()` regarding the limitation that the virtual mount point cannot be empty - so `OS_FileSysAddFixedMap(.., "/", "/")` does not work - never did.  However `OS_FileSysAddFixedMap(.., "/", "/root")` does work and allows one to open files in the root as "/root/<file>" from OSAL applications.

Fixes #580

**Testing performed**
Build and run all unit tests on native
Sanity check CFE
Confirm behavior of `OS_FileSysAddFixedMap()` + `OS_TranslatePath()` when mapping to root FS.

**Expected behavior changes**
Mount point directories do not need to be already existing when using `OS_FileSysAddFixedMap`

**System(s) tested on**
Ubuntu 20.04 (native)
VxWorks 6.9 (mcp750)

**Additional context**
Auto-creating the mount point dir is relevant to unit tests - this simplifies running the unit tests by not requiring the user to pre-create this directory.  Otherwise without this one gets unit test failures if the directory doesn't already exist.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.