### PR TITLE
Fix #471, order of operations for delete all

### DIFF
--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -337,7 +337,18 @@ void OS_DeleteAllObjects(void)
     {
         ObjectCount = 0;
         ++TryCount;
+
+        /* Delete timers and tasks first, as they could be actively using other object types  */
+        OS_ForEachObjectOfType(OS_OBJECT_TYPE_OS_TIMECB, OS_OBJECT_CREATOR_ANY,
+                OS_CleanUpObject, &ObjectCount);
+        OS_ForEachObjectOfType(OS_OBJECT_TYPE_OS_TIMEBASE, OS_OBJECT_CREATOR_ANY,
+                OS_CleanUpObject, &ObjectCount);
+        OS_ForEachObjectOfType(OS_OBJECT_TYPE_OS_TASK, OS_OBJECT_CREATOR_ANY,
+                OS_CleanUpObject, &ObjectCount);
+
+        /* Then try to delete all other remaining objects of any type */
         OS_ForEachObject(OS_OBJECT_CREATOR_ANY, OS_CleanUpObject, &ObjectCount);
+
         if (ObjectCount == 0 || TryCount > 4)
         {
             break;


### PR DESCRIPTION
**Describe the contribution**
When cleaning up for shutdown, delete resources that have a task/thread first, followed by other resource types.  This helps avoid possible dependencies as running threads might be using the other resources.

Fixes #471

**Testing performed**
Build and run unit tests
Sanity check CFE, ensure shutdown works as expected

**Expected behavior changes**
No visible impact ... internally the tasks are deleted first during shutdown, which only has an impact if/when tasks are actively using other OSAL resources.

**System(s) tested on**
Ubuntu 20.04 (native)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
