### PR TITLE
Fix #445, add pointer parameter checks

### DIFF
--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -1463,6 +1463,9 @@ int32 OS_ObjectIdToArrayIndex(osal_objtype_t idtype, osal_id_t object_id, osal_i
     osal_objtype_t actual_type;
     int32          return_code;
 
+    /* Check Parameters */
+    OS_CHECK_POINTER(ArrayIndex);
+
     obj_index   = OS_ObjectIdToSerialNumber_Impl(object_id);
     actual_type = OS_ObjectIdToType_Impl(object_id);
 

--- a/src/os/shared/src/osapi-timebase.c
+++ b/src/os/shared/src/osapi-timebase.c
@@ -347,6 +347,8 @@ int32 OS_TimeBaseGetFreeRun(osal_id_t timebase_id, uint32 *freerun_val)
     OS_timebase_internal_record_t *timebase;
 
     /* Check parameters */
+    OS_CHECK_POINTER(freerun_val);
+
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, LOCAL_OBJID_TYPE, timebase_id, &token);
     if (return_code == OS_SUCCESS)
     {

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -323,6 +323,10 @@ void Test_OS_ObjectIdToArrayIndex(void)
     expected = OS_ERR_INVALID_ID;
     actual   = OS_ObjectIdToArrayIndex(0xFFFF, UT_OBJID_OTHER, &local_idx);
     UtAssert_True(actual == expected, "OS_ObjectIdToArrayIndex() (%ld) == OS_ERR_INVALID_ID", (long)actual);
+
+    expected = OS_INVALID_POINTER;
+    actual   = OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TASK, objid, NULL);
+    UtAssert_True(actual == expected, "OS_ObjectIdToArrayIndex() (%ld) == OS_INVALID_POINTER", (long)actual);
 }
 
 void Test_OS_ObjectIdFindByName(void)

--- a/src/unit-test-coverage/shared/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-timebase.c
@@ -234,6 +234,10 @@ void Test_OS_TimeBaseGetFreeRun(void)
     int32  actual   = OS_TimeBaseGetFreeRun(UT_OBJID_1, &freerun);
 
     UtAssert_True(actual == expected, "OS_TimeBaseGetFreeRun() (%ld) == OS_SUCCESS", (long)actual);
+
+    expected = OS_INVALID_POINTER;
+    actual   = OS_TimeBaseGetFreeRun(UT_OBJID_1, NULL);
+    UtAssert_True(actual == expected, "OS_TimeBaseGetFreeRun() (%ld) == OS_INVALID_POINTER", (long)actual);
 }
 
 void Test_OS_TimeBase_CallbackThread(void)


### PR DESCRIPTION
**Describe the contribution**
Add OS_CHECK_POINTER macros to OS_ConvertToArrayIndex and OS_TimeBaseGetFreeRun.

Fixes #445

**Testing performed**
Run all unit tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
