### PR TITLE
Fix #606, Resolve cast-align error in VxWorks OS_TaskGetId_Impl

### DIFF
--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -400,16 +400,16 @@ int32 OS_TaskRegister_Impl(osal_id_t global_task_id)
  *-----------------------------------------------------------------*/
 osal_id_t OS_TaskGetId_Impl(void)
 {
-    OS_impl_task_internal_record_t *lrec;
-    size_t                          idx;
-    osal_id_t                       id;
+    void     *lrec;
+    size_t    idx;
+    osal_id_t id;
 
     id   = OS_OBJECT_ID_UNDEFINED;
-    lrec = (OS_impl_task_internal_record_t *)taskTcb(taskIdSelf());
+    lrec = taskTcb(taskIdSelf());
 
     if (lrec != NULL)
     {
-        idx = lrec - &OS_impl_task_table[0];
+        idx = (OS_impl_task_internal_record_t *)lrec - &OS_impl_task_table[0];
         if (idx < OS_MAX_TASKS)
         {
             id = OS_global_task_table[idx].active_id;


### PR DESCRIPTION
**Describe the contribution**
Fix #606 - store taskTCB return in a `void *`, then cast to `OS_impl_task_internal_record_t *` just for the pointer math to avoid a strict alignment compiler error

Note the error was observed with cast-align=strict on Ubuntu 20.04 with ENABLE_UNIT_TESTS=true

**Testing performed**
Built without the error after fix.  Built/ran unit tests on Ubuntu 18.04 and they all passed.

**Expected behavior changes**
None other than avoid compiler error

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04 (and 20.04 to confirm strict alignment error resolved)
 - Versions: Bundle + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC