### PR TITLE
Fix #707 change sem flush to solve race condition

### DIFF
--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -108,7 +108,7 @@ void Setup_Server(void)
     UtAssert_True(actual == expected, "OS_SocketAddrInit() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set server port */
-    actual = OS_SocketAddrSetPort(&s_addr, 9997);
+    actual = OS_SocketAddrSetPort(&s_addr, 9994);
     UtAssert_True(actual == expected, "OS_SocketAddrSetPort() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set server address */
@@ -142,7 +142,7 @@ void Setup_Client(void)
     UtAssert_True(actual == expected, "OS_SocketAddrInit() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set client port */
-    actual = OS_SocketAddrSetPort(&c_addr, 9996);
+    actual = OS_SocketAddrSetPort(&c_addr, 9993);
     UtAssert_True(actual == expected, "OS_SocketAddrSetPort() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set client address */
@@ -193,7 +193,7 @@ void Setup_Server2(void)
     UtAssert_True(actual == expected, "OS_SocketAddrInit() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set server port */
-    actual = OS_SocketAddrSetPort(&s2_addr, 9998);
+    actual = OS_SocketAddrSetPort(&s2_addr, 9995);
     UtAssert_True(actual == expected, "OS_SocketAddrSetPort() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set server address */
@@ -227,7 +227,7 @@ void Setup_Client2(void)
     UtAssert_True(actual == expected, "OS_SocketAddrInit() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set client port */
-    actual = OS_SocketAddrSetPort(&c2_addr, 9995);
+    actual = OS_SocketAddrSetPort(&c2_addr, 9992);
     UtAssert_True(actual == expected, "OS_SocketAddrSetPort() (%ld) == OS_SUCCESS", (long)actual);
 
     /* Set client address */
@@ -281,8 +281,8 @@ void Teardown_Multi(void)
 {
     uint32 status;
 
-    status = OS_BinSemFlush(bin_sem_id);
-    UtAssert_True(status == OS_SUCCESS, "BinSem1 Teardown multi flush Rc=%d", (int)status);
+    status = OS_BinSemGive(bin_sem_id);
+    UtAssert_True(status == OS_SUCCESS, "BinSem1 Teardown multi give Rc=%d", (int)status);
 
     OS_close(c2_socket_id);
     Teardown_Single();


### PR DESCRIPTION
**Describe the contribution**
fixes #707
Removed Sem flush and changed it to sem give to prevent a rare race condition. 
Change the port numbers to be different from network test for when test are run in parallel. 

**Testing performed**
Ran the unit tests in parallel 

**Expected behavior changes**
Test shouldn't lock or fail 

**System(s) tested on**
Ubuntu 20.04


**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC