### PR TITLE
Fix #724, #722, rename ut clear force fail

### DIFF
--- a/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
@@ -69,7 +69,7 @@ void Test_OS_FileStat_Impl(void)
     /* failure mode */
     UT_SetDefaultReturnValue(UT_KEY(OCS_stat), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileStat_Impl, ("local", &FileStats), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_stat));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_stat));
 
     /* nominal, no permission bits */
     memset(&FileStats, 0, sizeof(FileStats));
@@ -108,12 +108,12 @@ void Test_OS_FileChmod_Impl(void)
     /* failure mode 0 (open) */
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
 
     /* failure mode 1 (fstat) */
     UT_SetDefaultReturnValue(UT_KEY(OCS_fstat), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_fstat));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_fstat));
 
     /* failure mode 2 (fchmod) */
     UT_SetDefaultReturnValue(UT_KEY(OCS_fchmod), -1);
@@ -122,7 +122,7 @@ void Test_OS_FileChmod_Impl(void)
     /* non implemented error, e.g. such as DOS Filesystem with no perms  */
     OCS_errno = OCS_ENOTSUP;
     OSAPI_TEST_FUNCTION_RC(OS_FileChmod_Impl, ("local", OS_READ_WRITE), OS_ERR_NOT_IMPLEMENTED);
-    UT_ClearForceFail(UT_KEY(OCS_fchmod));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_fchmod));
 
     /* all permission bits with uid/gid match */
     RefStat.st_uid   = UT_PortablePosixFileTest_GetSelfEUID();

--- a/src/unit-test-coverage/shared/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-binsem.c
@@ -150,7 +150,7 @@ void Test_OS_BinSemGetIdByName(void)
     actual = OS_BinSemGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_BinSemGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_BinSemGetIdByName(&objid, "NF");

--- a/src/unit-test-coverage/shared/src/coveragetest-countsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-countsem.c
@@ -136,7 +136,7 @@ void Test_OS_CountSemGetIdByName(void)
     actual = OS_CountSemGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_CountSemGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_CountSemGetIdByName(&objid, "NF");

--- a/src/unit-test-coverage/shared/src/coveragetest-file.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-file.c
@@ -82,7 +82,7 @@ void Test_OS_OpenCreate(void)
     expected = OS_ERROR;
     actual   = OS_OpenCreate(&filedes, "/cf/file", OS_FILE_FLAG_NONE, OS_READ_WRITE);
     UtAssert_True(actual == OS_ERROR, "OS_OpenCreate() (%ld) == OS_ERROR (bad path)", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TranslatePath));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TranslatePath));
 }
 
 void Test_OS_close(void)
@@ -271,7 +271,7 @@ void Test_OS_cp(void)
     expected = -444;
     actual   = OS_cp("/cf/file1", "/cf/file2");
     UtAssert_True(actual == expected, "OS_cp() (%ld) == -444", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_GenericRead_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_GenericRead_Impl));
 
     UT_SetDataBuffer(UT_KEY(OS_GenericRead_Impl), ReadBuf, sizeof(ReadBuf), false);
     UT_SetDefaultReturnValue(UT_KEY(OS_GenericWrite_Impl), -555);
@@ -283,7 +283,7 @@ void Test_OS_cp(void)
     expected = OS_INVALID_POINTER;
     actual   = OS_cp("/cf/file1", "/cf/file2");
     UtAssert_True(actual == expected, "OS_cp() (%ld) == OS_INVALID_POINTER", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TranslatePath));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TranslatePath));
 }
 
 void Test_OS_mv(void)

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -103,7 +103,7 @@ void Test_OS_mkfs(void)
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_mkfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_mkfs() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     /* set up for failure due to empty strings */
     expected = OS_FS_ERR_PATH_INVALID;
@@ -140,7 +140,7 @@ void Test_OS_rmfs(void)
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_rmfs("/ramdev4");
     UtAssert_True(actual == expected, "OS_rmfs() (%ld) == OS_ERR_NAME_NOT_FOUND", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdGetByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdGetByName));
 
     expected = OS_INVALID_POINTER;
     actual   = OS_rmfs(NULL);
@@ -178,7 +178,7 @@ void Test_OS_initfs(void)
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_initfs(TestBuffer, "/ramdev0", "vol", OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0));
     UtAssert_True(actual == expected, "OS_initfs() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     /* set up for failure */
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdAllocateNew), OS_ERR_NO_FREE_IDS);
@@ -326,7 +326,7 @@ void Test_OS_chkfs(void)
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_chkfs("/cf", false);
     UtAssert_True(actual == expected, "OS_fsBytesFree() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     /* Test Fail due to no matching VolTab entry */
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch), OS_ERR_NAME_NOT_FOUND);
@@ -351,7 +351,7 @@ void Test_OS_FS_GetPhysDriveName(void)
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_FS_GetPhysDriveName(NameBuf, "none");
     UtAssert_True(actual == expected, "OS_FS_GetPhysDriveName() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     expected = OS_ERR_INCORRECT_OBJ_STATE;
     actual   = OS_FS_GetPhysDriveName(NameBuf, "none");
@@ -435,7 +435,7 @@ void Test_OS_TranslatePath(void)
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_strlen));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_strlen));
 
     /* Invalid no '/' */
     expected = OS_FS_ERR_PATH_INVALID;
@@ -455,7 +455,7 @@ void Test_OS_TranslatePath(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch), OS_ERR_NAME_NOT_FOUND);
     actual = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdGetBySearch));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch));
 
     /* VirtPathLen < VirtPathBegin */
     UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 4, OS_MAX_PATH_LEN);

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -441,7 +441,7 @@ void Test_OS_ObjectIdFindByName(void)
     actual   = OS_ObjectIdFindByName(OS_OBJECT_TYPE_OS_TASK, TaskName, &objid);
     UtAssert_True(actual == expected, "OS_ObjectFindIdByName(%s) (%ld) == OS_ERR_NAME_TOO_LONG", TaskName,
                   (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     /*
      * Pass in a name that is actually not found

--- a/src/unit-test-coverage/shared/src/coveragetest-mutex.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-mutex.c
@@ -121,7 +121,7 @@ void Test_OS_MutSemGetIdByName(void)
     actual = OS_MutSemGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_MutSemGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_MutSemGetIdByName(&objid, "NF");

--- a/src/unit-test-coverage/shared/src/coveragetest-queue.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-queue.c
@@ -73,7 +73,7 @@ void Test_OS_QueueCreate(void)
     expected = OS_ERR_NAME_TOO_LONG;
     actual   = OS_QueueCreate(&objid, "UT", OSAL_BLOCKCOUNT_C(0), OSAL_SIZE_C(4), 0);
     UtAssert_True(actual == expected, "OS_QueueCreate() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     expected = OS_QUEUE_INVALID_SIZE;
     actual   = OS_QueueCreate(&objid, "UT", OSAL_BLOCKCOUNT_C(1 + OS_QUEUE_MAX_DEPTH), OSAL_SIZE_C(4), 0);
@@ -153,7 +153,7 @@ void Test_OS_QueueGetIdByName(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName), OS_SUCCESS);
     actual = OS_QueueGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_QueueGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_QueueGetIdByName(&objid, "NF");

--- a/src/unit-test-coverage/shared/src/coveragetest-select.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-select.c
@@ -115,7 +115,7 @@ void Test_OS_SelectFdAddClearOps(void)
     UtAssert_True(!OS_SelectFdIsSet(&UtSet, UT_OBJID_1), "OS_SelectFdIsSet(1) == false");
     UtAssert_True(!OS_SelectFdIsSet(&UtSet, UT_OBJID_2), "OS_SelectFdIsSet(2) == false");
 
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdToArrayIndex));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdToArrayIndex));
     UtAssert_True(OS_SelectFdIsSet(&UtSet, UT_OBJID_1), "OS_SelectFdIsSet(1) == true");
     UtAssert_True(!OS_SelectFdIsSet(&UtSet, UT_OBJID_2), "OS_SelectFdIsSet(2) == false");
 }

--- a/src/unit-test-coverage/shared/src/coveragetest-sockets.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-sockets.c
@@ -375,7 +375,7 @@ void Test_OS_SocketGetIdByName(void)
     actual = OS_SocketGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_SocketGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_SocketGetIdByName(&objid, "NF");

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -227,7 +227,7 @@ void Test_OS_TaskGetIdByName(void)
     actual = OS_TaskGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_TaskGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_TaskGetIdByName(&objid, "NF");
@@ -318,14 +318,14 @@ void Test_OS_TaskFindIdBySystemData(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskValidateSystemData_Impl), expected);
     actual = OS_TaskFindIdBySystemData(&task_id, &test_sysdata, sizeof(test_sysdata));
     UtAssert_True(actual == expected, "OS_TaskFindIdBySystemData() (%ld) == OS_INVALID_POINTER", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TaskValidateSystemData_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskValidateSystemData_Impl));
 
     /* Test search failure */
     expected = OS_ERR_NAME_NOT_FOUND;
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch), expected);
     actual = OS_TaskFindIdBySystemData(&task_id, &test_sysdata, sizeof(test_sysdata));
     UtAssert_True(actual == expected, "OS_TaskFindIdBySystemData() (%ld) == OS_ERR_NAME_NOT_FOUND", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdGetBySearch));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch));
 }
 
 /* Osapi_Test_Setup

--- a/src/unit-test-coverage/shared/src/coveragetest-time.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-time.c
@@ -85,7 +85,7 @@ void Test_OS_TimerAdd(void)
     expected = OS_ERR_NAME_TOO_LONG;
     actual   = OS_TimerAdd(&objid, "UT", UT_OBJID_1, UT_TimerArgCallback, &arg);
     UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     expected = OS_INVALID_POINTER;
     actual   = OS_TimerAdd(&objid, "UT", UT_OBJID_1, NULL, &arg);
@@ -95,19 +95,19 @@ void Test_OS_TimerAdd(void)
     expected = OS_ERR_INCORRECT_OBJ_STATE;
     actual   = OS_TimerAdd(&objid, "UT", UT_OBJID_1, UT_TimerArgCallback, &arg);
     UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_ERR_INCORRECT_OBJ_STATE", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TaskGetId_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskGetId_Impl));
 
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetById), OS_ERROR);
     expected = OS_ERROR;
     actual   = OS_TimerAdd(&objid, "UT", UT_OBJID_1, UT_TimerArgCallback, &arg);
     UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_ERROR", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdGetById));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdGetById));
 
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdAllocateNew), OS_ERROR);
     expected = OS_ERROR;
     actual   = OS_TimerAdd(&objid, "UT", UT_OBJID_1, UT_TimerArgCallback, &arg);
     UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_ERROR", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdAllocateNew));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdAllocateNew));
 }
 
 void Test_OS_TimerCreate(void)
@@ -147,13 +147,13 @@ void Test_OS_TimerCreate(void)
     expected = OS_ERROR;
     actual   = OS_TimerCreate(&objid, "UT", &accuracy, UT_TimerCallback);
     UtAssert_True(actual == expected, "OS_TimerCreate() (%ld) == OS_ERROR", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TimeBaseCreate));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TimeBaseCreate));
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     expected = OS_ERR_NAME_TOO_LONG;
     actual   = OS_TimerCreate(&objid, "UT", &accuracy, UT_TimerCallback);
     UtAssert_True(actual == expected, "OS_TimerCreate() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 }
 
 void Test_OS_TimerSet(void)
@@ -186,7 +186,7 @@ void Test_OS_TimerSet(void)
     expected = OS_ERR_INCORRECT_OBJ_STATE;
     actual   = OS_TimerSet(UT_OBJID_2, 0, 1);
     UtAssert_True(actual == expected, "OS_TimerSet() (%ld) == OS_ERR_INCORRECT_OBJ_STATE", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TaskGetId_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskGetId_Impl));
 }
 
 void Test_OS_TimerDelete(void)
@@ -234,7 +234,7 @@ void Test_OS_TimerDelete(void)
     expected = OS_ERR_INCORRECT_OBJ_STATE;
     actual   = OS_TimerDelete(UT_OBJID_2);
     UtAssert_True(actual == expected, "OS_TimerDelete() (%ld) == OS_ERR_INCORRECT_OBJ_STATE", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TaskGetId_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskGetId_Impl));
 }
 
 void Test_OS_TimerGetIdByName(void)
@@ -250,7 +250,7 @@ void Test_OS_TimerGetIdByName(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName), OS_SUCCESS);
     actual = OS_TimerGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_TimerGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_TimerGetIdByName(&objid, "NF");
@@ -264,7 +264,7 @@ void Test_OS_TimerGetIdByName(void)
     expected = OS_ERR_INCORRECT_OBJ_STATE;
     actual   = OS_TimerGetIdByName(&objid, "NF");
     UtAssert_True(actual == expected, "OS_TimerGetIdByName() (%ld) == %ld", (long)actual, (long)expected);
-    UT_ClearForceFail(UT_KEY(OS_TaskGetId_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskGetId_Impl));
 }
 
 void Test_OS_TimerGetInfo(void)
@@ -301,7 +301,7 @@ void Test_OS_TimerGetInfo(void)
     expected = OS_ERR_INCORRECT_OBJ_STATE;
     actual   = OS_TimerGetInfo(UT_OBJID_1, &timer_prop);
     UtAssert_True(actual == expected, "OS_TimerGetInfo() (%ld) == OS_ERR_INCORRECT_OBJ_STATE", (long)actual);
-    UT_ClearForceFail(UT_KEY(OS_TaskGetId_Impl));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_TaskGetId_Impl));
 }
 
 /* Osapi_Test_Setup

--- a/src/unit-test-coverage/shared/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-timebase.c
@@ -103,7 +103,7 @@ void Test_OS_TimeBaseCreate(void)
     expected = OS_ERR_NAME_TOO_LONG;
     actual   = OS_TimeBaseCreate(&objid, "UT", UT_TimerSync);
     UtAssert_True(actual == expected, "OS_TimeBaseCreate() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
-    UT_ClearForceFail(UT_KEY(OCS_memchr));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskGetId_Impl), 1 | (OS_OBJECT_TYPE_OS_TIMEBASE << OS_OBJECT_TYPE_SHIFT));
     expected = OS_ERR_INCORRECT_OBJ_STATE;
@@ -166,7 +166,7 @@ void Test_OS_TimeBaseGetIdByName(void)
     actual = OS_TimeBaseGetIdByName(&objid, "UT");
     UtAssert_True(actual == expected, "OS_TimeBaseGetIdByName() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
-    UT_ClearForceFail(UT_KEY(OS_ObjectIdFindByName));
+    UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdFindByName));
 
     expected = OS_ERR_NAME_NOT_FOUND;
     actual   = OS_TimeBaseGetIdByName(&objid, "NF");

--- a/src/unit-test-coverage/vxworks/src/coveragetest-common.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-common.c
@@ -44,7 +44,7 @@ void Test_OS_API_Impl_Init(void)
     OSAPI_TEST_FUNCTION_RC(OS_API_Impl_Init(0), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_StubKey_OS_VxWorks_TableMutex_Init, OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_API_Impl_Init(OS_OBJECT_TYPE_OS_TASK), OS_ERROR);
-    UT_ClearForceFail(UT_StubKey_OS_VxWorks_TableMutex_Init);
+    UT_ClearDefaultReturnValue(UT_StubKey_OS_VxWorks_TableMutex_Init);
     OSAPI_TEST_FUNCTION_RC(OS_API_Impl_Init(OS_OBJECT_TYPE_OS_TASK), OS_SUCCESS);
     OSAPI_TEST_FUNCTION_RC(OS_API_Impl_Init(OS_OBJECT_TYPE_OS_QUEUE), OS_SUCCESS);
     OSAPI_TEST_FUNCTION_RC(OS_API_Impl_Init(OS_OBJECT_TYPE_OS_BINSEM), OS_SUCCESS);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-console.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-console.c
@@ -68,11 +68,11 @@ void Test_OS_ConsoleCreate_Impl(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_semCInitialize), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ConsoleCreate_Impl(&token), OS_SEM_FAILURE);
-    UT_ClearForceFail(UT_KEY(OCS_semCInitialize));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_semCInitialize));
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_taskSpawn), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ConsoleCreate_Impl(&token), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_taskSpawn));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_taskSpawn));
 
     token.obj_idx = OS_MAX_CONSOLES + 1;
     OSAPI_TEST_FUNCTION_RC(OS_ConsoleCreate_Impl(&token), OS_ERR_NOT_IMPLEMENTED);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
@@ -140,7 +140,7 @@ void Test_OS_FileSysMountVolume_Impl(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysMountVolume_Impl(&token), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
 
     /* Additional cases for the FS_BASED handling */
     OS_filesys_table[0].fstype = OS_FILESYS_TYPE_FS_BASED;
@@ -154,7 +154,7 @@ void Test_OS_FileSysMountVolume_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysMountVolume_Impl(&token), OS_FS_ERR_DRIVE_NOT_CREATED);
 
     /* Mount dir does exist but not a directory */
-    UT_ClearForceFail(UT_KEY(OCS_stat));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_stat));
     OSAPI_TEST_FUNCTION_RC(OS_FileSysMountVolume_Impl(&token), OS_FS_ERR_PATH_INVALID);
 
     /* Mount dir does exist and is a directory */
@@ -179,11 +179,11 @@ void Test_OS_FileSysUnmountVolume_Impl(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(&token), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_ioctl), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysUnmountVolume_Impl(&token), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_ioctl));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_ioctl));
 
     /* Additional cases for the FS_BASED handling (no op on unmount) */
     OS_filesys_table[0].fstype = OS_FILESYS_TYPE_FS_BASED;
@@ -217,7 +217,7 @@ void Test_OS_FileSysCheckVolume_Impl(void)
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysCheckVolume_Impl(&token, false), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_ioctl), -1);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysCheckVolume_Impl(&token, false), OS_ERROR);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
@@ -74,7 +74,7 @@ void Test_OS_API_Impl_Init(void)
     OSAPI_TEST_FUNCTION_RC(UT_Call_OS_VxWorks_TableMutex_Init(0), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OCS_semMInitialize), -1);
     OSAPI_TEST_FUNCTION_RC(UT_Call_OS_VxWorks_TableMutex_Init(OS_OBJECT_TYPE_OS_TASK), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_semMInitialize));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_semMInitialize));
     OSAPI_TEST_FUNCTION_RC(UT_Call_OS_VxWorks_TableMutex_Init(OS_OBJECT_TYPE_OS_TASK), OS_SUCCESS);
 }
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
@@ -55,10 +55,10 @@ void Test_OS_ModuleLoad_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(&token, "local"), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(&token, "local"), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
     UT_SetDefaultReturnValue(UT_KEY(OCS_loadModule), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(&token, "local"), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_loadModule));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_loadModule));
 }
 
 void Test_OS_ModuleUnload_Impl(void)
@@ -71,7 +71,7 @@ void Test_OS_ModuleUnload_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(&token), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OCS_unldByModuleId), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(&token), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_unldByModuleId));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_unldByModuleId));
 }
 
 void Test_OS_ModuleGetInfo_Impl(void)
@@ -93,7 +93,7 @@ void Test_OS_ModuleGetInfo_Impl(void)
     memset(&module_prop, 0, sizeof(module_prop));
     UT_SetDefaultReturnValue(UT_KEY(OCS_moduleInfoGet), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(&token, &module_prop), OS_SUCCESS);
-    UT_ClearForceFail(UT_KEY(OCS_moduleInfoGet));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_moduleInfoGet));
     UtAssert_True(!module_prop.addr.valid, "addresses in output not valid");
 }
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-no-module.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-no-module.c
@@ -51,10 +51,10 @@ void Test_OS_ModuleLoad_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(0, "local"), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(0, "local"), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
     UT_SetDefaultReturnValue(UT_KEY(OCS_loadModule), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleLoad_Impl(0, "local"), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_loadModule));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_loadModule));
 }
 
 void Test_OS_ModuleUnload_Impl(void)
@@ -65,7 +65,7 @@ void Test_OS_ModuleUnload_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(0), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OCS_unldByModuleId), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleUnload_Impl(0), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_unldByModuleId));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_unldByModuleId));
 }
 
 void Test_OS_ModuleGetInfo_Impl(void)
@@ -86,7 +86,7 @@ void Test_OS_ModuleGetInfo_Impl(void)
     memset(&module_prop, 0, sizeof(module_prop));
     UT_SetDefaultReturnValue(UT_KEY(OCS_moduleInfoGet), OCS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(0, &module_prop), OS_SUCCESS);
-    UT_ClearForceFail(UT_KEY(OCS_moduleInfoGet));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_moduleInfoGet));
     UtAssert_True(!module_prop.addr.valid, "addresses in output not valid");
 }
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
@@ -71,10 +71,10 @@ void Test_OS_SymTableIterator_Impl(void)
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 101), false);
     UT_SetDefaultReturnValue(UT_KEY(OCS_strlen), OS_MAX_SYM_LEN + 10);
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), false);
-    UT_ClearForceFail(UT_KEY(OCS_strlen));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_strlen));
     UT_SetDefaultReturnValue(UT_KEY(OCS_write), -1);
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), false);
-    UT_ClearForceFail(UT_KEY(OCS_write));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_write));
 }
 
 void Test_OS_SymbolTableDump_Impl(void)
@@ -85,7 +85,7 @@ void Test_OS_SymbolTableDump_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_SymbolTableDump_Impl("file", 10000), OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OCS_open), -1);
     OSAPI_TEST_FUNCTION_RC(OS_SymbolTableDump_Impl("file", 10000), OS_ERROR);
-    UT_ClearForceFail(UT_KEY(OCS_open));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_open));
 }
 
 /* ------------------- End of test cases --------------------------------------*/

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -75,7 +75,7 @@ void Test_OS_TaskCreate_Impl(void)
     UT_SetDefaultReturnValue(UT_KEY(OCS_malloc), OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(&token, 0), OS_ERROR);
 
-    UT_ClearForceFail(UT_KEY(OCS_malloc));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_malloc));
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(&token, OS_FP_ENABLED), OS_SUCCESS);
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 2, "malloc() called");
     UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 0, "free() not called");

--- a/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
@@ -120,12 +120,12 @@ void Test_OS_TimeBaseCreate_Impl(void)
     /* fail to initialize the sem */
     UT_SetDefaultReturnValue(UT_KEY(OCS_semMInitialize), -1);
     OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(&token), OS_TIMER_ERR_INTERNAL);
-    UT_ClearForceFail(UT_KEY(OCS_semMInitialize));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_semMInitialize));
 
     /* fail to spawn the task */
     UT_SetDefaultReturnValue(UT_KEY(OCS_taskSpawn), -1);
     OSAPI_TEST_FUNCTION_RC(OS_TimeBaseCreate_Impl(&token), OS_TIMER_ERR_INTERNAL);
-    UT_ClearForceFail(UT_KEY(OCS_taskSpawn));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_taskSpawn));
 
     /*
      * this call to TimeBaseCreate_Impl should also fail, because

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -180,21 +180,16 @@ void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, size_t BufferSize
 void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, size_t *MaxSize, size_t *Position);
 
 /**
- * Enable or disable the forced failure mode for the given stub function
- *
- * This triggers a constant failure mode from the stub function, if implemented.
- * The stub function will invoke a given failure path as defined by
- * the stub implementation.
- *
- * A count of the number of times the failure mode is invoked will be maintained.
+ * Set the default return value for the given stub function.
+ * User needs to use UT_ClearDefaultReturnValue to clear the value.
  *
  * \param FuncKey The stub function to add the return code to.
- * \param Value Arbitrary failure mode value (may or may not be used by the stub)
+ * \param Value Arbitrary return value (may or may not be used by the stub)
  */
 void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, int32 Value);
 
 /**
- * Disable the forced failure mode for the given stub function
+ * Disable the default return for the given stub function
  *
  * This undoes the action of UT_SetDefaultReturnValue()
  *
@@ -226,7 +221,7 @@ void UT_SetForceFail(UT_EntryKey_t FuncKey, int32 Value);
  *
  * \param FuncKey The stub function entry to clear.
  * 
- *  @deprecated replaced by UT_ClearDefaultReturnValue
+ * @deprecated replaced by UT_ClearDefaultReturnValue
  */
 void UT_ClearForceFail(UT_EntryKey_t FuncKey);
 #endif

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -193,6 +193,15 @@ void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, size_t *MaxSize,
  */
 void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, int32 Value);
 
+/**
+ * Disable the forced failure mode for the given stub function
+ *
+ * This undoes the action of UT_SetDefaultReturnValue()
+ *
+ * \param FuncKey The stub function entry to clear.
+ */
+void UT_ClearDefaultReturnValue(UT_EntryKey_t FuncKey);
+
 #ifndef OSAL_OMIT_DEPRECATED
 /**
  * Enable or disable the forced failure mode for the given stub function
@@ -209,7 +218,6 @@ void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, int32 Value);
  * @deprecated replaced by UT_SetDefaultReturnValue
  */
 void UT_SetForceFail(UT_EntryKey_t FuncKey, int32 Value);
-#endif
 
 /**
  * Disable the forced failure mode for the given stub function
@@ -217,8 +225,11 @@ void UT_SetForceFail(UT_EntryKey_t FuncKey, int32 Value);
  * This undoes the action of UT_SetDefaultReturnValue()
  *
  * \param FuncKey The stub function entry to clear.
+ * 
+ *  @deprecated replaced by UT_ClearDefaultReturnValue
  */
 void UT_ClearForceFail(UT_EntryKey_t FuncKey);
+#endif
 
 /**
  * Set a Hook function for a particular call

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -313,13 +313,13 @@ void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, int32 Value)
     UT_StubTableEntry_t *Rc;
 
     /*
-     * First find an existing force fail entry for the function.
+     * First find an existing default return value entry for the function.
      * In case one is already set we do not duplicate (unlike deferred codes)
      */
     Rc = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_FORCE_FAIL);
     if (Rc == NULL)
     {
-        /* Creating force fail entry - repeat search and grab any unused slot */
+        /* Creating default return value entry - repeat search and grab any unused slot */
         Rc = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_UNUSED);
     }
 

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -335,14 +335,7 @@ void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, int32 Value)
     }
 }
 
-#ifndef OSAL_OMIT_DEPRECATED
-void UT_SetForceFail(UT_EntryKey_t FuncKey, int32 Value)
-{
-    UT_SetDefaultReturnValue(FuncKey, Value);
-}
-#endif
-
-void UT_ClearForceFail(UT_EntryKey_t FuncKey)
+void UT_ClearDefaultReturnValue(UT_EntryKey_t FuncKey)
 {
     UT_StubTableEntry_t *StubPtr;
 
@@ -352,6 +345,18 @@ void UT_ClearForceFail(UT_EntryKey_t FuncKey)
         UT_ClearStubEntry(StubPtr);
     }
 }
+
+#ifndef OSAL_OMIT_DEPRECATED
+void UT_SetForceFail(UT_EntryKey_t FuncKey, int32 Value)
+{
+    UT_SetDefaultReturnValue(FuncKey, Value);
+}
+
+void UT_ClearForceFail(UT_EntryKey_t FuncKey)
+{
+    UT_ClearDefaultReturnValue(FuncKey);
+}
+#endif
 
 bool UT_GetStubRetcodeAndCount(UT_EntryKey_t FuncKey, int32 *Retcode, int32 *Count)
 {


### PR DESCRIPTION
**Describe the contribution**
Fixes #724  
Rename UT_ClearForceFail to UT_ClearDefaultValue

Fixes #722
Update the comments of UT_SetDefaultReturnValue to match the more general function

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**Additional context**
There will be more pull requests from other sub modules that are dependant on this. 

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC