### PR TITLE
Fix #726, Resolve user's guide generation warnings

### DIFF
--- a/src/os/inc/osapi-bsp.h
+++ b/src/os/inc/osapi-bsp.h
@@ -91,4 +91,6 @@ char *const *OS_BSP_GetArgV(void);
  ------------------------------------------------------------------*/
 void OS_BSP_SetExitCode(int32 code);
 
+/**@}*/
+
 #endif

--- a/src/os/inc/osapi-idmap.h
+++ b/src/os/inc/osapi-idmap.h
@@ -51,15 +51,6 @@
 #define OS_OBJECT_TYPE_USER        0x10 /**< @brief Object user type */
 /**@}*/
 
-/** @defgroup OSAPICore OSAL Core Operation APIs
- *
- * These are for OSAL core operations for startup/initialization, running, and shutdown.
- * Typically only used in bsps, unit tests, psps, etc.
- *
- * Not intended for user application use
- * @{
- */
-
 /** @defgroup OSAPIObjUtil OSAL Object ID Utility APIs
  * @{
  */


### PR DESCRIPTION
**Describe the contribution**
Fix #726 - closed group and removed old group.

**Testing performed**
`make usersguide` locally and confirmed no warnings

**Expected behavior changes**
No warnings on user's guide build

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC