### PR TITLE
Fix #730, Suppress invalid redundantAssignment warning from cppcheck

### DIFF
--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -762,6 +762,7 @@ void OS_WaitForStateChange(osal_objtype_t idtype, uint32 attempts)
         /*
          * After return, this task owns the table again
          */
+        /* cppcheck-suppress redundantAssignment */
         objtype->table_owner = saved_owner_id;
     }
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #730 - suppresses the invalid warning.

**Testing performed**
Re-ran cppcheck and observed no warnings

**Expected behavior changes**
None except no warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC