### PR TITLE
Fix #732, change uint32 to size_t

### DIFF
--- a/src/bsp/pc-rtems/src/bsp_console.c
+++ b/src/bsp/pc-rtems/src/bsp_console.c
@@ -41,7 +41,7 @@
    OS_BSP_ConsoleOutput_Impl
    See full description in header
  ------------------------------------------------------------------*/
-void OS_BSP_ConsoleOutput_Impl(const char *Str, uint32 DataLen)
+void OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen)
 {
     /* writes the raw data directly to STDOUT_FILENO (unbuffered) */
     write(STDOUT_FILENO, Str, DataLen);

--- a/src/os/rtems/src/os-impl-network.c
+++ b/src/os/rtems/src/os-impl-network.c
@@ -57,7 +57,7 @@ int32 OS_NetworkGetID_Impl(int32 *IdBuf)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_NetworkGetHostName_Impl(char *host_name, uint32 name_len)
+int32 OS_NetworkGetHostName_Impl(char *host_name, size_t name_len)
 {
     int32 return_code;
 

--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -156,7 +156,7 @@ int32 OS_QueueDelete_Impl(const OS_object_token_t *token)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, size_t size, size_t *size_copied, int32 timeout)
 {
     int32                            return_code;
     rtems_status_code                status;
@@ -253,7 +253,7 @@ int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, uint32 size, 
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_QueuePut_Impl(const OS_object_token_t *token, const void *data, uint32 size, uint32 flags)
+int32 OS_QueuePut_Impl(const OS_object_token_t *token, const void *data, size_t size, uint32 flags)
 {
     rtems_status_code                status;
     rtems_id                         rtems_queue_id;

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -359,7 +359,7 @@ int32 OS_TaskGetInfo_Impl(const OS_object_token_t *token, OS_task_prop_t *task_p
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, size_t sysdata_size)
 {
     if (sysdata == NULL || sysdata_size != sizeof(rtems_id))
     {


### PR DESCRIPTION
**Describe the contribution**
Fixes #732

change prototypes should be the same, from uint32 to size_t

**Testing performed**
Build on RTEMS 5

**Expected behavior changes**
Able to build

**System(s) tested on**
Ubuntu 20.04 as build host for RTEMS 5.0.0

**Additional context**
Dependant on nasa/osal#704 to successfully build

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
