### PR TITLE
Fix #429, OS_time_t with single tick counter

### DIFF
--- a/src/unit-test-coverage/shared/src/coveragetest-clock.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-clock.c
@@ -118,14 +118,14 @@ void Test_OS_TimeAccessConversions(void)
     UtAssert_UINT32_EQ(OS_TimeGetTotalMicroseconds(t4), 1901000);
 
     /* Note: Nanoseconds/Subseconds may not be exact due to limitations of OS_time_t resolution */
-    UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(t1), 1234567000);
-    UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(t2), 2528888000);
+    UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(t1), 1234567800);
+    UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(t2), 2528888800);
     UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(t3), 45678000);
     UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(t4), 1901000000);
 
     /* These functions only return the fractional part, not the whole part */
-    UtAssert_UINT32_EQ(OS_TimeGetSubsecondsPart(t1), 0x3c0c953a);
-    UtAssert_UINT32_EQ(OS_TimeGetSubsecondsPart(t2), 0x87653438);
+    UtAssert_UINT32_EQ(OS_TimeGetSubsecondsPart(t1), 0x3c0ca2a6);
+    UtAssert_UINT32_EQ(OS_TimeGetSubsecondsPart(t2), 0x876541a4);
     UtAssert_UINT32_EQ(OS_TimeGetSubsecondsPart(t3), 0x0bb18dad);
     UtAssert_UINT32_EQ(OS_TimeGetSubsecondsPart(t4), 0xe6a7ef9e);
 
@@ -139,8 +139,8 @@ void Test_OS_TimeAccessConversions(void)
     UtAssert_UINT32_EQ(OS_TimeGetMicrosecondsPart(t3), 45678);
     UtAssert_UINT32_EQ(OS_TimeGetMicrosecondsPart(t4), 901000);
 
-    UtAssert_UINT32_EQ(OS_TimeGetNanosecondsPart(t1), 234567000);
-    UtAssert_UINT32_EQ(OS_TimeGetNanosecondsPart(t2), 528888000);
+    UtAssert_UINT32_EQ(OS_TimeGetNanosecondsPart(t1), 234567800);
+    UtAssert_UINT32_EQ(OS_TimeGetNanosecondsPart(t2), 528888800);
     UtAssert_UINT32_EQ(OS_TimeGetNanosecondsPart(t3), 45678000);
     UtAssert_UINT32_EQ(OS_TimeGetNanosecondsPart(t4), 901000000);
 


### PR DESCRIPTION
**Describe the contribution**

Use a single 64-bit tick counter to implement `OS_time_t`, rather than a split 32 bit seconds + 32 bit microseconds counter.
    
This benefits in several ways:

- increases the timing precision by 10x (0.1us ticks)
- increases the representable range by 400x (+/-14000 yrs)
- simplifies addition/subtraction (no carry over)
- avoids "year 2038" bug w/32-bit timestamps

Fixes #429 

**Testing performed**
Build and run all unit tests, sanity check CFE

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11 + pc686 (qemu)

**Additional context**
This is the final step listed in issue #429, and it depends on several dependencies being merged already:

- PR nasa/cfe#1058
- PR nasa/psp#228
- PR nasa/osal#723

It is submitted as a separate PR from #723 due to the dependencies, so it doesn't necessarily all have to be merged at once.  However if CCB wants to accelerate the rollout this can be all done in a single merge cycle.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

