### PR TITLE
Fix #712, Replace UT_OS_LOG with UtPrintf

### DIFF
--- a/src/unit-tests/inc/ut_os_support.h
+++ b/src/unit-tests/inc/ut_os_support.h
@@ -109,8 +109,6 @@ static inline bool UtOsalImplemented(int32 Fn, const char *File, uint32 Line)
 
 /*--------------------------------------------------------------------------------*/
 
-#define UT_OS_LOG(...) UtAssert_Message(UTASSERT_CASETYPE_INFO, __FILE__, __LINE__, __VA_ARGS__);
-
 /*
  * An osal_id_t value which is not OS_OBJECT_ID_UNDEFINED and also
  * not aliasing any other valid value/type.

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.c
@@ -161,7 +161,7 @@ UT_os_apiinit_test_exit_tag:
 void UT_os_printf_test()
 {
     OS_printf_enable();
-    UT_OS_LOG("OS_printf() - #1 Nominal [This is the expected stdout output after API call]\n");
+    UtPrintf("OS_printf() - #1 Nominal [This is the expected stdout output after API call]\n");
     OS_printf("OS_printf() - #1 Nominal [ This is the expected stdout output after API call]\n");
 
     UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
@@ -184,7 +184,7 @@ void UT_os_printfenable_test()
     OS_printf_disable();
 
     OS_printf_enable();
-    UT_OS_LOG("OS_printf_enable() - #1 Nominal [This is the expected stdout output after API call]\n");
+    UtPrintf("OS_printf_enable() - #1 Nominal [This is the expected stdout output after API call]\n");
     OS_printf("OS_printf_enable() - #1 Nominal [This is the expected stdout output after API call]\n");
 
     UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
@@ -205,18 +205,18 @@ void UT_os_printfenable_test()
 void UT_os_printfdisable_test()
 {
     OS_printf_enable();
-    UT_OS_LOG("OS_printf_disable() - #1 Nominal [This is the expected stdout output before API call]\n");
+    UtPrintf("OS_printf_disable() - #1 Nominal [This is the expected stdout output before API call]\n");
     OS_printf("OS_printf_disable() - #1 Nominal [This is the expected stdout output before API call]\n");
 
     OS_printf_disable();
-    UT_OS_LOG("OS_printf_disable() - #1 Nominal [This is NOT the expected stdout output after API call]\n");
+    UtPrintf("OS_printf_disable() - #1 Nominal [This is NOT the expected stdout output after API call]\n");
     OS_printf("OS_printf_disable() - #1 Nominal [This is NOT the expected stdout output after API call]\n");
 
     UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
 
     /* Reset test environment */
     OS_printf_enable();
-    UT_OS_LOG("OS_printf_disable() - #1 Nominal [This is the expected stdout output after test reset]\n");
+    UtPrintf("OS_printf_disable() - #1 Nominal [This is the expected stdout output after test reset]\n");
     OS_printf("OS_printf_disable() - #1 Nominal [This is the expected stdout output after test reset]\n");
 }
 
@@ -286,11 +286,11 @@ void UT_os_getlocaltime_test()
     res = OS_GetLocalTime(&time_struct);
     if (res == OS_SUCCESS)
     {
-        UT_OS_LOG("\n");
+        UtPrintf("\n");
         for (i = 0; i < 5; i++)
         {
-            UT_OS_LOG("OS_GetLocalTime() - #3 Nominal ");
-            UT_OS_LOG("[Expecting output after API call to increase over time: %ld.%ld]\n", (long)time_struct.seconds,
+            UtPrintf("OS_GetLocalTime() - #3 Nominal ");
+            UtPrintf("[Expecting output after API call to increase over time: %ld.%ld]\n", (long)time_struct.seconds,
                       (long)time_struct.microsecs);
 
             OS_TaskDelay(20);
@@ -378,8 +378,8 @@ void UT_os_setlocaltime_test()
     {
         for (i = 0; i < 5; i++)
         {
-            UT_OS_LOG("OS_SetLocalTime() - #3 Nominal ");
-            UT_OS_LOG("[Expecting output before API call to increase over time: %ld.%ld]\n", (long)time_struct.seconds,
+            UtPrintf("OS_SetLocalTime() - #3 Nominal ");
+            UtPrintf("[Expecting output before API call to increase over time: %ld.%ld]\n", (long)time_struct.seconds,
                       (long)time_struct.microsecs);
 
             OS_TaskDelay(20);
@@ -394,7 +394,7 @@ void UT_os_setlocaltime_test()
     res = OS_SetLocalTime(&time_struct);
     if (res == OS_SUCCESS)
     {
-        UT_OS_LOG("OS_SetLocalTime() - #3 Nominal [New time set at %ld.%ld]\n", (long)time_struct.seconds,
+        UtPrintf("OS_SetLocalTime() - #3 Nominal [New time set at %ld.%ld]\n", (long)time_struct.seconds,
                   (long)time_struct.microsecs);
 
         res = OS_GetLocalTime(&time_struct);
@@ -402,8 +402,8 @@ void UT_os_setlocaltime_test()
         {
             for (i = 0; i < 5; i++)
             {
-                UT_OS_LOG("OS_SetLocalTime() - #3 Nominal ");
-                UT_OS_LOG("[Expecting output after API call to increase over time: %ld.%ld]\n",
+                UtPrintf("OS_SetLocalTime() - #3 Nominal ");
+                UtPrintf("[Expecting output after API call to increase over time: %ld.%ld]\n",
                           (long)time_struct.seconds, (long)time_struct.microsecs);
 
                 OS_TaskDelay(20);

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -84,7 +84,7 @@ void generic_test_task(void)
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
-    UT_OS_LOG("Starting GenericTask: %s, id: %lx\n", task_prop.name, OS_ObjectIdToInteger(task_id));
+    UtPrintf("Starting GenericTask: %s, id: %lx\n", task_prop.name, OS_ObjectIdToInteger(task_id));
 
     while (1)
     {
@@ -322,7 +322,7 @@ UT_os_task_delete_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void delete_handler_callback(void)
 {
-    UT_OS_LOG("Task delete callback...\n");
+    UtPrintf("Task delete callback...\n");
 }
 
 /*--------------------------------------------------------------------------------*/
@@ -337,7 +337,7 @@ void delete_handler_test_task(void)
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
-    UT_OS_LOG("Starting DeleteTest Task: %s, id: %lx\n", task_prop.name, OS_ObjectIdToInteger(task_id));
+    UtPrintf("Starting DeleteTest Task: %s, id: %lx\n", task_prop.name, OS_ObjectIdToInteger(task_id));
 
     g_task_result = OS_TaskInstallDeleteHandler(&delete_handler_callback);
 
@@ -443,7 +443,7 @@ void exit_test_task(void)
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
-    UT_OS_LOG("Starting ExitTest Task: %s, id: %lx\n", task_prop.name, OS_ObjectIdToInteger(task_id));
+    UtPrintf("Starting ExitTest Task: %s, id: %lx\n", task_prop.name, OS_ObjectIdToInteger(task_id));
 
     /*
     ** The parent task will check to see if this task is valid.
@@ -675,7 +675,7 @@ void register_test_task(void)
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
-    UT_OS_LOG("Starting RegisterTest Task: %s\n", task_prop.name);
+    UtPrintf("Starting RegisterTest Task: %s\n", task_prop.name);
     ;
 
     /*
@@ -775,7 +775,7 @@ void getid_test_task(void)
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
-    UT_OS_LOG("OS_TaskGetId() - #1 Nominal [This is the returned task Id=%lx]\n", OS_ObjectIdToInteger(task_id));
+    UtPrintf("OS_TaskGetId() - #1 Nominal [This is the returned task Id=%lx]\n", OS_ObjectIdToInteger(task_id));
 
     while (1)
     {
@@ -814,7 +814,7 @@ void UT_os_task_get_id_test()
     {
         OS_TaskDelay(500);
 
-        UT_OS_LOG("OS_TaskGetId() - #1 Nominal [This is the expected task Id=%lx]\n",
+        UtPrintf("OS_TaskGetId() - #1 Nominal [This is the expected task Id=%lx]\n",
                   OS_ObjectIdToInteger(g_task_ids[1]));
 
         res = OS_TaskDelete(g_task_ids[1]); /* Won't hurt if its already deleted */

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -804,9 +804,9 @@ void UT_os_readfile_test()
     OS_close(g_fDescs[0]);
     OS_remove(g_fNames[0]);
 
-    UT_OS_LOG("OS_read() success test -- Write to file:\n\t%s\n", g_writeBuff);
+    UtPrintf("OS_read() success test -- Write to file:\n\t%s\n", g_writeBuff);
     ;
-    UT_OS_LOG("OS_read() success test -- Read from file:\n\t%s\n", g_readBuff);
+    UtPrintf("OS_read() success test -- Read from file:\n\t%s\n", g_readBuff);
     ;
 
 UT_os_readfile_test_exit_tag:
@@ -975,9 +975,9 @@ void UT_os_writefile_test()
     OS_close(g_fDescs[0]);
     OS_remove(g_fNames[0]);
 
-    UT_OS_LOG("OS_write() success test -- Write to file:\n\t%s\n", g_writeBuff);
+    UtPrintf("OS_write() success test -- Write to file:\n\t%s\n", g_writeBuff);
     ;
-    UT_OS_LOG("OS_write() success test -- Read from file:\n\t%s\n", g_readBuff);
+    UtPrintf("OS_write() success test -- Read from file:\n\t%s\n", g_readBuff);
     ;
 
 UT_os_writefile_test_exit_tag:

--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -79,7 +79,7 @@ int32 UT_os_setup_fs()
     res = OS_mkfs(g_fsAddrPtr, g_devName, "RAM3", OSAL_SIZE_C(512), OSAL_BLOCKCOUNT_C(64));
     if (res != OS_SUCCESS)
     {
-        UT_OS_LOG("OS_mkfs() returns %d\n", (int)res);
+        UtPrintf("OS_mkfs() returns %d\n", (int)res);
         ;
         goto UT_os_setup_fs_exit_tag;
     }
@@ -87,7 +87,7 @@ int32 UT_os_setup_fs()
     res = OS_mount(g_devName, g_mntName);
     if (res != OS_SUCCESS)
     {
-        UT_OS_LOG("OS_mount() returns %d\n", (int)res);
+        UtPrintf("OS_mount() returns %d\n", (int)res);
         ;
         OS_rmfs(g_devName);
         goto UT_os_setup_fs_exit_tag;

--- a/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
+++ b/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
@@ -105,7 +105,7 @@ void UT_os_networkgetid_test()
 
     /* NOTE: This API does not return error codes.
      * Any return value could be valid */
-    UT_OS_LOG("OS_NetworkGetID() return value=%ld", (long)res);
+    UtPrintf("OS_NetworkGetID() return value=%ld", (long)res);
     UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_MIR);
 
 UT_os_networkgetid_test_exit_tag:

--- a/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
@@ -550,7 +550,7 @@ void UT_os_timerset_test()
         intervalTime   = 5;
         g_toleranceVal = 0;
 
-        UT_OS_LOG("\nOS_TimerSet() - #3 Interval-too-short (clk_accuracy=%d)\n", (int)g_clkAccuracy);
+        UtPrintf("\nOS_TimerSet() - #3 Interval-too-short (clk_accuracy=%d)\n", (int)g_clkAccuracy);
         res = OS_TimerSet(g_timerIds[3], startTime, intervalTime);
         if (res == OS_SUCCESS)
         {
@@ -588,7 +588,7 @@ void UT_os_timerset_test()
         startTime      = 1000;
         intervalTime   = 500000;
         g_toleranceVal = intervalTime / 20; /* 5% */
-        UT_OS_LOG("\nOS_TimerSet() - #1 Nominal condition (clk_accuracy=%d)\n", (int)g_clkAccuracy);
+        UtPrintf("\nOS_TimerSet() - #1 Nominal condition (clk_accuracy=%d)\n", (int)g_clkAccuracy);
         res = OS_TimerSet(g_timerIds[4], startTime, intervalTime);
         if (res == OS_SUCCESS)
         {


### PR DESCRIPTION
**Describe the contribution**
Fix #712 - replaces UT_OS_LOG with UtPrintf (it was just a duplicated macro)

**Testing performed**
Standard build and run of unit tests

**Expected behavior changes**
No change, just code duplication cleanup

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC