### PR TITLE
Fix #746, Add UtDebug message from OS_printf stub

### DIFF
--- a/src/ut-stubs/osapi-utstub-printf.c
+++ b/src/ut-stubs/osapi-utstub-printf.c
@@ -63,8 +63,12 @@ void OS_printf(const char *string, ...)
     int32   status;
     size_t  length = strlen(string);
     va_list va;
+    char    str[128];
 
     va_start(va, string);
+
+    vsnprintf(str, sizeof(str), string, va);
+    UtDebug("OS_printf: %s", str);
 
     status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(OS_printf), 0, va);
 


### PR DESCRIPTION
**Describe the contribution**
Fix #746 - added UtDebug in OS_printf stub

**Testing performed**
Built tests and confirmed debug output

**Expected behavior changes**
Outputs the OS_printf input as a debug message from stub

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC