### PR TITLE
Fix #699, format printf correctly

### DIFF
--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -328,8 +328,8 @@ void TestSelectSingleRead(void)
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_SUCCESS", (long)actual);
-    UtAssert_True(StateFlags == OS_STREAM_STATE_READABLE, "OS_SelectSingle() (%d) == OS_STREAM_STATE_READABLE",
-                  StateFlags);
+    UtAssert_True(StateFlags == OS_STREAM_STATE_READABLE, "OS_SelectSingle() (%x) == OS_STREAM_STATE_READABLE",
+                  (unsigned int)StateFlags);
 }
 
 void TestSelectMultipleRead(void)
@@ -441,8 +441,8 @@ void TestSelectSingleWrite(void)
 
         /* Verify Outputs */
         UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_SUCCESS", (long)actual);
-        UtAssert_True(StateFlags == OS_STREAM_STATE_WRITABLE, "OS_SelectSingle() (%d) == OS_STREAM_STATE_WRITABLE",
-                      StateFlags);
+        UtAssert_True(StateFlags == OS_STREAM_STATE_WRITABLE, "OS_SelectSingle() (%x) == OS_STREAM_STATE_WRITABLE",
+                      (unsigned int)StateFlags);
     }
 }
 
@@ -532,16 +532,16 @@ void TestSelectSingleFile(void)
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_SUCCESS", (long)actual);
-    UtAssert_True(StateFlags == OS_STREAM_STATE_READABLE, "OS_SelectSingle() (%d) == OS_STREAM_STATE_READABLE",
-                  StateFlags);
+    UtAssert_True(StateFlags == OS_STREAM_STATE_READABLE, "OS_SelectSingle() (%x) == OS_STREAM_STATE_READABLE",
+                  (unsigned int)StateFlags);
 
     StateFlags = OS_STREAM_STATE_WRITABLE;
     actual     = OS_SelectSingle(fd, &StateFlags, 100);
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_SUCCESS", (long)actual);
-    UtAssert_True(StateFlags == OS_STREAM_STATE_WRITABLE, "OS_SelectSingle() (%d) == OS_STREAM_STATE_WRITABLE",
-                  StateFlags);
+    UtAssert_True(StateFlags == OS_STREAM_STATE_WRITABLE, "OS_SelectSingle() (%x) == OS_STREAM_STATE_WRITABLE",
+                  (unsigned int)StateFlags);
 
     expected   = OS_ERROR_TIMEOUT;
     StateFlags = OS_STREAM_STATE_BOUND;

--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -318,7 +318,7 @@ void TestSelectSingleRead(void)
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_ERROR_TIMEOUT", (long)actual);
-    UtAssert_True(StateFlags == 0, "OS_SelectSingle() (%d) == None", StateFlags);
+    UtAssert_True(StateFlags == 0, "OS_SelectSingle() (0x%x) == None", (unsigned int)StateFlags);
 
     status = OS_BinSemGive(bin_sem_id);
 
@@ -433,7 +433,7 @@ void TestSelectSingleWrite(void)
         expected = OS_ERROR_TIMEOUT;
         /* Verify Outputs */
         UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_ERROR_TIMEOUT", (long)actual);
-        UtAssert_True(StateFlags == 0, "OS_SelectSingle() (%d) == None", StateFlags);
+        UtAssert_True(StateFlags == 0, "OS_SelectSingle() (0x%x) == None", (unsigned int)StateFlags);
 
         expected   = OS_SUCCESS;
         StateFlags = OS_STREAM_STATE_WRITABLE;
@@ -549,7 +549,7 @@ void TestSelectSingleFile(void)
 
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_ERROR_TIMEOUT", (long)actual);
-    UtAssert_True(StateFlags == 0, "OS_SelectSingle() (%d) == None", StateFlags);
+    UtAssert_True(StateFlags == 0, "OS_SelectSingle() (0x%x) == None", (unsigned int)StateFlags);
 }
 
 void UtTest_Setup(void)


### PR DESCRIPTION
**Describe the contribution**
Fixes #699
Fixed the formatting to correctly build. Have been unable to test on RTEMS 4

**Testing performed**
Tested on RTEMS 5 and worked. 

**Expected behavior changes**
Able to build 

**System(s) tested on**
Ubuntu 20.04 RTEMS 5

**Additional context**
Needs to be tested on RTEMS 4

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
