### PR TITLE
Fix #685 change file create to use read write

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -253,7 +253,7 @@ void TestChmod(void)
     /*Make a file to test on. Start in Read only mode */
     strncpy(filename, "/drive0/Filename1", sizeof(filename) - 1);
     filename[sizeof(filename) - 1] = 0;
-    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_ONLY);
+    status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_CREATE , OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat = %d", (int)status);
     status = OS_close(fd);
     UtAssert_True(status == OS_SUCCESS, "status after close = %d", (int)status);


### PR DESCRIPTION
**Describe the contribution**
fixes #685
Changed the file create to read write to work on RTEMS

**Testing performed**
Ran the test on RTEMS 5

**Expected behavior changes**
Test should pass

**System(s) tested on**
Ubunto 20.04, RTEMS 5


**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campell GSFC