### PR TITLE
Fix #577, Document nested tests not supported

### DIFF
--- a/ut_assert/inc/uttest.h
+++ b/ut_assert/inc/uttest.h
@@ -43,6 +43,11 @@
  *
  * Called by the user to register a new test case with the library.
  *
+ * Note: Nested addition of tests is not supported.  Calling
+ *       UtTest_Add from within a test function added using UtTest_Add
+ *       will not cause the nested test to execute, and will be
+ *       silently ignored.
+ *
  * \param Test     Main test function to call.
  * \param Setup    Setup function, called before the test function
  * \param Teardown Cleanup function, called after the test function


### PR DESCRIPTION
**Describe the contribution**
Fix #577 - adds documentation to the UtTest_Add API that nesting (UtTest_Add from within an added test) silently fails.

**Testing performed**
None, documentation only.  

**Expected behavior changes**
None

**System(s) tested on**
N/A

**Additional context**
nasa/cFE#841

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC