### PR TITLE
Fix #753, Remove UT_CheckForOpenSockets

### DIFF
--- a/src/ut-stubs/utstub-helpers.c
+++ b/src/ut-stubs/utstub-helpers.c
@@ -184,26 +184,3 @@ void UT_ObjIdDecompose(osal_id_t id, uint32 *indx, UT_ObjType_t *objtype)
     *indx             = idv & 0xFFFFUL;
     *objtype          = (idv >> 16) ^ 0x4000UL;
 }
-
-/*
-** Report and close any sockets found open
-** Moved here temporarily to ensure full compatibility with CFE implementation
-**
-** NOTE - this historically only checked for queues that were created but not
-** cleaned up.  Although the current impl could check for anything, only queues
-** are done for now.
-*/
-void UT_CheckForOpenSockets(void)
-{
-    UT_ObjTypeState_t *StatePtr;
-    uint32             i;
-
-    StatePtr = &UT_ObjState[UT_OBJTYPE_QUEUE];
-    for (i = 0; i <= StatePtr->LastIssueNumber; ++i)
-    {
-        if ((StatePtr->ValidBits[i >> 3] & (1 << (i & 0x07))) != 0)
-        {
-            UtAssert_Failed("UT_Queue %d left open.\n", (int)i);
-        }
-    }
-}

--- a/src/ut-stubs/utstub-helpers.h
+++ b/src/ut-stubs/utstub-helpers.h
@@ -108,12 +108,6 @@ osal_id_t UT_AllocStubObjId(UT_ObjType_t ObjType);
 void UT_DeleteStubObjId(UT_ObjType_t ObjType, osal_id_t ObjId);
 
 /*
- * Helper function - Report any queue objects found open
- * (for compatibility with CFE tests, only checks queues)
- */
-void UT_CheckForOpenSockets(void);
-
-/*
  * Helper function - Clear all OSAL UT stub objects
  * Resets the stub object table back to its initial/empty state
  */


### PR DESCRIPTION
**Describe the contribution**
Fix #753 - removes UT_CheckForOpenSockets which was an old hack to check if unit tests cleaned up sockets.  No longer applicable since the UT framework resets the state for each unit test.

**Testing performed**
Built and ran unit tests with nasa/cfe#1085

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 -  Versions: Bundle main + nasa/cFE#1085 + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC