### PR TITLE
Fix #757, Read extern C in osapi.h to support C++ use

### DIFF
--- a/src/os/inc/osapi.h
+++ b/src/os/inc/osapi.h
@@ -30,6 +30,11 @@
 #ifndef OSAPI_H
 #define OSAPI_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /*
  * Note - the "osapi-os-filesys.h" file previously included these system headers
  * plus a couple others.  Some existing code used stdio/stdlib functions but did


### PR DESCRIPTION
**Describe the contribution**
Fix #757, Readd extern C in osapi.h to support C++ use

**Testing performed**
Build and unit test, passes.
@johnphamngc - could you test in C++ context and confirm this resolves your issue?

**Expected behavior changes**
Works to include header in C++ again, no other functional change

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC