### PR TITLE
Fix #761, Terminate string in TestReadWriteLseek

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -330,7 +330,8 @@ void TestReadWriteLseek(void)
     status = OS_OpenCreate(&fd, filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status >= OS_SUCCESS, "status after creat = %d", (int)status);
 
-    size = strlen(buffer);
+    /* Write the string including null character */
+    size = strlen(buffer) + 1;
 
     /* test write portion of R/W mode */
     status = OS_write(fd, (void *)buffer, size);


### PR DESCRIPTION
**Describe the contribution**
Fix #761, Terminate string in TestReadWriteLseek

**Testing performed**
Initialized the character arrays to known values, observed missing termination in report, fixed w/ this comment and observed the garbage no longer being reported.

**Expected behavior changes**
No impact to main code, UT only (and just the report, test passes either way).

**System(s) tested on**
 - cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC