### PR TITLE
Fix #760, Install modules and clean up files for unit tests

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -943,4 +943,13 @@ void TestOpenFileAPI(void)
     */
     status = OS_CloseFileByName(filename2);
     UtAssert_True(status < OS_SUCCESS, "status after OS_CloseFileByName 2 = %d", (int)status);
+
+    /* Try removing the files from the drive to end the function */
+    status = OS_remove(filename1);
+    UtAssert_True(status == OS_SUCCESS, "status after remove filename1 = %d", (int)status);
+    status = OS_remove(filename2);
+    UtAssert_True(status == OS_SUCCESS, "status after remove filename2 = %d", (int)status);
+    status = OS_remove(filename3);
+    UtAssert_True(status == OS_SUCCESS, "status after remove filename3 = %d", (int)status);
+
 }

--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -50,6 +50,8 @@ OS_SockAddr_t c_addr;
 OS_SockAddr_t c2_addr;
 osal_id_t     bin_sem_id;
 
+#define OS_TEST_SELECT_FILENAME "/drive0/select_test.txt"
+
 /* *************************************** MAIN ************************************** */
 
 char *           fsAddrPtr = NULL;
@@ -58,7 +60,7 @@ static osal_id_t setup_file(void)
     osal_id_t id;
     OS_mkfs(fsAddrPtr, "/ramdev0", "RAM", 512, 20);
     OS_mount("/ramdev0", "/drive0");
-    OS_OpenCreate(&id, "/drive0/select_test.txt", OS_FILE_FLAG_CREATE, OS_READ_WRITE);
+    OS_OpenCreate(&id, OS_TEST_SELECT_FILENAME, OS_FILE_FLAG_CREATE, OS_READ_WRITE);
     return id;
 }
 
@@ -531,6 +533,10 @@ void TestSelectSingleFile(void)
     /* Verify Outputs */
     UtAssert_True(actual == expected, "OS_SelectSingle() (%ld) == OS_ERROR_TIMEOUT", (long)actual);
     UtAssert_True(StateFlags == 0, "OS_SelectSingle() (0x%x) == None", (unsigned int)StateFlags);
+
+    /* Close and remove file */
+    OS_close(fd);
+    OS_remove(OS_TEST_SELECT_FILENAME);
 }
 
 void UtTest_Setup(void)

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -2057,11 +2057,12 @@ void UT_os_outputtofile_test()
         }
     }
 
+UT_os_outputtofile_test_exit_tag:
+
     /* Reset test environment */
     OS_close(g_fDescs[0]);
     OS_remove(g_fNames[0]);
 
-UT_os_outputtofile_test_exit_tag:
     return;
 }
 

--- a/src/unit-tests/osloader-test/CMakeLists.txt
+++ b/src/unit-tests/osloader-test/CMakeLists.txt
@@ -19,4 +19,7 @@ while(MOD GREATER 0)
     PREFIX ""
     LIBRARY_OUTPUT_DIRECTORY utmod)
   add_dependencies(osal_loader_UT MODULE${MOD})
+  foreach(TGT ${INSTALL_TARGET_LIST})
+    install(TARGETS MODULE${MOD} DESTINATION ${TGT}/${UT_INSTALL_SUBDIR}/utmod)
+  endforeach()
 endwhile(MOD GREATER 0)


### PR DESCRIPTION
**Describe the contribution**
Fix #760 - Installs the modules used in unit testing and added removal of files where they were left-over after tests completed

**Testing performed**
Built and ran unit tests (also installed and ran osal_loader_UT from build/exe/* directory).  Confirmed no files were left over in /dev/shm

**Expected behavior changes**
UT's work and clean up files

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC

Ping @jhnphm