### PR TITLE
Fix #777, Static allocation of DummyVec in OSC_INUM_TO_IVEC stub

### DIFF
--- a/src/unit-test-coverage/ut-stubs/src/vxworks-intLib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/vxworks-intLib-stubs.c
@@ -50,10 +50,10 @@ static void OCS_intLib_dummyfunc(void) {}
 
 OCS_VOIDFUNCPTR *OCS_INUM_TO_IVEC(unsigned int ui)
 {
-    int32            Status = UT_DEFAULT_IMPL(OCS_INUM_TO_IVEC);
-    OCS_VOIDFUNCPTR *VecTbl;
-    OCS_VOIDFUNCPTR  DummyVec;
-    size_t           VecTblSize;
+    int32                  Status = UT_DEFAULT_IMPL(OCS_INUM_TO_IVEC);
+    OCS_VOIDFUNCPTR        *VecTbl;
+    static OCS_VOIDFUNCPTR DummyVec;
+    size_t                 VecTblSize;
 
     if (Status == 0)
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #777, declares DummyVec as static to avoid warning (and returning stack allocated memory) when returning VecTbl.

**Testing performed**
Build and execute unit tests, passed.

**Expected behavior changes**
Bug in stub fixed (could have been issues if return value used).

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle + this commit

**Additional context**
CodeQL warning resolution

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC