### PR TITLE
Fix #783, Initialize locals flagged in static analysis

### DIFF
--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -631,7 +631,7 @@ int32 OS_ObjectIdFindNextFree(OS_object_token_t *token)
 {
     uint32              max_id;
     uint32              base_id;
-    uint32              local_id;
+    uint32              local_id = 0;
     uint32              serial;
     uint32              i;
     int32               return_code;

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -439,7 +439,7 @@ UT_os_closedir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_readdir_test()
 {
-    osal_id_t   dirh;
+    osal_id_t   dirh = OS_OBJECT_ID_UNDEFINED;
     const char *testDesc;
 
     strcpy(g_subdirNames[0], " ");
@@ -566,7 +566,7 @@ UT_os_readdir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_rewinddir_test()
 {
-    osal_id_t   dirh;
+    osal_id_t   dirh = OS_OBJECT_ID_UNDEFINED;
     const char *testDesc;
 
     strcpy(g_subdirNames[0], " ");

--- a/src/ut-stubs/osapi-utstub-bsp.c
+++ b/src/ut-stubs/osapi-utstub-bsp.c
@@ -56,7 +56,7 @@ uint32 OS_BSP_GetArgC(void)
  ------------------------------------------------------------------*/
 char *const *OS_BSP_GetArgV(void)
 {
-    void *buffer;
+    void *buffer = NULL;
     int32 status;
 
     status = UT_DEFAULT_IMPL(OS_BSP_GetArgV);

--- a/src/ut-stubs/osapi-utstub-idmap.c
+++ b/src/ut-stubs/osapi-utstub-idmap.c
@@ -138,7 +138,7 @@ OS_common_record_t *OS_ObjectIdGlobalFromToken(const OS_object_token_t *token)
 {
     static OS_common_record_t fake_record;
     int32                     status;
-    OS_common_record_t *      recptr;
+    OS_common_record_t *      recptr = &fake_record;
 
     status = UT_DEFAULT_IMPL(OS_ObjectIdGlobalFromToken);
     if (status == 0 &&


### PR DESCRIPTION
**Describe the contribution**
Fix #783, Simply adds initialization where flagged by static analysis as possibly uninitialized

**Testing performed**
Build and run unit tests

**Expected behavior changes**
No functional change to non-test code, avoids returning uninitialized values from stubs.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC