### PR TITLE
Fix #785, Clean commented out code

### DIFF
--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -142,8 +142,6 @@ void TestTasks(void)
     OS_task_prop_t      taskprop;
     int                 loopcnt;
 
-    /* OS_TaskRegister(); */
-
     /* Testing Creating up to OS_MAX_TASKS, plus one more */
     memset(TaskData, 0xFF, sizeof(TaskData));
     for (tasknum = 0; tasknum < (OS_MAX_TASKS + 1); ++tasknum)
@@ -223,7 +221,6 @@ void TestTasks(void)
     /* Create Task 0 again */
     status = OS_TaskCreate(&task_0_id, "Task 0", task_generic_no_exit, OSAL_STACKPTR_C(task_0_stack), sizeof(task_0_stack),
                            OSAL_PRIORITY_C(TASK_0_PRIORITY), 0);
-    /*UtDebug("Create Status = %d, Id = %d\n",status,task_0_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate, recreate 0");
 
     /* Try and create another "Task 0", should fail as we already have one named "Task 0" */
@@ -233,29 +230,23 @@ void TestTasks(void)
 
     status = OS_TaskCreate(&task_2_id, "Task 2", task_generic_no_exit, OSAL_STACKPTR_C(task_2_stack), sizeof(task_2_stack),
                            OSAL_PRIORITY_C(TASK_2_PRIORITY), 0);
-    /*  UtDebug("Create Status = %d, Id = %d\n",status,task_2_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate, recreate 2");
 
     status = OS_TaskCreate(&task_3_id, "Task 3", task_generic_no_exit, OSAL_STACKPTR_C(task_3_stack), sizeof(task_3_stack),
                            OSAL_PRIORITY_C(TASK_3_PRIORITY), 0);
-    /*  UtDebug("Create Status = %d, Id = %d\n",status,task_3_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate, recreate 3");
 
     status = OS_TaskGetIdByName(&task_0_id, "Task 0");
-    /* UtDebug("Satus after Getting the id of \"Task 0\":%d,%d \n\n",status,task_0_id); */
     /*first newly created task should have id == 0*/
     UtAssert_True(status == OS_SUCCESS, "OS_TaskGetIdByName, Task 0");
 
     status = OS_TaskGetIdByName(&task_1_id, "Task 1");
-    /*UtDebug("Satus after Getting the id of \"Task 1\":%d,%d \n\n",status,task_1_id);*/
     UtAssert_True(status != OS_SUCCESS, "OS_TaskGetIdByName, Task 1");
 
     status = OS_TaskGetIdByName(&task_2_id, "Task 2");
-    /* UtDebug("Satus after Getting the id of \"Task 2\":%d,%d \n\n",status,task_2_id);*/
     UtAssert_True(status == OS_SUCCESS, "OS_TaskGetIdByName, Task 2");
 
     status = OS_TaskGetIdByName(&task_3_id, "Task 3");
-    /* UtDebug("Satus after Getting the id of \"Task 3\":%d,%d \n\n",status,task_3_id); */
     UtAssert_True(status == OS_SUCCESS, "OS_TaskGetIdByName, Task 3");
 
     /*
@@ -308,20 +299,16 @@ void TestQueues(void)
 
     InitializeQIds();
     status = OS_QueueCreate(&msgq_0, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
-    /* UtDebug("Status after Creating q 0: %d,%d\n",status,msgq_0);*/
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate, recreate 0");
 
     /* This one should fail */
     status = OS_QueueCreate(&msgq_1, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
-    /* UtDebug("Status after Creating q 0 again: %d,%d\n",status,msgq_1); */
     UtAssert_True(status != OS_SUCCESS, "OS_QueueCreate, dupe name 0");
 
     status = OS_QueueCreate(&msgq_2, "q 2", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
-    /* UtDebug("Status after Creating q 2: %d,%d\n",status,msgq_2); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate, recreate 2");
 
     status = OS_QueueCreate(&msgq_3, "q 3", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
-    /* UtDebug("Status after Creating q 3: %d,%d\n",status,msgq_3); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate, recreate 3");
 
     /*
@@ -349,19 +336,15 @@ void TestQueues(void)
     /* Time to Delete the Queues we just created */
 
     status = OS_QueueDelete(msgq_0);
-    /* UtDebug("Status after Deleting q 0 : %d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueDelete, q 0");
 
     status = OS_QueueDelete(msgq_1);
-    /* UtDebug("Status after Deleting q 1: %d\n",status); */
     UtAssert_True(status != OS_SUCCESS, "OS_QueueDelete, q 1");
 
     status = OS_QueueDelete(msgq_2);
-    /* UtDebug("Status after Deleting q 2: %d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueDelete, q 2");
 
     status = OS_QueueDelete(msgq_3);
-    /* UtDebug("Status after Deleting q 3: %d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueDelete, q 3");
 
 } /* end TestQueues */
@@ -404,35 +387,27 @@ void TestBinaries(void)
      */
     InitializeBinIds();
     status = OS_BinSemCreate(&bin_0, "Bin 0", OS_SEM_FULL, 0);
-    /* UtDebug("Status after creating: %d,%d\n",status,bin_0); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemCreate, recreate 0");
 
     status = OS_BinSemCreate(&bin_1, "Bin 0", OS_SEM_FULL, 0);
-    /* UtDebug("Status after creating: %d,%d\n",status,bin_1); */
     UtAssert_True(status != OS_SUCCESS, "OS_BinSemCreate, dupe name 0");
 
     status = OS_BinSemCreate(&bin_2, "Bin 2", OS_SEM_EMPTY, 0);
-    /* UtDebug("Status after creating: %d,%d\n",status,bin_2);  */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemCreate, recreate 2");
 
     status = OS_BinSemCreate(&bin_3, "Bin 3", OS_SEM_EMPTY, 0);
-    /* UtDebug("Status after creating: %d,%d\n",status,bin_3); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemCreate, recreate 3");
 
     status = OS_BinSemGetIdByName(&bin_0, "Bin 0");
-    /* UtDebug("Status after GETID: %d,%d\n",status,bin_0); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemGetIdByName, Bin 0");
 
     status = OS_BinSemGetIdByName(&bin_1, "Bin 1");
-    /* UtDebug("Status after GETID: %d,%d\n",status,bin_1); */
     UtAssert_True(status != OS_SUCCESS, "OS_BinSemGetIdByName, Bin 1");
 
     status = OS_BinSemGetIdByName(&bin_2, "Bin 2");
-    /* UtDebug("Status after GETID: %d,%d\n",status,bin_2); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemGetIdByName, Bin 2");
 
     status = OS_BinSemGetIdByName(&bin_3, "Bin 3");
-    /* UtDebug("Status after GETID: %d,%d\n",status,bin_3); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemGetIdByName, Bin 3");
 
     /*
@@ -442,12 +417,10 @@ void TestBinaries(void)
     UtAssert_True(status != OS_SUCCESS, "OS_BinSemDelete, Old ID");
 
     status = OS_BinSemDelete(bin_0);
-    /* UtDebug("Status after deleteing:%d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemDelete, Bin 0");
 
     /* this one was never created */
     status = OS_BinSemDelete(bin_1);
-    /* UtDebug("Status after deleteing:%d\n",status); */
     UtAssert_True(status != OS_SUCCESS, "OS_BinSemDelete, Bin 1");
 
     status = OS_BinSemDelete(bin_2);
@@ -496,19 +469,15 @@ void TestMutexes(void)
      */
     InitializeMutIds();
     status = OS_MutSemCreate(&mut_0, "Mut 0", 0);
-    /*  UtDebug("Status after creating Mut 0: %d,%d\n",status,mut_0);  */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemCreate, recreate 0");
 
     status = OS_MutSemCreate(&mut_1, "Mut 0", 0);
-    /*  UtDebug("Status after creating Mut 0 again: %d,%d\n",status,mut_1); */
     UtAssert_True(status != OS_SUCCESS, "OS_MutSemCreate, dupe name 0");
 
     status = OS_MutSemCreate(&mut_2, "Mut 2", 0);
-    /*  UtDebug("Status after creating Mut 2: %d,%d\n",status,mut_2); */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemCreate, recreate 2");
 
     status = OS_MutSemCreate(&mut_3, "Mut 3", 0);
-    /*  UtDebug("Status after creating Mut 3: %d,%d\n",status,mut_3); */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemCreate, recreate 3");
 
     status = OS_MutSemGetIdByName(&mut_0, "Mut 0");
@@ -530,20 +499,16 @@ void TestMutexes(void)
     UtAssert_True(status != OS_SUCCESS, "OS_MutSemDelete, Old ID");
 
     status = OS_MutSemDelete(mut_0);
-    /*  UtDebug("Status after deleteing Mut 0:%d\n",status);  */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemDelete, Mut 0");
 
     /* this one was never created*/
     status = OS_MutSemDelete(mut_1);
-    /*  UtDebug("Status after deleteing Mut 1:%d\n",status);  */
     UtAssert_True(status != OS_SUCCESS, "OS_MutSemDelete, Mut 1");
 
     status = OS_MutSemDelete(mut_2);
-    /*  UtDebug("Status after deleteing Mut 2:%d\n",status);  */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemDelete, Mut 2");
 
     status = OS_MutSemDelete(mut_3);
-    /*  UtDebug("Status after deleteing Mut 3:%d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemDelete, Mut 3");
 
 } /* end TestMutexes */
@@ -609,15 +574,12 @@ void TestGetInfos(void)
     UtAssert_True(status == OS_SUCCESS, "OS_TaskCreate");
 
     status = OS_QueueCreate(&msgq_0, "q 0", OSAL_BLOCKCOUNT_C(MSGQ_DEPTH), OSAL_SIZE_C(MSGQ_SIZE), 0);
-    /* UtDebug("Status after Creating q 0: %d,%d\n",status,msgq_0); */
     UtAssert_True(status == OS_SUCCESS, "OS_QueueCreate");
 
     status = OS_BinSemCreate(&bin_0, "Bin 0", 1, 0);
-    /* UtDebug("Status after creating: %d,%d\n",status,bin_0); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemCreate");
 
     status = OS_MutSemCreate(&mut_0, "Mut 0", 0);
-    /* UtDebug("Status after creating: %d,%d\n",status,mut_0); */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemCreate");
 
     /* Next Step is to get the properties of the objects */
@@ -639,14 +601,11 @@ void TestGetInfos(void)
 
     status = OS_QueueDelete(msgq_0);
     UtAssert_True(status == OS_SUCCESS, "OS_QueueDelete");
-    /* UtDebug("Status after Deleting q 0: %d\n",status); */
 
     status = OS_BinSemDelete(bin_0);
-    /* UtDebug("Status after deleteing:%d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_BinSemDelete");
 
     status = OS_MutSemDelete(mut_0);
-    /* UtDebug("Status after deleteing:%d\n",status); */
     UtAssert_True(status == OS_SUCCESS, "OS_MutSemDelete");
 }
 

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -735,7 +735,7 @@ void Test_OS_ConvertToArrayIndex(void)
      *
      */
     int32        expected = OS_SUCCESS;
-    int32        actual   = ~OS_SUCCESS; // OS_ConvertToArrayIndex();
+    int32        actual;
     osal_id_t    refobjid;
     osal_index_t local_idx;
 
@@ -1029,13 +1029,8 @@ void Test_OS_ObjectIdIterator(void)
 {
     /*
      * Test Case For:
-     * int32 OS_ObjectIdIteratorInit(OS_ObjectMatchFunc_t matchfunc, void *matcharg, osal_objtype_t objtype,
-                              OS_object_iter_t *iter);
-     * bool OS_ObjectFilterActive(void *ref, const OS_object_token_t *token, const OS_common_record_t *obj);
-     * int32 OS_ObjectIdIterateActive(osal_objtype_t objtype, OS_object_iter_t *iter);
-     * bool OS_ObjectIdIteratorGetNext(OS_object_iter_t *iter);
-     * void OS_ObjectIdIteratorDestroy(OS_object_iter_t *iter);
-     * int32 OS_ObjectIdIteratorProcessEntry(OS_object_iter_t *iter, int32 (*func)(osal_id_t, void *));
+     * OS_ObjectIdIteratorInit, OS_ObjectFilterActive, OS_ObjectIdIterateActive
+     * OS_ObjectIdIteratorGetNext, OS_ObjectIdIteratorDestroy, OS_ObjectIdIteratorProcessEntry
      */
     OS_object_iter_t iter;
     OS_common_record_t rec;

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -116,7 +116,7 @@ void UT_os_initfs_test()
     /*-----------------------------------------------------*/
     testDesc = "#2 Nominal";
 
-    /* Call to OS_FS_Init() is inside OS_API_Init(); */
+    /* Call to OS_FS_Init is inside OS_API_Init */
     res = OS_API_Init();
     if (res == OS_ERR_NOT_IMPLEMENTED)
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #785 - cleans commented out code (all from test code)

**Testing performed**
Build/execute unit test, passes

**Expected behavior changes**
None, just avoids static analysis warnings

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Would really benefit from ASSERT macro in cFE... maybe consider moving/consolidating these general macros?  Almost all the debug code that was commented out would be better replaced by ASSERT.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC