### PR TITLE
Fix #788, Resolve coercion alters value warnings

### DIFF
--- a/src/os/shared/src/osapi-errors.c
+++ b/src/os/shared/src/osapi-errors.c
@@ -98,7 +98,7 @@ static const OS_ErrorTable_Entry_t OS_GLOBAL_ERROR_NAME_TABLE[] = {
  *-----------------------------------------------------------------*/
 int32 OS_GetErrorName(int32 error_num, os_err_name_t *err_name)
 {
-    uint32                       return_code;
+    int32                        return_code;
     const OS_ErrorTable_Entry_t *Error;
 
     OS_CHECK_POINTER(err_name);

--- a/src/os/shared/src/osapi-network.c
+++ b/src/os/shared/src/osapi-network.c
@@ -65,7 +65,7 @@ int32 OS_NetworkAPI_Init(void)
  *-----------------------------------------------------------------*/
 int32 OS_NetworkGetHostName(char *host_name, size_t name_len)
 {
-    uint32 return_code;
+    int32 return_code;
 
     /* Check parameters */
     OS_CHECK_POINTER(host_name);


### PR DESCRIPTION
**Describe the contribution**
Fix #788 - fixed two locations with local return code defined as uint32, should be int32 (or eventually the status type)

**Testing performed**
Build and execute unit tests, passed

**Expected behavior changes**
No functional change, just resolves warnings

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
Static analysis warning

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC