### PR TITLE
Fix #790, Return status from OS_ConsoleAPI_Init

### DIFF
--- a/src/os/shared/src/osapi-printf.c
+++ b/src/os/shared/src/osapi-printf.c
@@ -111,7 +111,7 @@ int32 OS_ConsoleAPI_Init(void)
         OS_SharedGlobalVars.PrintfEnabled = true;
     }
 
-    return OS_SUCCESS;
+    return return_code;
 } /* end OS_ConsoleAPI_Init */
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Fix #790 - now returning status from OS_ConsoleAPI_Init so debug warnings will get reported correctly on errors

**Testing performed**
Build and executed unit tests, passed (note the OS_ConsoleAPI_Init test does not check status)

**Expected behavior changes**
Will send debug message on error

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
See #791 to add full branch coverage to unit tests w/ return checking

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC