### PR TITLE
Fix #779, Change global vars to not be hidden by local vars.

### DIFF
--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -68,7 +68,7 @@ int counter = 0;
  *
  * On RTEMS even a call to BinSemGetInfo has very ill effects.
  */
-void TimerFunction(osal_id_t timer_id)
+void TimerFunction(osal_id_t local_timer_id)
 {
     int32 status;
 

--- a/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
+++ b/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
@@ -64,7 +64,7 @@ int counter = 0;
  *
  * On RTEMS even a call to BinSemGetInfo has very ill effects.
  */
-void TimerFunction(osal_id_t timer_id)
+void TimerFunction(osal_id_t local_timer_id)
 {
     int32 status;
 

--- a/src/tests/queue-test/queue-test.c
+++ b/src/tests/queue-test/queue-test.c
@@ -58,7 +58,7 @@ uint32    timer_start    = 10000;
 uint32    timer_interval = 100000; /* 1000 = 1000 hz, 10000 == 100 hz */
 uint32    timer_accuracy;
 
-void TimerFunction(osal_id_t timer_id)
+void TimerFunction(osal_id_t local_timer_id)
 {
     timer_counter++;
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #779 
Rename global timer_id to local_timer_Id

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC