### PR TITLE
Fix #796, Update os-impl-no-sockets.c to match APIs

### DIFF
--- a/src/os/portable/os-impl-no-sockets.c
+++ b/src/os/portable/os-impl-no-sockets.c
@@ -42,157 +42,124 @@
  ***************************************************************************************/
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketOpen_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketOpen_Impl(uint32 sock_id)
+int32 OS_SocketOpen_Impl(const OS_object_token_t *token)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketOpen_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketBind_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr)
+int32 OS_SocketBind_Impl(const OS_object_token_t *token, const OS_SockAddr_t *Addr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketBind_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketConnect_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 timeout)
+int32 OS_SocketConnect_Impl(const OS_object_token_t *token, const OS_SockAddr_t *Addr, int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketConnect_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAccept_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Addr, int32 timeout)
+int32 OS_SocketAccept_Impl(const OS_object_token_t *sock_token, const OS_object_token_t *conn_token,
+                           OS_SockAddr_t *Addr, int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAccept_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketRecvFrom_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
+int32 OS_SocketRecvFrom_Impl(const OS_object_token_t *token, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr,
+                             int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketRecvFrom_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketSendTo_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr)
+int32 OS_SocketSendTo_Impl(const OS_object_token_t *token, const void *buffer, size_t buflen,
+                           const OS_SockAddr_t *RemoteAddr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketSendTo_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketGetInfo_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketGetInfo_Impl(uint32 sock_id, OS_socket_prop_t *sock_prop)
+int32 OS_SocketGetInfo_Impl(const OS_object_token_t *token, OS_socket_prop_t *sock_prop)
 {
     return OS_SUCCESS;
-} /* end OS_SocketGetInfo_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrInit_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrInit_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrToString_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketAddrToString_Impl(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr)
+int32 OS_SocketAddrToString_Impl(char *buffer, size_t buflen, const OS_SockAddr_t *Addr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrToString_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrFromString_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrFromString_Impl(OS_SockAddr_t *Addr, const char *string)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrFromString_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrGetPort_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrGetPort_Impl(uint16 *PortNum, const OS_SockAddr_t *Addr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrGetPort_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrSetPort_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrSetPort_Impl(OS_SockAddr_t *Addr, uint16 PortNum)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrSetPort_Impl */
+}


### PR DESCRIPTION
**Describe the contribution**
Fix #796 - updates os-impl-no-sockets.c to match latest APIs

**Testing performed**
Builds.

**Expected behavior changes**
Now can build without network (OSAL_CONFIG_INCLUDE_NETWORK FALSE)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC