### PR TITLE
Fix #797, Update os-impl-no-symtab.c to match APIs

### DIFF
--- a/src/os/portable/os-impl-no-symtab.c
+++ b/src/os/portable/os-impl-no-symtab.c
@@ -31,43 +31,34 @@
 #include "os-shared-module.h"
 
 /*----------------------------------------------------------------
+ * Implementation for no dynamic loader configuration
  *
- * Function: OS_GlobalSymbolLookup_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_GlobalSymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 
-} /* end OS_GlobalSymbolLookup_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no dynamic loader configuration
  *
- * Function: OS_ModuleSymbolLookup_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_ModuleSymbolLookup_Impl(uint32 local_id, cpuaddr *SymbolAddress, const char *SymbolName)
+int32 OS_ModuleSymbolLookup_Impl(const OS_object_token_t *token, cpuaddr *SymbolAddress, const char *SymbolName)
 {
     return OS_ERR_NOT_IMPLEMENTED;
 
-} /* end OS_ModuleSymbolLookup_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no dynamic loader configuration
  *
- * Function: OS_SymbolTableDump_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SymbolTableDump_Impl(const char *filename, size_t SizeLimit)
 {
     return (OS_ERR_NOT_IMPLEMENTED);
 
-} /* end OS_SymbolTableDump_Impl */
+}


### PR DESCRIPTION
**Describe the contribution**
Fix #797 - updates os-impl-no-symtab.c to match latest APIs

**Testing performed**
Builds.

**Expected behavior changes**
Now can build without dynamic loader (OSAL_CONFIG_INCLUDE_DYNAMIC_LOADER FALSE)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC