### PR TITLE
Fix #793, Remove unreachable code in OS_SocketOpen_Impl for BSD socket

### DIFF
--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -126,23 +126,14 @@ int32 OS_SocketOpen_Impl(const OS_object_token_t *token)
             return OS_ERR_NOT_IMPLEMENTED;
     }
 
-    switch (stream->socket_domain)
+    /* Only AF_INET* at this point, can add cases if support is expanded */
+    switch (stream->socket_type)
     {
-        case OS_SocketDomain_INET:
-        case OS_SocketDomain_INET6:
-            switch (stream->socket_type)
-            {
-                case OS_SocketType_DATAGRAM:
-                    os_proto = IPPROTO_UDP;
-                    break;
-                case OS_SocketType_STREAM:
-                    os_proto = IPPROTO_TCP;
-                    break;
-                default:
-                    break;
-            }
+        case OS_SocketType_DATAGRAM:
+            os_proto = IPPROTO_UDP;
             break;
-        default:
+        case OS_SocketType_STREAM:
+            os_proto = IPPROTO_TCP;
             break;
     }
 


### PR DESCRIPTION
**Describe the contribution**
Fix #793, Just simplifies switch statements based on previous checks.  Can always be expanded again if additional cases are implemented.

**Testing performed**
Build and execute unit tests, passed

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
Static analysis warning fix

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC