### PR TITLE
Fix #803, Add check of semaphore to avoid unreachable code in posix OS_BinSemCreate_Impl

### DIFF
--- a/src/os/posix/src/os-impl-binsem.c
+++ b/src/os/posix/src/os-impl-binsem.c
@@ -199,6 +199,17 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
         cond_created = 1;
 
         /*
+         * Check sem call, avoids unreachable destroy logic
+         */
+        ret = pthread_cond_signal(&(sem->cv));
+        if (ret != 0)
+        {
+            OS_DEBUG("Error: initial pthread_cond_signal failed: %s\n", strerror(ret));
+            return_code = OS_SEM_FAILURE;
+            break;
+        }
+
+        /*
          ** fill out the proper OSAL table fields
          */
 


### PR DESCRIPTION
**Describe the contribution**
Fix #803 - adds a check to send the semaphore to avoid unreachable code, basically a non-op placeholder to avoid refactoring unreachable code which would make it less future-proof

**Testing performed**
Build and execute unit tests, passed

**Expected behavior changes**
None, avoids static analysis warning and uncoverable code

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
Eventually when coverage is added to posix this will help meet the 100% goal

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC