### PR TITLE
Fix #805, Null terminate when using strncpy

### DIFF
--- a/src/os/portable/os-impl-no-sockets.c
+++ b/src/os/portable/os-impl-no-sockets.c
@@ -42,157 +42,124 @@
  ***************************************************************************************/
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketOpen_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketOpen_Impl(uint32 sock_id)
+int32 OS_SocketOpen_Impl(const OS_object_token_t *token)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketOpen_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketBind_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketBind_Impl(uint32 sock_id, const OS_SockAddr_t *Addr)
+int32 OS_SocketBind_Impl(const OS_object_token_t *token, const OS_SockAddr_t *Addr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketBind_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketConnect_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketConnect_Impl(uint32 sock_id, const OS_SockAddr_t *Addr, int32 timeout)
+int32 OS_SocketConnect_Impl(const OS_object_token_t *token, const OS_SockAddr_t *Addr, int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketConnect_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAccept_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketAccept_Impl(uint32 sock_id, uint32 connsock_id, OS_SockAddr_t *Addr, int32 timeout)
+int32 OS_SocketAccept_Impl(const OS_object_token_t *sock_token, const OS_object_token_t *conn_token,
+                           OS_SockAddr_t *Addr, int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAccept_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketRecvFrom_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketRecvFrom_Impl(uint32 sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr, int32 timeout)
+int32 OS_SocketRecvFrom_Impl(const OS_object_token_t *token, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr,
+                             int32 timeout)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketRecvFrom_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketSendTo_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketSendTo_Impl(uint32 sock_id, const void *buffer, size_t buflen, const OS_SockAddr_t *RemoteAddr)
+int32 OS_SocketSendTo_Impl(const OS_object_token_t *token, const void *buffer, size_t buflen,
+                           const OS_SockAddr_t *RemoteAddr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketSendTo_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketGetInfo_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketGetInfo_Impl(uint32 sock_id, OS_socket_prop_t *sock_prop)
+int32 OS_SocketGetInfo_Impl(const OS_object_token_t *token, OS_socket_prop_t *sock_prop)
 {
     return OS_SUCCESS;
-} /* end OS_SocketGetInfo_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrInit_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrInit_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrToString_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
-int32 OS_SocketAddrToString_Impl(char *buffer, uint32 buflen, const OS_SockAddr_t *Addr)
+int32 OS_SocketAddrToString_Impl(char *buffer, size_t buflen, const OS_SockAddr_t *Addr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrToString_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrFromString_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrFromString_Impl(OS_SockAddr_t *Addr, const char *string)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrFromString_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrGetPort_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrGetPort_Impl(uint16 *PortNum, const OS_SockAddr_t *Addr)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrGetPort_Impl */
+}
 
 /*----------------------------------------------------------------
+ * Implementation for no network configuration
  *
- * Function: OS_SocketAddrSetPort_Impl
- *
- *  Purpose: Implemented per internal OSAL API
- *           See prototype for argument/return detail
- *
+ * See prototype for argument/return detail
  *-----------------------------------------------------------------*/
 int32 OS_SocketAddrSetPort_Impl(OS_SockAddr_t *Addr, uint16 PortNum)
 {
     return OS_ERR_NOT_IMPLEMENTED;
-} /* end OS_SocketAddrSetPort_Impl */
+}

--- a/src/os/shared/src/osapi-binsem.c
+++ b/src/os/shared/src/osapi-binsem.c
@@ -289,7 +289,7 @@ int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_bin_sem_table, token);
 
-        strncpy(bin_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(bin_prop->name, record->name_entry, sizeof(bin_prop->name) - 1);
         bin_prop->creator = record->creator;
         return_code       = OS_BinSemGetInfo_Impl(&token, bin_prop);
 

--- a/src/os/shared/src/osapi-countsem.c
+++ b/src/os/shared/src/osapi-countsem.c
@@ -258,7 +258,7 @@ int32 OS_CountSemGetInfo(osal_id_t sem_id, OS_count_sem_prop_t *count_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_count_sem_table, token);
 
-        strncpy(count_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(count_prop->name, record->name_entry, sizeof(count_prop->name) - 1);
         count_prop->creator = record->creator;
 
         return_code = OS_CountSemGetInfo_Impl(&token, count_prop);

--- a/src/os/shared/src/osapi-errors.c
+++ b/src/os/shared/src/osapi-errors.c
@@ -121,7 +121,8 @@ int32 OS_GetErrorName(int32 error_num, os_err_name_t *err_name)
 
     if (Error->Number == error_num && Error->Name != NULL)
     {
-        strncpy(*err_name, Error->Name, OS_ERROR_NAME_LENGTH - 1);
+        strncpy(*err_name, Error->Name, sizeof(*err_name) - 1);
+        *err_name[sizeof(*err_name) - 1] = 0;
         return_code = OS_SUCCESS;
     }
     else

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -475,7 +475,8 @@ int32 OS_rename(const char *old, const char *new)
 
             if (stream->socket_domain == OS_SocketDomain_INVALID && strcmp(stream->stream_name, old) == 0)
             {
-                strcpy(stream->stream_name, new);
+                strncpy(stream->stream_name, new, sizeof(stream->stream_name) - 1);
+                stream->stream_name[sizeof(stream->stream_name) - 1] = 0;
             }
         }
 
@@ -606,7 +607,7 @@ int32 OS_FDGetInfo(osal_id_t filedes, OS_file_prop_t *fd_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_stream_table, token);
 
-        strncpy(fd_prop->Path, record->name_entry, OS_MAX_PATH_LEN - 1);
+        strncpy(fd_prop->Path, record->name_entry, sizeof(fd_prop->Path) - 1);
         fd_prop->User    = record->creator;
         fd_prop->IsValid = true;
 

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -152,7 +152,7 @@ int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fs
         filesys->blocksize = blocksize;
         filesys->numblocks = numblocks;
         filesys->address   = address;
-        strcpy(filesys->volume_name, fsvolname);
+        strncpy(filesys->volume_name, fsvolname, sizeof(filesys->volume_name) - 1);
 
         /*
          * Determine basic type of filesystem, if not already known
@@ -461,7 +461,8 @@ int32 OS_mount(const char *devname, const char *mountpoint)
             /* mark as mounted in the local table.
              * For now this does both sides (system and virtual) */
             filesys->flags |= OS_FILESYS_FLAG_IS_MOUNTED_SYSTEM | OS_FILESYS_FLAG_IS_MOUNTED_VIRTUAL;
-            strcpy(filesys->virtual_mountpt, mountpoint);
+            strncpy(filesys->virtual_mountpt, mountpoint, sizeof(filesys->virtual_mountpt) - 1);
+            filesys->virtual_mountpt[sizeof(filesys->virtual_mountpt) - 1] = 0;
         }
 
         OS_ObjectIdRelease(&token);

--- a/src/os/shared/src/osapi-module.c
+++ b/src/os/shared/src/osapi-module.c
@@ -255,7 +255,7 @@ int32 OS_ModuleLoad(osal_id_t *module_id, const char *module_name, const char *f
             else
             {
                 /* supplied filename was valid, so store a copy for future reference */
-                strncpy(module->file_name, filename, OS_MAX_PATH_LEN);
+                strncpy(module->file_name, filename, sizeof(module->file_name) - 1);
                 module->module_type = OS_MODULE_TYPE_DYNAMIC;
 
                 /* Now call the OS-specific implementation.  This reads info from the module table. */
@@ -333,8 +333,8 @@ int32 OS_ModuleInfo(osal_id_t module_id, OS_module_prop_t *module_prop)
         record = OS_OBJECT_TABLE_GET(OS_global_module_table, token);
         module = OS_OBJECT_TABLE_GET(OS_module_table, token);
 
-        strncpy(module_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
-        strncpy(module_prop->filename, module->file_name, OS_MAX_API_NAME - 1);
+        strncpy(module_prop->name, record->name_entry, sizeof(module_prop->name) - 1);
+        strncpy(module_prop->filename, module->file_name, sizeof(module_prop->filename) - 1);
 
         return_code = OS_ModuleGetInfo_Impl(&token, module_prop);
 

--- a/src/os/shared/src/osapi-mutex.c
+++ b/src/os/shared/src/osapi-mutex.c
@@ -272,7 +272,7 @@ int32 OS_MutSemGetInfo(osal_id_t sem_id, OS_mut_sem_prop_t *mut_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_mutex_table, token);
 
-        strncpy(mut_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(mut_prop->name, record->name_entry, sizeof(mut_prop->name) - 1);
         mut_prop->creator = record->creator;
 
         return_code = OS_MutSemGetInfo_Impl(&token, mut_prop);

--- a/src/os/shared/src/osapi-queue.c
+++ b/src/os/shared/src/osapi-queue.c
@@ -272,7 +272,7 @@ int32 OS_QueueGetInfo(osal_id_t queue_id, OS_queue_prop_t *queue_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_queue_table, token);
 
-        strncpy(queue_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(queue_prop->name, record->name_entry, sizeof(queue_prop->name) - 1);
         queue_prop->creator = record->creator;
 
         /*

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -477,7 +477,7 @@ int32 OS_SocketGetInfo(osal_id_t sock_id, OS_socket_prop_t *sock_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_stream_table, token);
 
-        strncpy(sock_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(sock_prop->name, record->name_entry, sizeof(sock_prop->name) - 1);
         sock_prop->creator = record->creator;
         return_code        = OS_SocketGetInfo_Impl(&token, sock_prop);
 

--- a/src/os/shared/src/osapi-time.c
+++ b/src/os/shared/src/osapi-time.c
@@ -538,7 +538,7 @@ int32 OS_TimerGetInfo(osal_id_t timer_id, OS_timer_prop_t *timer_prop)
         timecb   = OS_OBJECT_TABLE_GET(OS_timecb_table, token);
         timebase = OS_OBJECT_TABLE_GET(OS_timebase_table, timecb->timebase_token);
 
-        strncpy(timer_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(timer_prop->name, record->name_entry, sizeof(timer_prop->name) - 1);
         timer_prop->creator       = record->creator;
         timer_prop->interval_time = (uint32)timecb->interval_time;
         timer_prop->accuracy      = timebase->accuracy_usec;

--- a/src/os/shared/src/osapi-timebase.c
+++ b/src/os/shared/src/osapi-timebase.c
@@ -319,7 +319,7 @@ int32 OS_TimeBaseGetInfo(osal_id_t timebase_id, OS_timebase_prop_t *timebase_pro
         record   = OS_OBJECT_TABLE_GET(OS_global_timebase_table, token);
         timebase = OS_OBJECT_TABLE_GET(OS_timebase_table, token);
 
-        strncpy(timebase_prop->name, record->name_entry, OS_MAX_API_NAME - 1);
+        strncpy(timebase_prop->name, record->name_entry, sizeof(timebase_prop->name) - 1);
         timebase_prop->creator               = record->creator;
         timebase_prop->nominal_interval_time = timebase->nominal_interval_time;
         timebase_prop->freerun_time          = timebase->freerun_time;

--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -196,7 +196,8 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
     /*
     ** Copy symbol name
     */
-    strncpy(symRecord.SymbolName, name, OS_MAX_SYM_LEN);
+    strncpy(symRecord.SymbolName, name, sizeof(symRecord.SymbolName) - 1);
+    symRecord.SymbolName[sizeof(symRecord.SymbolName) - 1] = 0;
 
     /*
     ** Save symbol address

--- a/src/ut-stubs/osapi-utstub-binsem.c
+++ b/src/ut-stubs/osapi-utstub-binsem.c
@@ -197,8 +197,8 @@ int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
         UT_Stub_CopyToLocal(UT_KEY(OS_BinSemGetInfo), bin_prop, sizeof(*bin_prop)) < sizeof(*bin_prop))
     {
         UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &bin_prop->creator);
-        strncpy(bin_prop->name, "Name", OS_MAX_API_NAME - 1);
-        bin_prop->name[OS_MAX_API_NAME - 1] = '\0';
+        strncpy(bin_prop->name, "Name", sizeof(bin_prop->name) - 1);
+        bin_prop->name[sizeof(bin_prop->name) - 1] = '\0';
     }
 
     return status;

--- a/src/ut-stubs/osapi-utstub-countsem.c
+++ b/src/ut-stubs/osapi-utstub-countsem.c
@@ -202,8 +202,8 @@ int32 OS_CountSemGetInfo(osal_id_t sem_id, OS_count_sem_prop_t *count_prop)
         UT_Stub_CopyToLocal(UT_KEY(OS_CountSemGetInfo), count_prop, sizeof(*count_prop)) < sizeof(*count_prop))
     {
         UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &count_prop->creator);
-        strncpy(count_prop->name, "Name", OS_MAX_API_NAME - 1);
-        count_prop->name[OS_MAX_API_NAME - 1] = '\0';
+        strncpy(count_prop->name, "Name", sizeof(count_prop->name) - 1);
+        count_prop->name[sizeof(count_prop->name) - 1] = '\0';
     }
 
     return status;

--- a/src/ut-stubs/osapi-utstub-filesys.c
+++ b/src/ut-stubs/osapi-utstub-filesys.c
@@ -249,7 +249,8 @@ int32 OS_FS_GetPhysDriveName(char *PhysDriveName, const char *MountPoint)
     int32 status;
 
     status = UT_DEFAULT_IMPL(OS_FS_GetPhysDriveName);
-    strncpy(PhysDriveName, MountPoint, OS_FS_PHYS_NAME_LEN);
+    strncpy(PhysDriveName, MountPoint, OS_FS_PHYS_NAME_LEN - 1);
+    PhysDriveName[OS_FS_PHYS_NAME_LEN - 1] = 0;
 
     return status;
 }
@@ -288,7 +289,8 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
     if (status == OS_SUCCESS && VirtualPath != NULL && LocalPath != NULL &&
         UT_Stub_CopyToLocal(UT_KEY(OS_TranslatePath), LocalPath, OS_MAX_LOCAL_PATH_LEN) == 0)
     {
-        strncpy(LocalPath, VirtualPath, OS_MAX_LOCAL_PATH_LEN);
+        strncpy(LocalPath, VirtualPath, OS_MAX_LOCAL_PATH_LEN - 1);
+        LocalPath[OS_MAX_LOCAL_PATH_LEN - 1] = 0;
     }
 
     return status;

--- a/src/ut-stubs/osapi-utstub-mutex.c
+++ b/src/ut-stubs/osapi-utstub-mutex.c
@@ -229,8 +229,8 @@ int32 OS_MutSemGetInfo(osal_id_t sem_id, OS_mut_sem_prop_t *mut_prop)
     if (status == OS_SUCCESS &&
         UT_Stub_CopyToLocal(UT_KEY(OS_MutSemGetInfo), mut_prop, sizeof(*mut_prop)) < sizeof(*mut_prop))
     {
-        strncpy(mut_prop->name, "Name", OS_MAX_API_NAME - 1);
-        mut_prop->name[OS_MAX_API_NAME - 1] = '\0';
+        strncpy(mut_prop->name, "Name", sizeof(mut_prop->name) - 1);
+        mut_prop->name[sizeof(mut_prop->name) - 1] = '\0';
         UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &mut_prop->creator);
     }
 

--- a/src/ut-stubs/osapi-utstub-queue.c
+++ b/src/ut-stubs/osapi-utstub-queue.c
@@ -270,8 +270,8 @@ int32 OS_QueueGetInfo(osal_id_t queue_id, OS_queue_prop_t *queue_prop)
         UT_Stub_CopyToLocal(UT_KEY(OS_QueueGetInfo), queue_prop, sizeof(*queue_prop)) < sizeof(*queue_prop))
     {
         UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &queue_prop->creator);
-        strncpy(queue_prop->name, "Name", OS_MAX_API_NAME - 1);
-        queue_prop->name[OS_MAX_API_NAME - 1] = '\0';
+        strncpy(queue_prop->name, "Name", sizeof(queue_prop->name) - 1);
+        queue_prop->name[sizeof(queue_prop->name) - 1] = '\0';
     }
 
     return status;

--- a/src/ut-stubs/osapi-utstub-sockets.c
+++ b/src/ut-stubs/osapi-utstub-sockets.c
@@ -237,7 +237,8 @@ int32 OS_SocketGetInfo(osal_id_t sock_id, OS_socket_prop_t *sock_prop)
         if (CopySize < sizeof(*sock_prop))
         {
             UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &sock_prop->creator);
-            strncpy(sock_prop->name, "ut", sizeof(sock_prop->name));
+            strncpy(sock_prop->name, "ut", sizeof(sock_prop->name) - 1);
+            sock_prop->name[sizeof(sock_prop->name) - 1] = 0;
         }
     }
 

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -284,8 +284,8 @@ int32 OS_TaskGetInfo(osal_id_t task_id, OS_task_prop_t *task_prop)
         UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &task_prop->creator);
         task_prop->stack_size = OSAL_SIZE_C(100);
         task_prop->priority   = OSAL_PRIORITY_C(150);
-        strncpy(task_prop->name, "UnitTest", OS_MAX_API_NAME - 1);
-        task_prop->name[OS_MAX_API_NAME - 1] = '\0';
+        strncpy(task_prop->name, "UnitTest", sizeof(task_prop->name) - 1);
+        task_prop->name[sizeof(task_prop->name) - 1] = '\0';
     }
 
     return status;

--- a/src/ut-stubs/osapi-utstub-timebase.c
+++ b/src/ut-stubs/osapi-utstub-timebase.c
@@ -144,8 +144,8 @@ int32 OS_TimeBaseGetInfo(osal_id_t timebase_id, OS_timebase_prop_t *timebase_pro
         UT_Stub_CopyToLocal(UT_KEY(OS_TimeBaseGetInfo), timebase_prop, sizeof(*timebase_prop)) < sizeof(*timebase_prop))
     {
         UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &timebase_prop->creator);
-        strncpy(timebase_prop->name, "Name", OS_MAX_API_NAME - 1);
-        timebase_prop->name[OS_MAX_API_NAME - 1] = '\0';
+        strncpy(timebase_prop->name, "Name", sizeof(timebase_prop->name) - 1);
+        timebase_prop->name[sizeof(timebase_prop->name) - 1] = '\0';
     }
 
     return status;


### PR DESCRIPTION
**Describe the contribution**
Fix #805 - fixed a couple missing null terminations and applied the general pattern (sizeof where it works)

**Testing performed**
Build and execute unit tests

**Expected behavior changes**
Avoid missing null termination issues, no longer truncating filename in OS_ModuleInfo (src/os/shared/src/osapi-module.c)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC