### PR TITLE
Fix #808, length-limited string length checks

### DIFF
--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -128,4 +128,28 @@ void OS_IdleLoop_Impl(void);
  ------------------------------------------------------------------*/
 void OS_ApplicationShutdown_Impl(void);
 
+
+/*----------------------------------------------------------------
+
+   Function: OS_strnlen
+
+    Purpose: Utility function to safely find the length of a string
+             within a fixed-size array buffer.
+
+             Provides a local OSAL routine to get the functionality
+             of the (non-C99) "strnlen()" function, via the 
+             C89/C99 standard "memchr()" function instead.
+    
+ ------------------------------------------------------------------*/
+static inline size_t OS_strnlen(const char *s, size_t maxlen)
+{
+    const char *end = memchr(s, 0, maxlen);
+    if (end != NULL)
+    {
+        /* actual length of string is difference */
+        maxlen = end - s;
+    }
+    return maxlen;
+}
+
 #endif  /* OS_SHARED_COMMON_H  */

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -42,6 +42,7 @@
  */
 #include "os-shared-filesys.h"
 #include "os-shared-idmap.h"
+#include "os-shared-common.h"
 
 enum
 {
@@ -102,8 +103,9 @@ bool OS_FileSys_FindVirtMountPoint(void *ref, const OS_object_token_t *token, co
         return false;
     }
 
-    mplen = strlen(filesys->virtual_mountpt);
-    return (mplen > 0 && strncmp(target, filesys->virtual_mountpt, mplen) == 0 &&
+    mplen = OS_strnlen(filesys->virtual_mountpt, sizeof(filesys->virtual_mountpt));
+    return (mplen > 0 && mplen < sizeof(filesys->virtual_mountpt) &&
+            strncmp(target, filesys->virtual_mountpt, mplen) == 0 &&
             (target[mplen] == '/' || target[mplen] == 0));
 } /* end OS_FileSys_FindVirtMountPoint */
 
@@ -257,7 +259,7 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
         ++dev_name;
     }
 
-    if (strlen(dev_name) >= OS_FS_DEV_NAME_LEN)
+    if (memchr(dev_name,0,sizeof(filesys->volume_name)) == NULL)
     {
         return OS_ERR_NAME_TOO_LONG;
     }
@@ -793,7 +795,7 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
     /*
     ** Check length
     */
-    VirtPathLen = strlen(VirtualPath);
+    VirtPathLen = OS_strnlen(VirtualPath, OS_MAX_PATH_LEN);
     if (VirtPathLen >= OS_MAX_PATH_LEN)
     {
         return OS_FS_ERR_PATH_TOO_LONG;
@@ -808,7 +810,7 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
 
     /* strrchr returns a pointer to the last '/' char, so we advance one char */
     name_ptr = name_ptr + 1;
-    if (strlen(name_ptr) >= OS_MAX_FILE_NAME)
+    if (memchr(name_ptr, 0, OS_MAX_FILE_NAME) == NULL)
     {
         return OS_FS_ERR_NAME_TOO_LONG;
     }
@@ -838,8 +840,8 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
 
         if ((filesys->flags & OS_FILESYS_FLAG_IS_MOUNTED_SYSTEM) != 0)
         {
-            SysMountPointLen = strlen(filesys->system_mountpt);
-            VirtPathBegin    = strlen(filesys->virtual_mountpt);
+            SysMountPointLen = OS_strnlen(filesys->system_mountpt, sizeof(filesys->system_mountpt));
+            VirtPathBegin    = OS_strnlen(filesys->virtual_mountpt, sizeof(filesys->virtual_mountpt));
             if (SysMountPointLen < OS_MAX_LOCAL_PATH_LEN)
             {
                 memcpy(LocalPath, filesys->system_mountpt, SysMountPointLen);

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -1501,7 +1501,7 @@ int32 OS_GetResourceName(osal_id_t object_id, char *buffer, size_t buffer_size)
 
         if (record->name_entry != NULL)
         {
-            name_len = strlen(record->name_entry);
+            name_len = OS_strnlen(record->name_entry, buffer_size);
             if (buffer_size <= name_len)
             {
                 /* indicates the name does not fit into supplied buffer */

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -42,6 +42,7 @@
 #include "os-shared-idmap.h"
 #include "os-shared-file.h"
 #include "os-shared-sockets.h"
+#include "os-shared-common.h"
 
 /*
  * Other OSAL public APIs used by this module
@@ -104,7 +105,7 @@ void OS_CreateSocketName(const OS_object_token_t *token, const OS_SockAddr_t *Ad
     }
     if (OS_SocketAddrGetPort_Impl(&port, Addr) == OS_SUCCESS)
     {
-        len = strlen(sock->stream_name);
+        len = OS_strnlen(sock->stream_name, sizeof(sock->stream_name));
         snprintf(&sock->stream_name[len], OS_MAX_API_NAME - len, ":%u", (unsigned int)port);
     }
     sock->stream_name[OS_MAX_API_NAME - 1] = 0;
@@ -112,7 +113,7 @@ void OS_CreateSocketName(const OS_object_token_t *token, const OS_SockAddr_t *Ad
     if (parent_name)
     {
         /* Append the name from the parent socket. */
-        len = strlen(sock->stream_name);
+        len = OS_strnlen(sock->stream_name, sizeof(sock->stream_name));
         snprintf(&sock->stream_name[len], sizeof(sock->stream_name) - len, "-%s", parent_name);
         sock->stream_name[sizeof(sock->stream_name) - 1] = 0;
     }

--- a/src/os/vxworks/src/os-impl-shell.c
+++ b/src/os/vxworks/src/os-impl-shell.c
@@ -34,6 +34,7 @@
 #include "os-shared-shell.h"
 #include "os-shared-file.h"
 #include "os-shared-idmap.h"
+#include "os-shared-common.h"
 
 #include <shellLib.h>
 #include <taskLib.h>
@@ -78,7 +79,7 @@ int32 OS_ShellOutputToFile_Impl(const OS_object_token_t *token, const char *Cmd)
         cmd_impl = OS_OBJECT_TABLE_GET(OS_impl_filehandle_table, cmd_token);
 
         /* copy the command to the file, and then seek back to the beginning of the file */
-        OS_write(fdCmd, Cmd, strlen(Cmd));
+        OS_write(fdCmd, Cmd, OS_strnlen(Cmd, OS_MAX_CMD_LEN));
         OS_lseek(fdCmd, 0, OS_SEEK_SET);
 
         /* Create a shell task the will run the command in the file, push output to OS_fd */

--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -172,7 +172,7 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
      */
     state = &OS_VxWorks_SymbolDumpState;
 
-    if (strlen(name) >= OS_MAX_SYM_LEN)
+    if (memchr(name, 0, OS_MAX_SYM_LEN) == NULL)
     {
         OS_DEBUG("%s(): symbol name too long\n", __func__);
         state->StatusCode = OS_ERROR;

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -62,12 +62,11 @@ void Test_OS_FileSysAddFixedMap(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_FS_ERR_PATH_TOO_LONG);
     UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 2, OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_FS_ERR_PATH_TOO_LONG);
-    UT_ResetState(UT_KEY(OCS_strlen));
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_strrchr), -1);
-    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 1, 2 + OS_FS_DEV_NAME_LEN);
+    UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 3, OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_ERR_NAME_TOO_LONG);
-    UT_ResetState(UT_KEY(OCS_strlen));
+    UT_ResetState(UT_KEY(OCS_memchr));
     UT_ResetState(UT_KEY(OCS_strrchr));
 
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_SUCCESS);
@@ -431,18 +430,18 @@ void Test_OS_TranslatePath(void)
     actual   = OS_TranslatePath(NULL, NULL);
     UtAssert_True(actual == expected, "OS_TranslatePath(NULL,NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
 
-    UT_SetDefaultReturnValue(UT_KEY(OCS_strlen), OS_MAX_PATH_LEN + 10);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);
-    UT_ClearDefaultReturnValue(UT_KEY(OCS_strlen));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 
     /* Invalid no '/' */
     expected = OS_FS_ERR_PATH_INVALID;
     actual   = OS_TranslatePath("invalid", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
 
-    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 2, OS_MAX_FILE_NAME + 1);
+    UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 2, OS_ERROR);
     expected = OS_FS_ERR_NAME_TOO_LONG;
     actual   = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath(/cf/test) (%ld) == OS_FS_ERR_NAME_TOO_LONG", (long)actual);
@@ -458,13 +457,13 @@ void Test_OS_TranslatePath(void)
     UT_ClearDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch));
 
     /* VirtPathLen < VirtPathBegin */
-    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 4, OS_MAX_PATH_LEN);
+    UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 4, OS_ERROR);
     expected = OS_FS_ERR_PATH_INVALID;
     actual   = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath(/cf/test) (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
 
     /* (SysMountPointLen + VirtPathLen) > OS_MAX_LOCAL_PATH_LEN */
-    UT_SetDeferredRetcode(UT_KEY(OCS_strlen), 3, OS_MAX_LOCAL_PATH_LEN);
+    UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 3, OS_ERROR);
     expected = OS_FS_ERR_PATH_TOO_LONG;
     actual   = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath(/cf/test) (%ld) == OS_FS_ERR_PATH_TOO_LONG", (long)actual);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
@@ -69,9 +69,9 @@ void Test_OS_SymTableIterator_Impl(void)
 
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), true);
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 101), false);
-    UT_SetDefaultReturnValue(UT_KEY(OCS_strlen), OS_MAX_SYM_LEN + 10);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), false);
-    UT_ClearDefaultReturnValue(UT_KEY(OCS_strlen));
+    UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
     UT_SetDefaultReturnValue(UT_KEY(OCS_write), -1);
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), false);
     UT_ClearDefaultReturnValue(UT_KEY(OCS_write));


### PR DESCRIPTION
**Describe the contribution**

Create a wrapper around `memchr()` that mimics the non-C99 function `strnlen()` which is defined in POSIX-2008.

Use this instead of `strlen()` whenever the string being checked either originates in or will be copied into a fixed-length array buffer.

Fixes #808 

**Testing performed**
Build and sanity check CFE
Run all unit tests on both native and RTEMS

**Expected behavior changes**
No behavior changes except if a bug causes strings to be unterminated.

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11.3 (qemu)

**Additional context**
Worth noting that in most cases this was testing the length of a string in the internal OSAL table entry, which was already length-checked when created.  So this check is somewhat redundant, the only way this could catch something is if there is memory corruption of some sort.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
