### PR TITLE
Fix #809, cast args to printf in queue-test

### DIFF
--- a/src/tests/queue-test/queue-test.c
+++ b/src/tests/queue-test/queue-test.c
@@ -87,7 +87,7 @@ void task_1(void)
         {
             ++task_1_messages;
             UtAssert_True(data_received == expected, "TASK 1: data_received (%u) == expected (%u)",
-                          data_received, expected);
+                          (unsigned int)data_received, (unsigned int)expected);
 
             expected++;
         }


### PR DESCRIPTION
**Describe the contribution**

Using `%u` conversion requires an `unsigned int` arg, not `uint32` (it matches on some platforms, not on others).

Fixes #809

**Testing performed**
Build and run tests on RTEMS 4.11.3.

**Expected behavior changes**
No more format mismatch warning/error.

**System(s) tested on**
RTEMS 4.11.3 QEMU target on Ubuntu 20.04 build host

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

