### PR TITLE
Fix #814, UT Stub match macro behavior

### DIFF
--- a/src/ut-stubs/osapi-utstub-file.c
+++ b/src/ut-stubs/osapi-utstub-file.c
@@ -48,7 +48,7 @@ static int32 UT_GenericReadStub(const char *fname, UT_EntryKey_t fkey, void *buf
     int32  status;
     size_t CopySize;
 
-    status = UT_DefaultStubImpl(fname, fkey, 0x7FFFFFFF);
+    status = UT_DefaultStubImpl(fname, fkey, 0x7FFFFFFF, NULL);
 
     if (status == 0x7FFFFFFF)
     {
@@ -86,7 +86,7 @@ static int32 UT_GenericWriteStub(const char *fname, UT_EntryKey_t fkey, const vo
     int32  status;
     size_t CopySize;
 
-    status = UT_DefaultStubImpl(fname, fkey, 0x7FFFFFFF);
+    status = UT_DefaultStubImpl(fname, fkey, 0x7FFFFFFF, NULL);
 
     if (status == 0x7FFFFFFF)
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #814 - Updates stub helpers to match the behavior of calling the default implementation stub macro (NULL va list)

**Testing performed**
Build/execute unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC