### PR TITLE
Fix #752, Utilize UTASSERT_CASETYPE_NA to report OS_ERR_NOT_IMPLEMENTED

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -270,7 +270,7 @@ void TestChmod(void)
     }
     else
     {
-        UtPrintf("OS_chmod not implemented for write only\n");
+        UtAssert_Type(NA, false, "OS_chmod not implemented for write only");
     }
 
     /*Testing Read Only */
@@ -285,7 +285,7 @@ void TestChmod(void)
     }
     else
     {
-        UtPrintf("OS_chmod not implemented for read only\n");
+        UtAssert_Type(NA, false, "OS_chmod not implemented for read only");
     }
 
     /*Testing Read Write */
@@ -300,7 +300,7 @@ void TestChmod(void)
     }
     else
     {
-        UtPrintf("OS_chmod not implemented for read write\n");
+        UtAssert_Type(NA, false, "OS_chmod not implemented for read write");
     }
 
     /*Removing the file */

--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -115,7 +115,7 @@ void TestDatagramNetworkApi_Setup(void)
     actual = OS_SocketOpen(&socket_id, OS_SocketDomain_INET6, OS_SocketType_DATAGRAM);
     if (actual == OS_ERR_NOT_IMPLEMENTED)
     {
-        UtPrintf("INET6 not supported\n");
+        UtAssert_Type(NA, false, "INET6 not supported");
     }
     else
     {
@@ -135,7 +135,7 @@ void TestDatagramNetworkApi_Setup(void)
     actual = OS_SocketAddrInit(&addr, OS_SocketDomain_INET6);
     if (actual == OS_ERR_NOT_IMPLEMENTED)
     {
-        UtPrintf("INET6 not supported\n");
+        UtAssert_Type(NA, false, "INET6 not supported");
     }
     else
     {
@@ -145,7 +145,7 @@ void TestDatagramNetworkApi_Setup(void)
     actual = OS_SocketAddrInit(NULL, OS_SocketDomain_INET6);
     if (actual == OS_ERR_NOT_IMPLEMENTED)
     {
-        UtPrintf("INET6 not supported\n");
+        UtAssert_Type(NA, false, "INET6 not supported");
     }
     else
     {

--- a/src/tests/symbol-api-test/symbol-api-test.c
+++ b/src/tests/symbol-api-test/symbol-api-test.c
@@ -48,24 +48,42 @@ void TestSymbolApi(void)
     */
     UtPrintf("Dumping symbol table with a limit of 32768 bytes\n");
     status = OS_SymbolTableDump("/ram/SymbolTable32k.dat", 32768);
-    UtAssert_True(status == OS_SUCCESS || status == OS_ERR_NOT_IMPLEMENTED, "status after 32k OS_SymbolTableDump = %d",
-                  (int)status);
+    if (status == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssert_Type(NA, false, "Module API not implemented");
+    }
+    else
+    {
+        UtAssert_True(status == OS_SUCCESS, "status after 32k OS_SymbolTableDump = %d", (int)status);
+    }
 
     /*
     ** dump the symbol table with a 128k byte limit
     */
     UtPrintf("Dumping symbol table with a limit of 131072 bytes\n");
     status = OS_SymbolTableDump("/ram/SymbolTable128k.dat", 131072);
-    UtAssert_True(status == OS_SUCCESS || status == OS_ERR_NOT_IMPLEMENTED, "status after 128k OS_SymbolTableDump = %d",
-                  (int)status);
+    if (status == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssert_Type(NA, false, "Module API not implemented");
+    }
+    else
+    {
+        UtAssert_True(status == OS_SUCCESS, "status after 128k OS_SymbolTableDump = %d", (int)status);
+    }
 
     /*
     ** dump the symbol table with a 512k byte limit
     */
     UtPrintf("Dumping symbol table with a limit of 524288 bytes\n");
     status = OS_SymbolTableDump("/ram/SymbolTable512k.dat", 524288);
-    UtAssert_True(status == OS_SUCCESS || status == OS_ERR_NOT_IMPLEMENTED, "status after 512k OS_SymbolTableDump = %d",
-                  (int)status);
+    if (status == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssert_Type(NA, false, "Module API not implemented");
+    }
+    else
+    {
+        UtAssert_True(status == OS_SUCCESS, "status after 512k OS_SymbolTableDump = %d", (int)status);
+    }
 
     /*
     ** Test the symbol lookup


### PR DESCRIPTION
**Describe the contribution**
Fixes #752
use UTASSERT_CASETYPE_NA  instead of UtPrintf to report cases when not implemented 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC