### PR TITLE
Fix #817, Simplify name truncation in OS_CreateSocketName

### DIFF
--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -98,23 +98,21 @@ void OS_CreateSocketName(const OS_object_token_t *token, const OS_SockAddr_t *Ad
 
     sock = OS_OBJECT_TABLE_GET(OS_stream_table, *token);
 
-    if (OS_SocketAddrToString_Impl(sock->stream_name, OS_MAX_API_NAME, Addr) != OS_SUCCESS)
+    if (OS_SocketAddrToString_Impl(sock->stream_name, sizeof(sock->stream_name), Addr) != OS_SUCCESS)
     {
         sock->stream_name[0] = 0;
     }
     if (OS_SocketAddrGetPort_Impl(&port, Addr) == OS_SUCCESS)
     {
         len = OS_strnlen(sock->stream_name, sizeof(sock->stream_name));
-        snprintf(&sock->stream_name[len], OS_MAX_API_NAME - len, ":%u", (unsigned int)port);
+        snprintf(&sock->stream_name[len], sizeof(sock->stream_name) - len, ":%u", (unsigned int)port);
     }
-    sock->stream_name[OS_MAX_API_NAME - 1] = 0;
 
     if (parent_name)
     {
         /* Append the name from the parent socket. */
         len = OS_strnlen(sock->stream_name, sizeof(sock->stream_name));
         snprintf(&sock->stream_name[len], sizeof(sock->stream_name) - len, "-%s", parent_name);
-        sock->stream_name[sizeof(sock->stream_name) - 1] = 0;
     }
 } /* end OS_CreateSocketName */
 


### PR DESCRIPTION
**Describe the contribution**
Fix #817 - just truncating at the end for socket name (not possibly 3 different locations)

**Testing performed**
Built and executed unit tests, passed

**Expected behavior changes**
Will just truncate socket name at the end

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
Note coverage test isn't doing full branch coverage, still getting full line coverage.  Branch coverage is an existing issue.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA