### PR TITLE
Fix #737, UT_Stub_CheckForceFail -> UT_Stub_CheckDefaultReturnValue

### DIFF
--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -315,7 +315,7 @@ void UT_Stub_CallOnce(void (*Func)(void));
 bool UT_Stub_CheckDeferredRetcode(UT_EntryKey_t FuncKey, int32 *Retcode);
 
 /**
- * Check for a forced failure mode entry for the given stub function
+ * Check for a default return value entry for the given stub function
  *
  * If a UT_SetDefaultReturnValue() option is in place for the given function this
  * will return true and increment the internal usage counter.
@@ -324,7 +324,7 @@ bool UT_Stub_CheckDeferredRetcode(UT_EntryKey_t FuncKey, int32 *Retcode);
  * \param Value Set to the value supplied to UT_SetDefaultReturnValue()
  * \returns true if force fail mode is active
  */
-bool UT_Stub_CheckForceFail(UT_EntryKey_t FuncKey, int32 *Value);
+bool UT_Stub_CheckDefaultReturnValue(UT_EntryKey_t FuncKey, int32 *Value);
 
 /**
  * Copies data from a test-supplied buffer to the local buffer

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -396,7 +396,7 @@ uint32 UT_GetStubCount(UT_EntryKey_t FuncKey)
     return Count;
 }
 
-bool UT_Stub_CheckForceFail(UT_EntryKey_t FuncKey, int32 *Value)
+bool UT_Stub_CheckDefaultReturnValue(UT_EntryKey_t FuncKey, int32 *Value)
 {
     bool                 Result = false;
     UT_StubTableEntry_t *StubPtr;
@@ -404,9 +404,12 @@ bool UT_Stub_CheckForceFail(UT_EntryKey_t FuncKey, int32 *Value)
     StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_FORCE_FAIL);
     if (StubPtr != NULL)
     {
-        /* For "force fail" entries, the count will reflect the number of times it was used */
+        /* For default return value entries, the count will reflect the number of times it was used */
         ++StubPtr->Data.Rc.Count;
-        *Value = StubPtr->Data.Rc.Value;
+        if (Value != NULL)
+        {
+            *Value = StubPtr->Data.Rc.Value;
+        }
         Result = true;
     }
 
@@ -761,7 +764,7 @@ int32 UT_DefaultStubImplWithArgs(const char *FunctionName, UT_EntryKey_t FuncKey
 
     if (!UT_Stub_CheckDeferredRetcode(FuncKey, &Retcode))
     {
-        if (!UT_Stub_CheckForceFail(FuncKey, &Retcode))
+        if (!UT_Stub_CheckDefaultReturnValue(FuncKey, &Retcode))
         {
             Retcode = DefaultRc;
         }


### PR DESCRIPTION
**Describe the contribution**
Fix #737 - renames UT_Stub_CheckForceFail to UT_Stub_CheckDefaultReturnValue, also only sets Value if not NULL (can pass in NULL value doesn't matter)

**Testing performed**
Build and execute unit tests (with corresponding nasa/cFE#1173)

**Expected behavior changes**
None, name change

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + nasa/cFE#1173 + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC