### PR TITLE
Fix #833, Initialize file descriptor in OS_OpenCreate

### DIFF
--- a/src/os/inc/osapi-file.h
+++ b/src/os/inc/osapi-file.h
@@ -125,7 +125,7 @@ typedef enum
  * of outputting the ID/descriptor separately from the return value, rather
  * than relying on the user to convert it back.
  *
- * @param[out] filedes  The handle ID
+ * @param[out] filedes  The handle ID (OS_OBJECT_ID_UNDEFINED on failure)
  * @param[in] path      File name to create or open
  * @param[in] flags     The file permissions - see @ref OS_file_flag_t
  * @param[in] access    Intended access mode - see @ref OSFileAccess

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -98,9 +98,8 @@ int32 OS_FileAPI_Init(void)
  *
  * Function: OS_OpenCreate
  *
- *  Purpose: Local helper routine, not part of OSAL API.
- *           Implements both "open" and "creat" file operations
- *           (The difference is a matter of what flags are passed in)
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
 int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access)
@@ -112,6 +111,9 @@ int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 acc
 
     /* Check parameters */
     OS_CHECK_POINTER(filedes);
+
+    /* Initialize file descriptor */
+    *filedes = OS_OBJECT_ID_UNDEFINED;
 
     /*
     ** Check for a valid access mode

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -173,8 +173,10 @@ void TestCreatRemove(void)
     UtAssert_True(status == OS_SUCCESS, "status after remove max name length file = %d", (int)status);
 
     /* try creating with file name too big, should fail */
+    fd     = ~OS_OBJECT_ID_UNDEFINED;
     status = OS_OpenCreate(&fd, longfilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status < OS_SUCCESS, "status after create file name too long = %d", (int)status);
+    UtAssert_UINT32_EQ(fd, OS_OBJECT_ID_UNDEFINED);
 
     /* try removing with file name too big. Should Fail */
     status = OS_remove(longfilename);
@@ -233,8 +235,10 @@ void TestOpenClose(void)
     UtAssert_True(status != OS_SUCCESS, "status after close = %d", (int)status);
 
     /*  open a file that was never in the system */
+    fd     = ~OS_OBJECT_ID_UNDEFINED;
     status = OS_OpenCreate(&fd, "/drive0/FileNotHere", OS_FILE_FLAG_NONE, OS_READ_ONLY);
     UtAssert_True(status < OS_SUCCESS, "status after open = %d", (int)status);
+    UtAssert_UINT32_EQ(fd, OS_OBJECT_ID_UNDEFINED);
 
     /* try removing the file from the drive  to end the function */
     status = OS_remove(filename);


### PR DESCRIPTION
**Describe the contribution**
Fix #833 - Initializes the file descriptor (output parameter) for all cases in OS_OpenCreate

Avoids various "possible uninitialized variable" warnings for routines that utilize this API.

**Testing performed**
Build and execute unit tests, passed

**Expected behavior changes**
Avoids static analysis warning, output never unset.

**System(s) tested on**
 - Hardware: cFS Lab 5
 - OS: CentOS 7
 - Versions: Bundle main + this commit

**Additional context**
nasa/cFE#1185

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC