### PR TITLE
Fix #832 Override default stub logic

### DIFF
--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -258,7 +258,8 @@ void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *Use
  * \param FuncKey  The stub function to add the hook to.
  * \param HookFunc User defined hook function.  Set NULL to delete/clear an entry.
  * \param UserObj  Arbitrary user data object to pass to the hook function
- */void UT_SetHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *UserObj);
+ */
+void UT_SetHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *UserObj);
 
 /**
  * Set a variable-argument Hook function for a particular call

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -118,6 +118,15 @@ typedef int32 (*UT_VaHookFunc_t)(void *UserObj, int32 StubRetcode, uint32 CallCo
 void UT_ResetState(UT_EntryKey_t FuncKey);
 
 /**
+ * A value to indicate if the currently running stub's behavior after
+ * a hook call should be run or not.
+ *
+ * \param Retcode The boolean value indicating the override.  When 'true'
+ * indicates remaining stub code should not be run, it is in override.
+ */
+bool UT_StubIsOverridden(UT_EntryKey_t FuncKey);
+
+/**
  * Add a deferred return code entry for the given stub function
  *
  * A deferred ("count down") return code for the stub function will be
@@ -240,6 +249,18 @@ void UT_ClearForceFail(UT_EntryKey_t FuncKey);
 void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *UserObj);
 
 /**
+ * Set a Hook function for a particular call, but override any remaining stub functionality
+ *
+ * This triggers a callback to a user-defined function when the stub is invoked.
+ * Upon return to the original stub the OverrideStub will be true and any remaining
+ * code lines in stub (that are purposefully bypassed by the stub) will not be executed.
+ *
+ * \param FuncKey  The stub function to add the hook to.
+ * \param HookFunc User defined hook function.  Set NULL to delete/clear an entry.
+ * \param UserObj  Arbitrary user data object to pass to the hook function
+ */void UT_SetHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *UserObj);
+
+/**
  * Set a variable-argument Hook function for a particular call
  *
  * Identical to the normal hook function except that it includes a va_list argument
@@ -256,6 +277,22 @@ void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *Use
  * \param UserObj  Arbitrary user data object to pass to the hook function
  */
 void UT_SetVaHookFunction(UT_EntryKey_t FuncKey, UT_VaHookFunc_t HookFunc, void *UserObj);
+
+/**
+ * Set a Hook function for a particular call, but override any remaining stub functionality
+ * for va_list using functions.  However, some systems have limited support for va_list, so 
+ * this might not be available on those systems.  Tests should use the generic (non-va) hook 
+ * function unless the arguments are truly necessary.
+ *
+ * This triggers a callback to a user-defined function when the stub is invoked.
+ * Upon return to the original stub the OverrideStub will be true and any remaining
+ * code lines in stub (that are purposefully bypassed by the stub) will not be executed.
+ *
+ * \param FuncKey  The stub function to add the hook to.
+ * \param HookFunc User defined hook function.  Set NULL to delete/clear an entry.
+ * \param UserObj  Arbitrary user data object to pass to the hook function
+ */
+void UT_SetVaHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_VaHookFunc_t HookFunc, void *UserObj);
 
 /**
  * Get a count for the number of times a stub was invoked, at its most recent return value

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -279,22 +279,6 @@ void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *Use
 void UT_SetVaHookFunction(UT_EntryKey_t FuncKey, UT_VaHookFunc_t HookFunc, void *UserObj);
 
 /**
- * Set a Hook function for a particular call, but override any remaining stub functionality
- * for va_list using functions.  However, some systems have limited support for va_list, so 
- * this might not be available on those systems.  Tests should use the generic (non-va) hook 
- * function unless the arguments are truly necessary.
- *
- * This triggers a callback to a user-defined function when the stub is invoked.
- * Upon return to the original stub the OverrideStub will be true and any remaining
- * code lines in stub (that are purposefully bypassed by the stub) will not be executed.
- *
- * \param FuncKey  The stub function to add the hook to.
- * \param HookFunc User defined hook function.  Set NULL to delete/clear an entry.
- * \param UserObj  Arbitrary user data object to pass to the hook function
- */
-void UT_SetVaHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_VaHookFunc_t HookFunc, void *UserObj);
-
-/**
  * Get a count for the number of times a stub was invoked, at its most recent return value
  *
  * Test cases may check this to determine if a particular stub was called during the test.

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -615,8 +615,8 @@ void UT_SetHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFun
     {
         StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_UNUSED);
 
-        StubPtr->FuncKey     = FuncKey;
-        StubPtr->EntryType   = UT_ENTRYTYPE_OVERRIDE_STUB;
+        StubPtr->FuncKey   = FuncKey;
+        StubPtr->EntryType = UT_ENTRYTYPE_OVERRIDE_STUB;
     }
 
     UT_SetHookFunction(FuncKey, HookFunc, UserObj);

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -184,24 +184,6 @@ static UT_StubTableEntry_t *UT_GetStubEntry(UT_EntryKey_t FuncKey, UT_EntryType_
     return (StubPtr);
 }
 
-static void UT_DoSetOverride(UT_EntryKey_t FuncKey)
-{
-    UT_StubTableEntry_t *StubPtr;
-
-    /* check if there is already an entry */
-    StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_OVERRIDE_STUB);
-
-    /* If NULL, then this is the first set, set a UT_ENTRYTYPE_OVERRIDE_STUB */
-    if (StubPtr == NULL)
-    {
-        StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_UNUSED);
-
-        StubPtr->FuncKey     = FuncKey;
-        StubPtr->EntryType   = UT_ENTRYTYPE_OVERRIDE_STUB;
-    }
-
-}
-
 void UT_ResetState(UT_EntryKey_t FuncKey)
 {
     UT_StubTableEntry_t *StubPtr;
@@ -623,7 +605,19 @@ void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *Use
 
 void UT_SetHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *UserObj)
 {    
-    UT_DoSetOverride(FuncKey);
+    UT_StubTableEntry_t *StubPtr;
+
+    /* check if there is already an entry */
+    StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_OVERRIDE_STUB);
+
+    /* If NULL, then this is the first set, set a UT_ENTRYTYPE_OVERRIDE_STUB */
+    if (StubPtr == NULL)
+    {
+        StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_UNUSED);
+
+        StubPtr->FuncKey     = FuncKey;
+        StubPtr->EntryType   = UT_ENTRYTYPE_OVERRIDE_STUB;
+    }
 
     UT_SetHookFunction(FuncKey, HookFunc, UserObj);
 }

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -876,7 +876,7 @@ int32 UT_DefaultStubImpl(const char *FunctionName, UT_EntryKey_t FuncKey, int32 
 
 bool UT_StubIsOverridden(UT_EntryKey_t FuncKey)
 {
-    UT_StubTableEntry_t  *StubPtr;
+    UT_StubTableEntry_t *StubPtr;
 
     /* get override status */
     StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_OVERRIDE_STUB);

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -637,13 +637,6 @@ void UT_SetVaHookFunction(UT_EntryKey_t FuncKey, UT_VaHookFunc_t HookFunc, void 
     UT_DoSetHookFunction(FuncKey, Value, UserObj, true);
 }
 
-void UT_SetVaHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_VaHookFunc_t HookFunc, void *UserObj)
-{    
-    UT_DoSetOverride(FuncKey);
-
-    UT_SetVaHookFunction(FuncKey, HookFunc, UserObj);
-}
-
 const void *UT_Hook_GetArgPtr(const UT_StubContext_t *ContextPtr, const char *Name, size_t ExpectedTypeSize)
 {
     uint32                      i;

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -604,7 +604,7 @@ void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *Use
 }
 
 void UT_SetHookOverrideStubFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *UserObj)
-{    
+{
     UT_StubTableEntry_t *StubPtr;
 
     /* check if there is already an entry */


### PR DESCRIPTION
**Describe the contribution**
This is a new set hook function that allows a test designer to bypass the remaining default stub implementation after the hook is called.  Test designers can do this as needed, but current tests will be unaffected because it must be set in a test to be used.  Current tests will never set the override and their expectations of the stub code running after the hook are still valid.  Stubs will need updated to make the check for the override, but that is all that will need to change in them.

**Testing performed**
I have written 7 unit type tests to show that the behavior without the override set continues to be the same.  Each of these tests is doubled with a control test, for a total of 14 tests.  The tests are run with no changes, with cFS commit 5ca472a and using my working version of cfs_cf (unit-test-cf-3.0), this shows that the results of each pair of tests are the same; which is the expectation as they are duplicates.  The repo for cfs_cf is given the new UT_SetHookOverrideStubFunction instead of UT_SetHookFunction in 7 of the tests with each duplicate test left untouched as the control test.  A build is attempted showing that the function does not exist.  The repo, osal, is updated with the changes implementing the override and the repo, cfe, gets a two stubs updated to allow the bypass (CFE_MSG_GetSize, CFE_MSG_GetMsgId).  After a successful full rebuild, the 14 tests are run again.  The results confirm the changes have provided the desired behavior.  While the control tests all still receive the same results as the no updates test run, all of the override tests have their expected changes.  

Details of the specific tests:

1 Test_GetSize_Returns_1 & Test_GetSize_Returns_1_Control
- Initial testing: both receive TSF - as expected, forced return value >= 0, no data buffer set
- Override Control: receives TSF - as expected, forced return value >= 0, no data buffer set
- Override Updated: No TSF, No extra pass == No stub code after hook - as expected Override enabled, no data buffer set

2 Test_GetSize_wUTSDB_Returns_1 & Test_GetSize_wUTSDB_Returns_1_Control
- Initial testing: both receive extra PASS - as expected, forced return value >= 0, yes data buffer set
- Override Control: receive extra PASS - as expected, forced return value >= 0, yes data buffer set
- Override Updated: No TSF, No extra pass == No stub code after hook - as expected Override enabled, yes data buffer set

3 Test_GetSize_Returns_0  & Test_GetSize_Returns_0_Control
- For brevity, these results are the same as 1, I used 1, 0, -1 in my tests because it is the cross over point, >= 0

4 Test_GetSize_wUTSDB_Returns_0 & Test_GetSize_wUTSDB_Returns_0_Control
- Same as 2

5 Test_GetSize_Returns_neg1 & Test_GetSize_Returns_neg1_Control
6 Test_GetSize_wUTSDB_Returns_neg1 & Test_GetSize_wUTSDB_Returns_neg1_Control
- all grouped together because all are same, no TSF, no extra PASS, forced return < 0, code does not run anyway

7 Test_GetSize_OtherKey &Test_GetSize_OtherKey_Control
- Initial testing: both receive 3 TSF - as expected, forced return value >= 0, 2 to CFE_MSG_GetSize, 1 to CFE_MSG_GetMsgId
- Override Control: same as Initial testing - as expected
- Override Updated: 1 TSF, no extra PASS - as expected, both CFE_MSG_GetSize overridden, but CFE_MSG_GetMsgId is not
[OverrideExperiment.txt](https://github.com/nasa/osal/files/6094000/OverrideExperiment.txt)
[do-no-harm.txt](https://github.com/nasa/osal/files/6094012/do-no-harm.txt)

**Expected behavior changes**
Test designers will have the option to use UT_SetHookOverrideStubFunction instead of UT_SetHookFunction.
When this is selected any stub behavior that appears after the hook function is called can be bypassed; as long as the stub checks for the override and allows it.
No other behavior will be changed, as it was a requirement that the change have no impact to current operations.

**System(s) tested on**
- PC
- RHEL 7.8
- cFS commit https://github.com/nasa/cFS/commit/5ca472a450deae7bbbd434465e611f8a6ab3c849
- cfs_cf unit-test-cf-3.0 branch

**Additional context**
The override control tests show there is no behavioral changes unless the new override function is used.  The override updated tests show that the desired outcome is achieved in each instance.

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Gibson NASA/GSFC 587
