### PR TITLE
Fix #873, Remove rogue while loop in OS_DeleteAllObjects

### DIFF
--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -352,8 +352,6 @@ void OS_DeleteAllObjects(void)
         }
         OS_TaskDelay(5);
     }
-    while (ObjectCount > 0 && TryCount < 5)
-        ;
 } /* end OS_DeleteAllObjects */
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
**Describe the contribution**
Fix #873 - removed rogue while loop

**Testing performed**
Build/run unit tests, passed
CI

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC