### PR TITLE
Fix #854, Const correct input pointers

### DIFF
--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -72,7 +72,7 @@
  *
  * returns: Highest numbered file descriptor in the output fd_set
  *-----------------------------------------------------------------*/
-static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
+static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, const OS_FdSet *OSAL_set)
 {
     size_t       offset;
     size_t       bit;

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -364,7 +364,7 @@ void OS_ObjectIdTransactionCancel(OS_object_token_t *token);
 
     Returns: None
  ------------------------------------------------------------------*/
-void OS_ObjectIdTransactionFinish(OS_object_token_t *token, osal_id_t *final_id);
+void OS_ObjectIdTransactionFinish(OS_object_token_t *token, const osal_id_t *final_id);
 
 /*----------------------------------------------------------------
    Function: OS_ObjectIdConvertToken

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -1103,7 +1103,7 @@ int32 OS_ObjectIdGetById(OS_lock_mode_t lock_mode, osal_objtype_t idtype, osal_i
  * be changed.
  *
  *-----------------------------------------------------------------*/
-void OS_ObjectIdTransactionFinish(OS_object_token_t *token, osal_id_t *final_id)
+void OS_ObjectIdTransactionFinish(OS_object_token_t *token, const osal_id_t *final_id)
 {
     OS_common_record_t *record;
 


### PR DESCRIPTION
**Describe the contribution**
Fix #854 - const input pointers for OS_FdSet_ConvertIn_Impl and OS_ObjectIdTransactionFinish

**Testing performed**
Build/execute unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC, OSAL code review