### PR TITLE
Fix #842, Remove NULL redefine

### DIFF
--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -125,10 +125,6 @@ extern "C"
      */
     typedef void (*OS_ArgCallback_t)(osal_id_t object_id, void *arg);
 
-#ifndef NULL /* pointer to nothing */
-#define NULL ((void *)0)
-#endif
-
     /*
     ** Check Sizes
     */


### PR DESCRIPTION
**Describe the contribution**
Fix #842 - removes NULL redefine from common_types.h

Note: identified in OSAL code review and as implemented it was **always** defining NULL

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC