### PR TITLE
Fix #855, check against FD_SETSIZE in bsd-select

### DIFF
--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -72,16 +72,16 @@
  *
  * returns: Highest numbered file descriptor in the output fd_set
  *-----------------------------------------------------------------*/
-static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
+static int32 OS_FdSet_ConvertIn_Impl(int *os_maxfd, fd_set *os_set, OS_FdSet *OSAL_set)
 {
     size_t       offset;
     size_t       bit;
     osal_index_t id;
     uint8        objids;
     int          osfd;
-    int          maxfd;
+    int32        status;
 
-    maxfd = -1;
+    status = OS_SUCCESS;
     for (offset = 0; offset < sizeof(OSAL_set->object_ids); ++offset)
     {
         objids = OSAL_set->object_ids[offset];
@@ -94,10 +94,18 @@ static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
                 osfd = OS_impl_filehandle_table[id].fd;
                 if (osfd >= 0 && OS_impl_filehandle_table[id].selectable)
                 {
-                    FD_SET(osfd, os_set);
-                    if (osfd > maxfd)
+                    if (osfd >= FD_SETSIZE)
                     {
-                        maxfd = osfd;
+                        /* out of range of select() implementation */
+                        status = OS_ERR_OPERATION_NOT_SUPPORTED;
+                    }
+                    else
+                    {
+                        FD_SET(osfd, os_set);
+                        if (osfd > *os_maxfd)
+                        {
+                            *os_maxfd = osfd;
+                        }
                     }
                 }
             }
@@ -106,7 +114,7 @@ static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
         }
     }
 
-    return maxfd;
+    return status;
 } /* end OS_FdSet_ConvertIn_Impl */
 
 /*----------------------------------------------------------------
@@ -267,6 +275,12 @@ int32 OS_SelectSingle_Impl(const OS_object_token_t *token, uint32 *SelectFlags, 
         return OS_ERR_OPERATION_NOT_SUPPORTED;
     }
 
+    if (impl->fd >= FD_SETSIZE)
+    {
+        /* out of range of select() implementation */
+        return OS_ERR_OPERATION_NOT_SUPPORTED;
+    }
+
     if (*SelectFlags != 0)
     {
         FD_ZERO(&wr_set);
@@ -319,40 +333,40 @@ int32 OS_SelectMultiple_Impl(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs)
 {
     fd_set wr_set;
     fd_set rd_set;
-    int    osfd;
     int    maxfd;
     int32  return_code;
 
-    /*
-     * This return code will be used if the set(s) do not
-     * contain any file handles capable of select().  It
-     * will be overwritten with the real result of the
-     * select call, if selectable file handles were specified.
-     */
-    return_code = OS_ERR_OPERATION_NOT_SUPPORTED;
     FD_ZERO(&rd_set);
     FD_ZERO(&wr_set);
     maxfd = -1;
     if (ReadSet != NULL)
     {
-        osfd = OS_FdSet_ConvertIn_Impl(&rd_set, ReadSet);
-        if (osfd > maxfd)
+        return_code = OS_FdSet_ConvertIn_Impl(&maxfd, &rd_set, ReadSet);
+        if (return_code != OS_SUCCESS)
         {
-            maxfd = osfd;
+            return return_code;
         }
     }
     if (WriteSet != NULL)
     {
-        osfd = OS_FdSet_ConvertIn_Impl(&wr_set, WriteSet);
-        if (osfd > maxfd)
+        return_code = OS_FdSet_ConvertIn_Impl(&maxfd, &wr_set, WriteSet);
+        if (return_code != OS_SUCCESS)
         {
-            maxfd = osfd;
+            return return_code;
         }
     }
 
     if (maxfd >= 0)
     {
         return_code = OS_DoSelect(maxfd, &rd_set, &wr_set, msecs);
+    }
+    else
+    {
+        /*
+         * This return code will be used if the set(s) were
+         * both empty/NULL or otherwise did not contain valid filehandles.
+         */
+        return_code = OS_ERR_INVALID_ID;
     }
 
     if (return_code == OS_SUCCESS)

--- a/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-io.h
+++ b/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-io.h
@@ -39,5 +39,6 @@
  *
  *****************************************************/
 void UT_PortablePosixIOTest_Set_Selectable(osal_index_t local_id, bool is_selectable);
+void UT_PortablePosixIOTest_Set_FD(osal_index_t local_id, int fd);
 
 #endif /* UT_ADAPTOR_PORTABLE_POSIX_IO_H  */

--- a/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
+++ b/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
@@ -35,3 +35,8 @@ void UT_PortablePosixIOTest_Set_Selectable(osal_index_t local_id, bool is_select
 {
     OS_impl_filehandle_table[local_id].selectable = is_selectable;
 }
+
+void UT_PortablePosixIOTest_Set_FD(osal_index_t local_id, int fd)
+{
+    OS_impl_filehandle_table[local_id].fd = fd;
+}

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_sys_select.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_sys_select.h
@@ -35,6 +35,8 @@
 /* constants normally defined in sys/select.h */
 /* ----------------------------------------- */
 
+#define OCS_FD_SETSIZE 10
+
 /* ----------------------------------------- */
 /* types normally defined in sys/select.h */
 /* ----------------------------------------- */

--- a/src/unit-test-coverage/ut-stubs/override_inc/sys/select.h
+++ b/src/unit-test-coverage/ut-stubs/override_inc/sys/select.h
@@ -50,4 +50,6 @@
 #define FD_CLR   OCS_FD_CLR
 #define FD_ZERO  OCS_FD_ZERO
 
+#define FD_SETSIZE OCS_FD_SETSIZE
+
 #endif /* SELECT_H  */


### PR DESCRIPTION
**Describe the contribution**
The `select()` implementation utilizes its own set size limit that should be checked.

Fixes #855

**Testing performed**
Build and run all unit tests, confirm coverage of select is testing new branches/returns.

**Expected behavior changes**
Calls to OS_SelectSingle/OS_SelectMultiple will fail if an FD within the set is outside the range of the underlying `FD_SETSIZE` from the C library.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Unfortunately this is a limitation/problem of the `select()` API - valid file handles may be effectively un-selectable due simply to the fact that `FD_SETSIZE` may be lower than the maximum number of open file descriptors.

The only alternative is to use `poll()` instead which uses a different API that does not have this limitation, but has a different issue in that it requires an array of `struct pollfd` data structures to be allocated somehow.

However in practice it is very unlikely to hit the `FD_SETSIZE` limit because this is (probably) much higher than the `OS_MAX_NUM_OPEN_FILES` limit.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
