### PR TITLE
Fix #883, remove unreachable test

### DIFF
--- a/src/os/shared/src/osapi-mutex.c
+++ b/src/os/shared/src/osapi-mutex.c
@@ -198,7 +198,6 @@ int32 OS_MutSemTake(osal_id_t sem_id)
     OS_mutex_internal_record_t *mutex;
     OS_object_token_t           token;
     int32                       return_code;
-    osal_id_t                   self_task;
 
     /* Check Parameters */
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, LOCAL_OBJID_TYPE, sem_id, &token);
@@ -209,16 +208,8 @@ int32 OS_MutSemTake(osal_id_t sem_id)
         return_code = OS_MutSemTake_Impl(&token);
         if (return_code == OS_SUCCESS)
         {
-            self_task = OS_TaskGetId();
-
-            if (OS_ObjectIdDefined(mutex->last_owner))
-            {
-                OS_DEBUG("WARNING: Task %lu taking mutex %lu while owned by task %lu\n",
-                         OS_ObjectIdToInteger(self_task), OS_ObjectIdToInteger(sem_id),
-                         OS_ObjectIdToInteger(mutex->last_owner));
-            }
-
-            mutex->last_owner = self_task;
+            /* Always set the owner if OS_MutSemTake_Impl() returned success */
+            mutex->last_owner = OS_TaskGetId();
         }
     }
 


### PR DESCRIPTION
**Describe the contribution**

The only way for this test happen would be if somehow the normal unlock process was bypassed, such that the underlying OS mutex was unlocked but OSAL state still had it owned by a task.  Removing as extraneous/unneeded.

Fixes #883 

**Testing performed**
Build and run CFE, run unit tests

**Expected behavior changes**
None.  This condition never happens at runtime, and only a debug statement if it did.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
As noted, it is not _entirely_ unreachable in all circumstances - if there was some sort of bug that cause the wrong mutex to get released and/or otherwise throw off OSAL state, this debug message would tell you that it happened.  But outside of a bug somewhere, this really should never happen....

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
