### PR TITLE
Fix #876, break up logic in return statement

### DIFF
--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -104,8 +104,26 @@ bool OS_FileSys_FindVirtMountPoint(void *ref, const OS_object_token_t *token, co
     }
 
     mplen = OS_strnlen(filesys->virtual_mountpt, sizeof(filesys->virtual_mountpt));
-    return (mplen > 0 && mplen < sizeof(filesys->virtual_mountpt) &&
-            strncmp(target, filesys->virtual_mountpt, mplen) == 0 && (target[mplen] == '/' || target[mplen] == 0));
+
+    /*
+     * The virtual_mountpt member should be a substring of the search target.
+     * If this matches a basic substring check then it may be match
+     */
+    if (mplen == 0 || mplen >= sizeof(filesys->virtual_mountpt) ||
+        strncmp(target, filesys->virtual_mountpt, mplen) != 0)
+    {
+        /* not a substring, so not a match */
+        return false;
+    }
+
+    /*
+     * Confirm that the substring ends at either a directory separator
+     * or the end of string  (so exact mount points also match).
+     *
+     * For instance consider a virtual_mountpt of /mnt/abc and searching
+     * for target=/mnt/abcd - this should return false in that case.
+     */
+    return (target[mplen] == '/' || target[mplen] == 0);
 } /* end OS_FileSys_FindVirtMountPoint */
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
**Describe the contribution**
The return statement from OS_FileSys_FindVirtMountPoint() was performing several match operations and was hard to understand.

This breaks up the statement so it is easier to read and adds some informational comments.

Fixes #876 

**Testing performed**
Build and run unit tests

**Expected behavior changes**
None - actual logic is the same.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.