### PR TITLE
Fix #869, rename OS_U32ValueWrapper_t

### DIFF
--- a/src/os/posix/src/os-impl-console.c
+++ b/src/os/posix/src/os-impl-console.c
@@ -90,7 +90,7 @@ void OS_ConsoleWakeup_Impl(const OS_object_token_t *token)
  *-----------------------------------------------------------------*/
 static void *OS_ConsoleTask_Entry(void *arg)
 {
-    OS_U32ValueWrapper_t               local_arg;
+    OS_VoidPtrValueWrapper_t           local_arg;
     OS_impl_console_internal_record_t *local;
     OS_object_token_t                  token;
 
@@ -123,7 +123,7 @@ int32 OS_ConsoleCreate_Impl(const OS_object_token_t *token)
     OS_impl_console_internal_record_t *local;
     pthread_t                          consoletask;
     int32                              return_code;
-    OS_U32ValueWrapper_t               local_arg = {0};
+    OS_VoidPtrValueWrapper_t           local_arg = {0};
 
     local = OS_OBJECT_TABLE_GET(OS_impl_console_table, *token);
 

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -116,7 +116,7 @@ static void OS_NoopSigHandler(int signal) {} /* end OS_NoopSigHandler */
 ---------------------------------------------------------------------------------------*/
 static void *OS_PthreadTaskEntry(void *arg)
 {
-    OS_U32ValueWrapper_t local_arg;
+    OS_VoidPtrValueWrapper_t local_arg;
 
     local_arg.opaque_arg = arg;
     OS_TaskEntryPoint(local_arg.id); /* Never returns */
@@ -577,7 +577,7 @@ int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority
  *-----------------------------------------------------------------*/
 int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
 {
-    OS_U32ValueWrapper_t            arg;
+    OS_VoidPtrValueWrapper_t        arg;
     int32                           return_code;
     OS_impl_task_internal_record_t *impl;
     OS_task_internal_record_t *     task;
@@ -797,10 +797,10 @@ int32 OS_TaskSetPriority_Impl(const OS_object_token_t *token, osal_priority_t ne
  *-----------------------------------------------------------------*/
 int32 OS_TaskRegister_Impl(osal_id_t global_task_id)
 {
-    int32                return_code;
-    OS_U32ValueWrapper_t arg;
-    int                  old_state;
-    int                  old_type;
+    int32                    return_code;
+    OS_VoidPtrValueWrapper_t arg;
+    int                      old_state;
+    int                      old_type;
 
     /*
      * Set cancel state=ENABLED, type=DEFERRED
@@ -838,7 +838,7 @@ int32 OS_TaskRegister_Impl(osal_id_t global_task_id)
  *-----------------------------------------------------------------*/
 osal_id_t OS_TaskGetId_Impl(void)
 {
-    OS_U32ValueWrapper_t self_record;
+    OS_VoidPtrValueWrapper_t self_record;
 
     self_record.opaque_arg = pthread_getspecific(POSIX_GlobalVars.ThreadKey);
 

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -315,7 +315,7 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
 
 static void *OS_TimeBasePthreadEntry(void *arg)
 {
-    OS_U32ValueWrapper_t local_arg;
+    OS_VoidPtrValueWrapper_t local_arg;
 
     local_arg.opaque_arg = arg;
     OS_TimeBase_CallbackThread(local_arg.id);
@@ -340,7 +340,7 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
     struct timespec                     ts;
     OS_impl_timebase_internal_record_t *local;
     OS_timebase_internal_record_t *     timebase;
-    OS_U32ValueWrapper_t                arg;
+    OS_VoidPtrValueWrapper_t            arg;
 
     local    = OS_OBJECT_TABLE_GET(OS_impl_timebase_table, *token);
     timebase = OS_OBJECT_TABLE_GET(OS_timebase_table, *token);

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -128,7 +128,7 @@ void OS_TimeBaseUnlock_Impl(const OS_object_token_t *token)
  *-----------------------------------------------------------------*/
 static rtems_timer_service_routine OS_TimeBase_ISR(rtems_id rtems_timer_id, void *arg)
 {
-    OS_U32ValueWrapper_t                user_data;
+    OS_VoidPtrValueWrapper_t            user_data;
     OS_object_token_t                   token;
     OS_impl_timebase_internal_record_t *local;
 
@@ -427,7 +427,7 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
  *-----------------------------------------------------------------*/
 int32 OS_TimeBaseSet_Impl(const OS_object_token_t *token, uint32 start_time, uint32 interval_time)
 {
-    OS_U32ValueWrapper_t                user_data;
+    OS_VoidPtrValueWrapper_t            user_data;
     OS_impl_timebase_internal_record_t *local;
     int32                               return_code;
     int                                 status;

--- a/src/os/shared/inc/os-shared-globaldefs.h
+++ b/src/os/shared/inc/os-shared-globaldefs.h
@@ -65,6 +65,9 @@ typedef struct OS_object_token OS_object_token_t;
  * Wrapper for encoding of other types into a generic void* type required as argument
  * to callbacks and pthread entry/return values, etc.
  *
+ * This is used where OSAL needs to pass non-pointer/integer values through an interface
+ * that accepts a void* opaque pass-through argument.
+ *
  * Note this can only encode types with sizes <= sizeof(void*)
  */
 typedef union
@@ -73,7 +76,14 @@ typedef union
     OS_ArgCallback_t arg_callback_func;
     osal_id_t        id;
     osal_index_t     idx;
-} OS_U32ValueWrapper_t;
+} OS_VoidPtrValueWrapper_t;
+
+/*
+ * The wrapper structure size should be equal to void* - if not this means
+ * one or more of the other members are bigger than void*, and therefore cannot
+ * be passed directly through the intended interface
+ */
+CompileTimeAssert(sizeof(OS_VoidPtrValueWrapper_t) == sizeof(void *), VoidValueWrapperSize);
 
 /*
  * The "OS_DEBUG" is a no-op unless OSAL_CONFIG_DEBUG_PRINTF is enabled.


### PR DESCRIPTION
**Describe the contribution**
The "U32" designation in the name had become confusing because all the members had over time migrated to a separate non-uint32/dedicated type.

The point is to pass a value through a void* so a name change better indicates that purpose.

Also adds a compile time assert to this intent - this wrapper may only be used to directly pass values which have a size less than or equal to `sizeof(void*)` -- if anything is bigger than this it will not work.

Fixes #869 

**Testing performed**
Build and run all tests, sanity check

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
