### PR TITLE
Fix #867, better error translation for ESPIPE errno

### DIFF
--- a/src/os/portable/os-impl-posix-io.c
+++ b/src/os/portable/os-impl-posix-io.c
@@ -138,7 +138,7 @@ int32 OS_GenericSeek_Impl(const OS_object_token_t *token, int32 offset, uint32 w
              * Use a different error code to differentiate from an
              * error involving a bad whence/offset
              */
-            retval = OS_ERR_NOT_IMPLEMENTED;
+            retval = OS_ERR_OPERATION_NOT_SUPPORTED;
         }
         else
         {

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
@@ -84,7 +84,7 @@ void Test_OS_GenericSeek_Impl(void)
 
     /* The seek implementation also checks for this specific pipe errno */
     OCS_errno = OCS_ESPIPE;
-    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (&token, 0, OS_SEEK_END), OS_ERR_NOT_IMPLEMENTED);
+    OSAPI_TEST_FUNCTION_RC(OS_GenericSeek_Impl, (&token, 0, OS_SEEK_END), OS_ERR_OPERATION_NOT_SUPPORTED);
 }
 
 void Test_OS_GenericRead_Impl(void)


### PR DESCRIPTION
**Describe the contribution**
The ESPIPE errno means that seeking is not supported on the given file handle.  Translate to the `OS_ERR_OPERATION_NOT_SUPPORTED` error rather than not implemented as it better indicates the actual condition.

Fixes #867

**Testing performed**
Build and sanity check, run tests

**Expected behavior changes**
Better error code if attempting to seek on a pipe/socket

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
