### PR TITLE
Fix #882, make module comment same as other services

### DIFF
--- a/src/os/shared/src/osapi-module.c
+++ b/src/os/shared/src/osapi-module.c
@@ -48,10 +48,7 @@
 
 /*
  * Sanity checks on the user-supplied configuration
- * The relevent OS_MAX limit should be defined
- *
- * OS_MAX_MODULES is allowed to be zero in which case the
- * table is not instantiated.
+ * The relevent OS_MAX limit should be defined and greater than zero
  */
 #if !defined(OS_MAX_MODULES) || (OS_MAX_MODULES <= 0)
 #error "osconfig.h must define OS_MAX_MODULES to a valid value"


### PR DESCRIPTION
**Describe the contribution**
In the current implementation, the same patterns apply to modules as the rest of the OSAL services.  

Fixes #882

**Testing performed**
Build and run tests

**Expected behavior changes**
None - comment only

**System(s) tested on**
Ubuntu 20.04

**Additional context**
In a previous version there as a special case for 0 modules but this is no longer true, and the comment had become outdated.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
