### PR TITLE
Fix #886, return moduleInfoGet error

### DIFF
--- a/src/os/vxworks/src/os-impl-loader.c
+++ b/src/os/vxworks/src/os-impl-loader.c
@@ -164,6 +164,7 @@ int32 OS_ModuleGetInfo_Impl(const OS_object_token_t *token, OS_module_prop_t *mo
     MODULE_INFO                       vxModuleInfo;
     STATUS                            vxStatus;
     OS_impl_module_internal_record_t *impl;
+    int32                             return_code;
 
     impl = OS_OBJECT_TABLE_GET(OS_impl_module_table, *token);
 
@@ -176,6 +177,7 @@ int32 OS_ModuleGetInfo_Impl(const OS_object_token_t *token, OS_module_prop_t *mo
     if (vxStatus == ERROR)
     {
         OS_DEBUG("OSAL: OS_ModuleInfoGet Error from vxWorks: %d\n", vxStatus);
+        return_code = OS_ERROR;
     }
     else
     {
@@ -186,8 +188,10 @@ int32 OS_ModuleGetInfo_Impl(const OS_object_token_t *token, OS_module_prop_t *mo
         module_prop->addr.data_size    = vxModuleInfo.segInfo.dataSize;
         module_prop->addr.bss_address  = (cpuaddr)vxModuleInfo.segInfo.bssAddr;
         module_prop->addr.bss_size     = vxModuleInfo.segInfo.bssSize;
+
+        return_code = OS_SUCCESS;
     }
 
-    return (OS_SUCCESS);
+    return (return_code);
 
 } /* end OS_ModuleGetInfo_Impl */

--- a/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
@@ -87,12 +87,12 @@ void Test_OS_ModuleGetInfo_Impl(void)
     UtAssert_True(module_prop.addr.valid, "addresses in output valid");
 
     /*
-     * Note this still returns SUCCESS if the underlying call fails,
-     * but the boolean in the output struct should be false.
+     * This returns OS_ERROR if the underlying call fails,
+     * and the boolean in the output struct should be false.
      */
     memset(&module_prop, 0, sizeof(module_prop));
     UT_SetDefaultReturnValue(UT_KEY(OCS_moduleInfoGet), OCS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(&token, &module_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ModuleGetInfo_Impl(&token, &module_prop), OS_ERROR);
     UT_ClearDefaultReturnValue(UT_KEY(OCS_moduleInfoGet));
     UtAssert_True(!module_prop.addr.valid, "addresses in output not valid");
 }


### PR DESCRIPTION
**Describe the contribution**
Propagate a VxWorks error on moduleInfoGet() call into OS_ERROR return.

Fixes #886

**Testing performed**
Build and sanity check, run unit tests

**Expected behavior changes**
Error on moduleInfoGet() gets returned to caller as OS_ERROR status.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
