### PR TITLE
Fix #889, report timer_gettime error

### DIFF
--- a/src/os/vxworks/src/os-impl-timebase.c
+++ b/src/os/vxworks/src/os-impl-timebase.c
@@ -546,8 +546,6 @@ int32 OS_TimeBaseSet_Impl(const OS_object_token_t *token, uint32 start_time, uin
 
         if (status == OK)
         {
-            return_code = OS_SUCCESS;
-
             /*
              * VxWorks will round the interval up to the next higher
              * system tick interval.  Sometimes this can make a substantial
@@ -565,6 +563,8 @@ int32 OS_TimeBaseSet_Impl(const OS_object_token_t *token, uint32 start_time, uin
             status = timer_gettime(local->host_timerid, &timeout);
             if (status == OK)
             {
+                return_code = OS_SUCCESS;
+
                 local->configured_start_time = (timeout.it_value.tv_sec * 1000000) + (timeout.it_value.tv_nsec / 1000);
                 local->configured_interval_time =
                     (timeout.it_interval.tv_sec * 1000000) + (timeout.it_interval.tv_nsec / 1000);
@@ -581,6 +581,13 @@ int32 OS_TimeBaseSet_Impl(const OS_object_token_t *token, uint32 start_time, uin
                              OS_ObjectIdToInteger(OS_ObjectIdFromToken(token)), (unsigned long)interval_time,
                              (unsigned long)local->configured_interval_time);
                 }
+            }
+            else
+            {
+                return_code = OS_ERROR;
+
+                OS_DEBUG("WARNING: timer %lu timer_gettime() failed - timer not configured properly?\n",
+                         OS_ObjectIdToInteger(OS_ObjectIdFromToken(token)));
             }
         }
         else

--- a/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
@@ -191,7 +191,12 @@ void Test_OS_VxWorks_SigWait(void)
     UT_SetDataBuffer(UT_KEY(OCS_timer_settime), &config_value, sizeof(config_value), false);
     UT_SetDataBuffer(UT_KEY(OCS_timer_gettime), &config_value, sizeof(config_value), false);
     UT_TimeBaseTest_Setup(UT_INDEX_0, signo, true);
-    OS_TimeBaseSet_Impl(&token, 1111111, 2222222);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(&token, 1111111, 2222222), OS_SUCCESS);
+
+    UT_SetDataBuffer(UT_KEY(OCS_timer_settime), &config_value, sizeof(config_value), false);
+    UT_SetDeferredRetcode(UT_KEY(OCS_timer_gettime), 1, OCS_ERROR);
+    UT_TimeBaseTest_Setup(UT_INDEX_0, signo, true);
+    OSAPI_TEST_FUNCTION_RC(OS_TimeBaseSet_Impl(&token, 1111111, 2222222), OS_ERROR);
 
     UT_SetDataBuffer(UT_KEY(OCS_sigwait), &signo, sizeof(signo), false);
     OSAPI_TEST_FUNCTION_RC(UT_TimeBaseTest_CallSigWaitFunc(OS_OBJECT_ID_UNDEFINED), 1111111);


### PR DESCRIPTION
**Describe the contribution**
In VxWorks the impl calls timer_settime followed by timer_gettime on the same timer to check if rounding occurred.  If the second call fails this reports it as an error.

Note unless there is some sort of OS bug this should be impossible to happen as this code only runs after a successful timer_settime.

Fixes #889

**Testing performed**
Build and sanity check, run unit tests

**Expected behavior changes**
A failure to call timer_gettime after timer_settime is reported as an error.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
