### PR TITLE
Fix #861, compile time assert for sockaddr size

### DIFF
--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -73,6 +73,15 @@ typedef union
 #endif
 } OS_SockAddr_Accessor_t;
 
+/*
+ * Confirm that the abstract socket address buffer size (OS_SOCKADDR_MAX_LEN) is
+ * large enough to store any of the enabled address types.  If this is true, the
+ * size of the above union will match OS_SOCKADDR_MAX_LEN.  However, if any
+ * implemention-provided struct types are larger than this, the union will be
+ * larger, and this indicates a configuration error.
+ */
+CompileTimeAssert(sizeof(OS_SockAddr_Accessor_t) == OS_SOCKADDR_MAX_LEN, SockAddrSize);
+
 /****************************************************************************************
                                     Sockets API
  ***************************************************************************************/
@@ -200,7 +209,7 @@ int32 OS_SocketBind_Impl(const OS_object_token_t *token, const OS_SockAddr_t *Ad
             break;
     }
 
-    if (addrlen == 0 || addrlen > OS_SOCKADDR_MAX_LEN)
+    if (addrlen == 0)
     {
         return OS_ERR_BAD_ADDRESS;
     }
@@ -560,7 +569,7 @@ int32 OS_SocketAddrInit_Impl(OS_SockAddr_t *Addr, OS_SocketDomain_t Domain)
             break;
     }
 
-    if (addrlen == 0 || addrlen > OS_SOCKADDR_MAX_LEN)
+    if (addrlen == 0)
     {
         return OS_ERR_NOT_IMPLEMENTED;
     }


### PR DESCRIPTION
**Describe the contribution**
OSAL provides an abstract buffer for socket addresses, independent of the underlying implementation.  The size of this buffer is
configurable by the user via compile-time options.

This adds a CompileTimeAssert to confirm that the size of this abstract buffer is large enough to store any of the enabled
address types. This also removes the need for runtime tests.

Fixes #861

**Testing performed**
Build and sanity test, run unit tests

**Expected behavior changes**
This change means that the `OS_SOCKADDR_MAX_LEN`  __must__ be configured large enough for all enabled address types.  For instance, ipv6 addresses are likely to be larger than ipv4 addresses in the implementation.  It is therefore possible to se OS_SOCKADDR_MAX_LEN large enough for ipv4 but not large enough for ipv6.

A configuration such as this used to work if the runtime code only used ipv4 addresses.  If runtime code used ipv6 address, it would fail at runtime.  With this change, a configuration such as this will fail to compile, and enforce that the abstract size is large enough for any/all enabled address types, regardless of what is actually used.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
