### PR TITLE
Fix #863, check/report fcntl status

### DIFF
--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -156,10 +156,24 @@ int32 OS_SocketOpen_Impl(const OS_object_token_t *token)
      * any blocking would be done explicitly via the select() wrappers
      */
     os_flags = fcntl(impl->fd, F_GETFL);
-    os_flags |= OS_IMPL_SOCKET_FLAGS;
-    fcntl(impl->fd, F_SETFL, os_flags);
-
-    impl->selectable = ((os_flags & O_NONBLOCK) != 0);
+    if (os_flags == -1)
+    {
+        /* No recourse if F_GETFL fails - just report the error and move on. */
+        OS_DEBUG("fcntl(F_GETFL): %s\n", strerror(errno));
+    }
+    else
+    {
+        os_flags |= OS_IMPL_SOCKET_FLAGS;
+        if (fcntl(impl->fd, F_SETFL, os_flags) == -1)
+        {
+            /* No recourse if F_SETFL fails - just report the error and move on. */
+            OS_DEBUG("fcntl(F_SETFL): %s\n", strerror(errno));
+        }
+        else
+        {
+            impl->selectable = ((os_flags & O_NONBLOCK) != 0);
+        }
+    }
 
     return OS_SUCCESS;
 } /* end OS_SocketOpen_Impl */
@@ -360,10 +374,24 @@ int32 OS_SocketAccept_Impl(const OS_object_token_t *sock_token, const OS_object_
                  * any blocking would be done explicitly via the select() wrappers
                  */
                 os_flags = fcntl(conn_impl->fd, F_GETFL);
-                os_flags |= OS_IMPL_SOCKET_FLAGS;
-                fcntl(conn_impl->fd, F_SETFL, os_flags);
-
-                conn_impl->selectable = ((os_flags & O_NONBLOCK) != 0);
+                if (os_flags == -1)
+                {
+                    /* No recourse if F_GETFL fails - just report the error and move on. */
+                    OS_DEBUG("fcntl(F_GETFL): %s\n", strerror(errno));
+                }
+                else
+                {
+                    os_flags |= OS_IMPL_SOCKET_FLAGS;
+                    if (fcntl(conn_impl->fd, F_SETFL, os_flags) == -1)
+                    {
+                        /* No recourse if F_SETFL fails - just report the error and move on. */
+                        OS_DEBUG("fcntl(F_SETFL): %s\n", strerror(errno));
+                    }
+                    else
+                    {
+                        conn_impl->selectable = ((os_flags & O_NONBLOCK) != 0);
+                    }
+                }
             }
         }
     }

--- a/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-io.h
+++ b/src/unit-test-coverage/portable/adaptors/inc/ut-adaptor-portable-posix-io.h
@@ -39,5 +39,7 @@
  *
  *****************************************************/
 void UT_PortablePosixIOTest_Set_Selectable(osal_index_t local_id, bool is_selectable);
+bool UT_PortablePosixIOTest_Get_Selectable(osal_index_t local_id);
+void UT_PortablePosixIOTest_ResetImpl(osal_index_t local_id);
 
 #endif /* UT_ADAPTOR_PORTABLE_POSIX_IO_H  */

--- a/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
+++ b/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
@@ -31,7 +31,18 @@
 
 #include <os-impl-io.h>
 
+void UT_PortablePosixIOTest_ResetImpl(osal_index_t local_id)
+{
+    OS_impl_filehandle_table[local_id].fd         = -1;
+    OS_impl_filehandle_table[local_id].selectable = false;
+}
+
 void UT_PortablePosixIOTest_Set_Selectable(osal_index_t local_id, bool is_selectable)
 {
     OS_impl_filehandle_table[local_id].selectable = is_selectable;
+}
+
+bool UT_PortablePosixIOTest_Get_Selectable(osal_index_t local_id)
+{
+    return OS_impl_filehandle_table[local_id].selectable;
 }


### PR DESCRIPTION
**Describe the contribution**
The fcntl() function is documented as returning -1 on error, so test for this condition and report errno if so.  There is no
recourse/handling - this just reports the error.

However - failure to set the O_NONBLOCK flag via this method will fall back to blocking mode being used (timeouts will not
work as a result).

Fixes #863

**Testing performed**
Build and sanity check, run unit tests, check coverage

**Expected behavior changes**
if setting O_NONBLOCK fails, then debug message is printed and blocking mode is used.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
No real recourse in code - this shouldn't fail, but if it does, errno is printed so user can diagnose why it failed.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
