### PR TITLE
Fix #752, Utilize UTASSERT_CASETYPE_NA to report OS_ERR_NOT_IMPLEMENTED

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -274,7 +274,7 @@ void TestChmod(void)
     }
     else
     {
-        UtPrintf("OS_chmod not implemented for write only\n");
+        UtAssert_NA("OS_chmod not implemented for write only");
     }
 
     /*Testing Read Only */
@@ -289,7 +289,7 @@ void TestChmod(void)
     }
     else
     {
-        UtPrintf("OS_chmod not implemented for read only\n");
+        UtAssert_NA("OS_chmod not implemented for read only");
     }
 
     /*Testing Read Write */
@@ -304,7 +304,7 @@ void TestChmod(void)
     }
     else
     {
-        UtPrintf("OS_chmod not implemented for read write\n");
+        UtAssert_NA("OS_chmod not implemented for read write");
     }
 
     /*Removing the file */

--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -122,7 +122,7 @@ void TestDatagramNetworkApi_Setup(void)
         actual = OS_SocketOpen(&socket_id, OS_SocketDomain_INET6, OS_SocketType_DATAGRAM);
         if (actual == OS_ERR_NOT_IMPLEMENTED)
         {
-            UtPrintf("INET6 not supported\n");
+            UtAssert_NA("INET6 not supported");
         }
         else
         {
@@ -142,7 +142,7 @@ void TestDatagramNetworkApi_Setup(void)
         actual = OS_SocketAddrInit(&addr, OS_SocketDomain_INET6);
         if (actual == OS_ERR_NOT_IMPLEMENTED)
         {
-            UtPrintf("INET6 not supported\n");
+            UtAssert_NA("INET6 not supported");
         }
         else
         {
@@ -152,7 +152,7 @@ void TestDatagramNetworkApi_Setup(void)
         actual = OS_SocketAddrInit(NULL, OS_SocketDomain_INET6);
         if (actual == OS_ERR_NOT_IMPLEMENTED)
         {
-            UtPrintf("INET6 not supported\n");
+            UtAssert_NA("INET6 not supported");
         }
         else
         {
@@ -378,7 +378,7 @@ void TestDatagramNetworkApi(void)
     }
     else
     {
-        UtAssert_Type(NA, false, "Network API not implemented");
+        UtAssert_NA("Network API not implemented");
     }
 
 } /* end TestDatagramNetworkApi */
@@ -466,7 +466,7 @@ void TestStreamNetworkApi(void)
     actual      = OS_SocketOpen(&s_socket_id, OS_SocketDomain_INET, OS_SocketType_STREAM);
     if (actual == OS_ERR_NOT_IMPLEMENTED)
     {
-        UtAssert_Type(NA, false, "Network API not implemented");
+        UtAssert_NA("Network API not implemented");
     }
     else
     {

--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -338,7 +338,7 @@ void TestSelectSingleRead(void)
     }
     else
     {
-        UtAssert_Type(NA, false, "Network API not implemented");
+        UtAssert_NA("Network API not implemented");
     }
 }
 
@@ -396,7 +396,7 @@ void TestSelectMultipleRead(void)
     }
     else
     {
-        UtAssert_Type(NA, false, "Network API not implemented");
+        UtAssert_NA("Network API not implemented");
     }
 }
 
@@ -467,7 +467,7 @@ void TestSelectSingleWrite(void)
     }
     else
     {
-        UtAssert_Type(NA, false, "Network API not implemented");
+        UtAssert_NA("Network API not implemented");
     }
 }
 
@@ -548,7 +548,7 @@ void TestSelectMultipleWrite(void)
     }
     else
     {
-        UtAssert_Type(NA, false, "Network API not implemented");
+        UtAssert_NA("Network API not implemented");
     }
 }
 

--- a/src/tests/symbol-api-test/symbol-api-test.c
+++ b/src/tests/symbol-api-test/symbol-api-test.c
@@ -48,24 +48,42 @@ void TestSymbolApi(void)
     */
     UtPrintf("Dumping symbol table with a limit of 32768 bytes\n");
     status = OS_SymbolTableDump("/ram/SymbolTable32k.dat", 32768);
-    UtAssert_True(status == OS_SUCCESS || status == OS_ERR_NOT_IMPLEMENTED, "status after 32k OS_SymbolTableDump = %d",
-                  (int)status);
+    if (status == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssert_NA("Module API not implemented");
+    }
+    else
+    {
+        UtAssert_True(status == OS_SUCCESS, "status after 32k OS_SymbolTableDump = %d", (int)status);
+    }
 
     /*
     ** dump the symbol table with a 128k byte limit
     */
     UtPrintf("Dumping symbol table with a limit of 131072 bytes\n");
     status = OS_SymbolTableDump("/ram/SymbolTable128k.dat", 131072);
-    UtAssert_True(status == OS_SUCCESS || status == OS_ERR_NOT_IMPLEMENTED, "status after 128k OS_SymbolTableDump = %d",
-                  (int)status);
+    if (status == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssert_NA("Module API not implemented");
+    }
+    else
+    {
+        UtAssert_True(status == OS_SUCCESS, "status after 128k OS_SymbolTableDump = %d", (int)status);
+    }
 
     /*
     ** dump the symbol table with a 512k byte limit
     */
     UtPrintf("Dumping symbol table with a limit of 524288 bytes\n");
     status = OS_SymbolTableDump("/ram/SymbolTable512k.dat", 524288);
-    UtAssert_True(status == OS_SUCCESS || status == OS_ERR_NOT_IMPLEMENTED, "status after 512k OS_SymbolTableDump = %d",
-                  (int)status);
+    if (status == OS_ERR_NOT_IMPLEMENTED)
+    {
+        UtAssert_NA("Module API not implemented");
+    }
+    else
+    {
+        UtAssert_True(status == OS_SUCCESS, "status after 512k OS_SymbolTableDump = %d", (int)status);
+    }
 
     /*
     ** Test the symbol lookup

--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -95,6 +95,9 @@ typedef struct
 /* Asserts a test failure */
 #define UtAssert_Failed(...) UtAssertEx(false, UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
+/* Assert a test Not Applicable */
+#define UtAssert_NA(...) UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, __VA_ARGS__)
+
 /* Compares two integers and determines if they are equal within a specified absolute tolerance. */
 #define UtAssert_IntegerCmpAbs(x, y, Tolerance, ...) \
     UtAssertEx((abs((x) - (y)) <= (Tolerance)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)


### PR DESCRIPTION
**Describe the contribution**
Fixes  #752
Create new macro UtAssert_NA to use instead of UtPrintf to report cases when not implemented

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This is a redo of #816 which was closed because it was going to be part of #787 but that won't be done in the near future so this task is back as its own pull request. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
