### PR TITLE
Fix #888, better return codes from OS_SymbolTableDump_Impl

### DIFF
--- a/src/os/inc/osapi-error.h
+++ b/src/os/inc/osapi-error.h
@@ -84,6 +84,7 @@ typedef char os_err_name_t[OS_ERROR_NAME_LENGTH];
 #define OS_ERR_STREAM_DISCONNECTED     (-37) /**< @brief Stream disconnected */
 #define OS_ERR_OPERATION_NOT_SUPPORTED (-38) /**< @brief Requested operation not support on supplied object(s) */
 #define OS_ERR_INVALID_SIZE            (-40) /**< @brief Invalid Size */
+#define OS_ERR_OUTPUT_TOO_LARGE        (-41) /**< @brief Size of output exceeds limit  */
 
 /*
 ** Defines for File System Calls

--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -175,7 +175,7 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
     if (memchr(name, 0, OS_MAX_SYM_LEN) == NULL)
     {
         OS_DEBUG("%s(): symbol name too long\n", __func__);
-        state->StatusCode = OS_ERROR;
+        state->StatusCode = OS_ERR_NAME_TOO_LONG;
         return (false);
     }
 
@@ -190,6 +190,7 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
         ** However this is not considered an error, just a stop condition.
         */
         OS_DEBUG("%s(): symbol table size exceeded\n", __func__);
+        state->StatusCode = OS_ERR_OUTPUT_TOO_LARGE;
         return (false);
     }
 
@@ -262,6 +263,16 @@ int32 OS_SymbolTableDump_Impl(const char *filename, size_t size_limit)
         (void)symEach(sysSymTbl, OS_SymTableIterator_Impl, 0);
 
         close(state->fd);
+    }
+
+    /*
+     * If output size was zero this means a failure of the symEach call,
+     * in that it didn't iterate over anything at all.
+     */
+    if (state->StatusCode == OS_SUCCESS && state->CurrSize == 0)
+    {
+        OS_DEBUG("%s(): No symbols found!\n", __func__);
+        state->StatusCode = OS_ERROR;
     }
 
     return (state->StatusCode);

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-symtab.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-symtab.h
@@ -31,5 +31,6 @@
 #include "common_types.h"
 
 int32 UT_SymTabTest_CallIteratorFunc(const char *name, void *val, size_t TestSize, size_t SizeLimit);
+int32 UT_SymTabTest_GetIteratorStatus(void);
 
 #endif /* UT_ADAPTOR_SYMTAB_H  */

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-symtab.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-symtab.c
@@ -47,3 +47,11 @@ int32 UT_SymTabTest_CallIteratorFunc(const char *name, void *val, size_t TestSiz
      */
     return OS_SymTableIterator_Impl((char *)name, (OCS_SYM_VALUE)val, 0, 0, 0);
 }
+
+/*
+ * Gets the current status of the iterator function
+ */
+int32 UT_SymTabTest_GetIteratorStatus(void)
+{
+    return OS_VxWorks_SymbolDumpState.StatusCode;
+}


### PR DESCRIPTION
**Describe the contribution**
Improve the error codes from this function.

- Introduces a new error `OS_ERR_OUTPUT_TOO_LARGE` if the size limit was insufficient (instead of `OS_SUCCESS`).
- Return `OS_ERROR` if an empty file was written - this likely indicates some fundamental issue with the VxWorks symbol table.
- Return `OS_ERR_NAME_TOO_LONG` if one of the symbol names was too long, (instead of generic `OS_ERROR`).

Improve unit test to check for/verify these responses.

Fixes #888

**Testing performed**
Build and sanity check, run all unit tests, confirm coverage of new cases.

**Expected behavior changes**
Better/more descriptive return codes if OS_SymbolTableDump_Impl does not do what is expected.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.