### PR TITLE
Fix #919, check index inside fdset conversions

### DIFF
--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -88,9 +88,9 @@ static int OS_FdSet_ConvertIn_Impl(fd_set *os_set, OS_FdSet *OSAL_set)
         bit    = 0;
         while (objids != 0)
         {
-            if (objids & 0x01)
+            id = OSAL_INDEX_C((offset * 8) + bit);
+            if ((objids & 0x01) != 0 && id < OS_MAX_NUM_OPEN_FILES)
             {
-                id   = OSAL_INDEX_C((offset * 8) + bit);
                 osfd = OS_impl_filehandle_table[id].fd;
                 if (osfd >= 0 && OS_impl_filehandle_table[id].selectable)
                 {
@@ -134,9 +134,9 @@ static void OS_FdSet_ConvertOut_Impl(fd_set *output, OS_FdSet *Input)
         bit    = 0;
         while (objids != 0)
         {
-            if (objids & 0x01)
+            id = OSAL_INDEX_C((offset * 8) + bit);
+            if ((objids & 0x01) != 0 && id < OS_MAX_NUM_OPEN_FILES)
             {
-                id   = OSAL_INDEX_C((offset * 8) + bit);
                 osfd = OS_impl_filehandle_table[id].fd;
                 if (osfd < 0 || !FD_ISSET(osfd, output))
                 {


### PR DESCRIPTION
**Describe the contribution**
Add an extra limit check for the index, as it is possible due to padding that this goes beyond the end of the array.

Fixes #919 

**Testing performed**
Validate all coverage tests now pass

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Should fix the issue seen in integration candidate #917 

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
