### PR TITLE
Fix #921, make non-selectable FD an error

### DIFF
--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -92,9 +92,9 @@ static int32 OS_FdSet_ConvertIn_Impl(int *os_maxfd, fd_set *os_set, const OS_FdS
             if ((objids & 0x01) != 0 && id < OS_MAX_NUM_OPEN_FILES)
             {
                 osfd = OS_impl_filehandle_table[id].fd;
-                if (osfd >= 0 && OS_impl_filehandle_table[id].selectable)
+                if (osfd >= 0)
                 {
-                    if (osfd >= FD_SETSIZE)
+                    if (osfd >= FD_SETSIZE || !OS_impl_filehandle_table[id].selectable)
                     {
                         /* out of range of select() implementation */
                         status = OS_ERR_OPERATION_NOT_SUPPORTED;

--- a/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
@@ -112,10 +112,13 @@ void Test_OS_SelectMultiple_Impl(void)
     UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
 
     memset(&ReadSet, 0, sizeof(ReadSet));
-    memset(&WriteSet, 0xff, sizeof(WriteSet));
-    OSAPI_TEST_FUNCTION_RC(OS_SelectMultiple_Impl, (&ReadSet, &WriteSet, 0), OS_SUCCESS);
-    memset(&ReadSet, 0xff, sizeof(ReadSet));
     memset(&WriteSet, 0, sizeof(WriteSet));
+    WriteSet.object_ids[0] = 1;
+    OSAPI_TEST_FUNCTION_RC(OS_SelectMultiple_Impl, (&ReadSet, &WriteSet, 0), OS_SUCCESS);
+
+    memset(&ReadSet, 0, sizeof(ReadSet));
+    memset(&WriteSet, 0, sizeof(WriteSet));
+    ReadSet.object_ids[0] = 1;
     UT_SetDefaultReturnValue(UT_KEY(OCS_select), 0);
     OSAPI_TEST_FUNCTION_RC(OS_SelectMultiple_Impl, (&ReadSet, &WriteSet, 1), OS_ERROR_TIMEOUT);
 
@@ -133,6 +136,13 @@ void Test_OS_SelectMultiple_Impl(void)
 
     /* Test cases where the FD exceeds FD_SETSIZE in the write set */
     memset(&ReadSet, 0, sizeof(ReadSet));
+    memset(&WriteSet, 0xff, sizeof(WriteSet));
+    OSAPI_TEST_FUNCTION_RC(OS_SelectMultiple_Impl, (&ReadSet, &WriteSet, 0), OS_ERR_OPERATION_NOT_SUPPORTED);
+
+    /* Test cases where additional bits are set in the OS_FdSet */
+    UT_PortablePosixIOTest_Set_FD(UT_INDEX_0, 0);
+    UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
+    memset(&ReadSet, 0xff, sizeof(ReadSet));
     memset(&WriteSet, 0xff, sizeof(WriteSet));
     OSAPI_TEST_FUNCTION_RC(OS_SelectMultiple_Impl, (&ReadSet, &WriteSet, 0), OS_ERR_OPERATION_NOT_SUPPORTED);
 


### PR DESCRIPTION
**Describe the contribution**
Fix #921
Do not silently ignore a filehandle which was included in the `OS_FdSet` but the "selectable" flag is false.  Instead translate this to the `OS_ERR_OPERATION_NOT_SUPPORTED` error.

**Testing performed**
Run unit tests on native and RTEMS and make sure all passing

**Expected behavior changes**
Passing a filehandle into `OS_SelectMultiple()` (via the OS_FdSet) for which the RTOS does not implement select() should return the 
OS_ERR_OPERATION_NOT_SUPPORTED error (again)

**System(s) tested on**
Ubuntu 20.04 (native) and RTEMS 4.11.3 (cross)

**Additional context**
This is old behavior but was masked by the fact that OS_SelectMultiple_Impl() actually returned the same error - OS_ERR_OPERATION_NOT_SUPPORTED - for an _empty_ set as it did if one passed a non-empty set that had a non-selectable filehandle within it.  If the handles passed in did not support select() then the implementation treated it as an empty set.

A recent change modified that behavior and gave it a different code if the sets were truly empty vs. being not empty but having a bad FD inside it.

However the unit tests were relying specifically on the OS_ERR_OPERATION_NOT_SUPPORTED code being generated in order to skip the test cases on RTEMS.

This change basically restores the return code of OS_ERR_OPERATION_NOT_SUPPORTED but still keeping a unique code for if/when the sets are passed in completely empty.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
