### PR TITLE
Fix #853, remove OS_TaskRegister

### DIFF
--- a/src/examples/tasking-example/tasking-example.c
+++ b/src/examples/tasking-example/tasking-example.c
@@ -127,8 +127,6 @@ void task_1(void)
 
     OS_printf("Starting task 1\n");
 
-    OS_TaskRegister();
-
     while (1)
     {
         status = OS_MutSemTake(mutex_id);
@@ -170,8 +168,6 @@ void task_2(void)
     uint32 status;
 
     OS_printf("Starting task 2\n");
-
-    OS_TaskRegister();
 
     while (1)
     {
@@ -219,8 +215,6 @@ void task_3(void)
     uint32 status;
 
     OS_printf("Starting task 3\n");
-
-    OS_TaskRegister();
 
     while (1)
     {

--- a/src/os/inc/osapi-task.h
+++ b/src/os/inc/osapi-task.h
@@ -171,18 +171,6 @@ int32 OS_TaskSetPriority(osal_id_t task_id, osal_priority_t new_priority);
 
 /*-------------------------------------------------------------------------------------*/
 /**
- * @brief Obsolete
- * @deprecated Explicit registration call no longer needed
- *
- * Obsolete function retained for compatibility purposes.
- * Does Nothing in the current implementation.
- *
- * @return #OS_SUCCESS (always), see @ref OSReturnCodes
- */
-int32 OS_TaskRegister(void);
-
-/*-------------------------------------------------------------------------------------*/
-/**
  * @brief Obtain the task id of the calling task
  *
  * This function returns the task id of the calling task

--- a/src/os/shared/inc/os-shared-task.h
+++ b/src/os/shared/inc/os-shared-task.h
@@ -166,7 +166,7 @@ int32 OS_TaskGetInfo_Impl(const OS_object_token_t *token, OS_task_prop_t *task_p
     Purpose: Perform registration actions after new task creation
 
         NOTE: This is invoked via the OS_TaskEntryPoint() immediately
-              after new task creation, not through OS_TaskRegister() API
+              after new task creation
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -331,25 +331,6 @@ int32 OS_TaskSetPriority(osal_id_t task_id, osal_priority_t new_priority)
 
 /*----------------------------------------------------------------
  *
- * Function: OS_TaskRegister
- *
- *  Purpose: Implemented per public OSAL API
- *           See description in API and header file for detail
- *
- *-----------------------------------------------------------------*/
-int32 OS_TaskRegister(void)
-{
-    OS_object_token_t token;
-
-    /*
-     * Just to retain compatibility (really, only the unit test cares)
-     * this will return NON success when called from a non-task context
-     */
-    return OS_ObjectIdGetById(OS_LOCK_MODE_NONE, LOCAL_OBJID_TYPE, OS_TaskGetId_Impl(), &token);
-} /* end OS_TaskRegister */
-
-/*----------------------------------------------------------------
- *
  * Function: OS_TaskGetId
  *
  *  Purpose: Implemented per public OSAL API

--- a/src/tests/bin-sem-flush-test/bin-sem-flush-test.c
+++ b/src/tests/bin-sem-flush-test/bin-sem-flush-test.c
@@ -62,7 +62,6 @@ void task_1(void)
     int               counter = 0;
 
     OS_printf("Starting task 1\n");
-    OS_TaskRegister();
 
     OS_printf("TASK 1: Waiting on the semaphore\n");
     status = OS_BinSemTake(bin_sem_id);
@@ -101,7 +100,6 @@ void task_2(void)
 
     task_2_failures = 0;
     OS_printf("Starting task 2\n");
-    OS_TaskRegister();
 
     OS_printf("TASK 2: Waiting on the semaphore\n");
     status = OS_BinSemTake(bin_sem_id);
@@ -139,7 +137,6 @@ void task_3(void)
     int               counter = 0;
 
     OS_printf("Starting task 3\n");
-    OS_TaskRegister();
 
     OS_printf("TASK 3: Waiting on the semaphore\n");
     status = OS_BinSemTake(bin_sem_id);

--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -106,8 +106,6 @@ void task_1(void)
 
     OS_printf("Starting task 1\n");
 
-    OS_TaskRegister();
-
     OS_printf("Delay for 1 second before starting\n");
     OS_TaskDelay(1000);
 

--- a/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
+++ b/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
@@ -101,8 +101,6 @@ void task_1(void)
 
     OS_printf("Starting task 1\n");
 
-    OS_TaskRegister();
-
     OS_printf("Delay for 1 second before starting\n");
     OS_TaskDelay(1000);
 

--- a/src/tests/count-sem-test/count-sem-test.c
+++ b/src/tests/count-sem-test/count-sem-test.c
@@ -59,7 +59,6 @@ void task_1(void)
     uint32 status;
 
     OS_printf("Starting task 1\n");
-    OS_TaskRegister();
 
     while (1)
     {
@@ -100,7 +99,6 @@ void task_2(void)
     uint32 status;
 
     OS_printf("Starting task 2\n");
-    OS_TaskRegister();
 
     while (1)
     {
@@ -126,7 +124,6 @@ void task_3(void)
     uint32 status;
 
     OS_printf("Starting task 3\n");
-    OS_TaskRegister();
 
     while (1)
     {

--- a/src/tests/mutex-test/mutex-test.c
+++ b/src/tests/mutex-test/mutex-test.c
@@ -60,7 +60,6 @@ void task_1(void)
     uint32 status;
 
     OS_printf("Starting task 1\n");
-    OS_TaskRegister();
 
     while (1)
     {
@@ -112,7 +111,6 @@ void task_2(void)
     uint32 status;
 
     OS_printf("Starting task 2\n");
-    OS_TaskRegister();
 
     while (1)
     {
@@ -165,7 +163,6 @@ void task_3(void)
     uint32 status;
 
     OS_printf("Starting task 3\n");
-    OS_TaskRegister();
 
     while (1)
     {

--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -109,8 +109,6 @@ void UtTest_Setup(void)
 
 void task_generic_no_exit(void)
 {
-    OS_TaskRegister();
-
     while (1)
     {
         OS_TaskDelay(100);

--- a/src/tests/queue-test/queue-test.c
+++ b/src/tests/queue-test/queue-test.c
@@ -72,8 +72,6 @@ void task_1(void)
 
     OS_printf("Starting task 1\n");
 
-    OS_TaskRegister();
-
     OS_printf("Delay for 1 second before starting\n");
     OS_TaskDelay(1000);
 

--- a/src/tests/sem-speed-test/sem-speed-test.c
+++ b/src/tests/sem-speed-test/sem-speed-test.c
@@ -96,7 +96,6 @@ void task_1(void)
     uint32 status;
 
     OS_printf("Starting task 1\n");
-    OS_TaskRegister();
 
     while (task_1_work < SEMTEST_WORK_LIMIT)
     {
@@ -123,7 +122,6 @@ void task_2(void)
     uint32 status;
 
     OS_printf("Starting task 2\n");
-    OS_TaskRegister();
 
     while (task_2_work < SEMTEST_WORK_LIMIT)
     {

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -184,17 +184,6 @@ void Test_OS_TaskSetPriority(void)
 
     UtAssert_True(actual == expected, "OS_TaskSetPriority() (%ld) == OS_SUCCESS", (long)actual);
 }
-void Test_OS_TaskRegister(void)
-{
-    /*
-     * Test Case For:
-     * int32 OS_TaskRegister (void)
-     */
-    int32 expected = OS_SUCCESS;
-    int32 actual   = OS_TaskRegister();
-
-    UtAssert_True(actual == expected, "OS_TaskRegister() (%ld) == OS_SUCCESS", (long)actual);
-}
 void Test_OS_TaskGetId(void)
 {
     /*
@@ -360,7 +349,6 @@ void UtTest_Setup(void)
     ADD_TEST(OS_TaskExit);
     ADD_TEST(OS_TaskDelay);
     ADD_TEST(OS_TaskSetPriority);
-    ADD_TEST(OS_TaskRegister);
     ADD_TEST(OS_TaskGetId);
     ADD_TEST(OS_TaskGetIdByName);
     ADD_TEST(OS_TaskGetInfo);

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -79,8 +79,6 @@ void generic_test_task(void)
     osal_id_t      task_id;
     OS_task_prop_t task_prop;
 
-    OS_TaskRegister();
-
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
@@ -332,8 +330,6 @@ void delete_handler_test_task(void)
     osal_id_t      task_id;
     OS_task_prop_t task_prop;
 
-    OS_TaskRegister();
-
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
 
@@ -437,8 +433,6 @@ void exit_test_task(void)
 {
     osal_id_t      task_id;
     OS_task_prop_t task_prop;
-
-    OS_TaskRegister();
 
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);
@@ -657,120 +651,12 @@ UT_os_task_set_priority_test_exit_tag:
     return;
 }
 
-/*--------------------------------------------------------------------------------*
-** Syntax: OS_TaskRegister
-** Purpose: Registers the task, performs application- and OS-specific inits
-** Parameters: To-be-filled-in
-** Returns: OS_ERR_INVALID_ID if the id passed in is not a valid task id
-**          OS_ERROR if the OS call failed
-**          OS_SUCCESS if succeeded
-**--------------------------------------------------------------------------------*/
-void register_test_task(void)
-{
-    osal_id_t      task_id;
-    OS_task_prop_t task_prop;
-
-    g_task_result = OS_TaskRegister();
-
-    task_id = OS_TaskGetId();
-    OS_TaskGetInfo(task_id, &task_prop);
-
-    UtPrintf("Starting RegisterTest Task: %s\n", task_prop.name);
-    ;
-
-    /*
-    ** Release the semaphore so the main function can record the results of the test
-    ** and clean up
-    */
-    OS_BinSemGive(g_task_sync_sem);
-
-    for (;;)
-    {
-        OS_TaskDelay(1000);
-    }
-}
-
-/*--------------------------------------------------------------------------------*/
-
-void UT_os_task_register_test(void)
-{
-    int32       res = 0;
-    const char *testDesc;
-
-    /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    res = OS_TaskRegister();
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_register_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_TaskRegister();
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
-
-    /* Setup */
-    res = OS_BinSemCreate(&g_task_sync_sem, "TaskSync", 1, 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Bin-Sem-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        OS_BinSemTake(g_task_sync_sem);
-
-        res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], register_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
-                            sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-        if (res != OS_SUCCESS)
-        {
-            testDesc = "#3 Nominal - Task-Create failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        }
-        else
-        {
-            /* Wait for the task to finish the test */
-            OS_BinSemTake(g_task_sync_sem);
-            /* Delay to let child task run */
-            OS_TaskDelay(500);
-
-            OS_TaskDelete(g_task_ids[3]);
-            res = OS_BinSemDelete(g_task_sync_sem);
-
-            if (g_task_result == OS_SUCCESS)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-    }
-
-UT_os_task_register_test_exit_tag:
-    return;
-}
-
 /*--------------------------------------------------------------------------------*/
 
 void getid_test_task(void)
 {
     osal_id_t      task_id;
     OS_task_prop_t task_prop;
-
-    OS_TaskRegister();
 
     task_id = OS_TaskGetId();
     OS_TaskGetInfo(task_id, &task_prop);

--- a/src/unit-tests/oscore-test/ut_oscore_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_test.c
@@ -237,7 +237,6 @@ void UtTest_Setup(void)
     UtTest_Add(UT_os_task_exit_test, UT_os_init_task_exit_test, NULL, "OS_TaskExit");
     UtTest_Add(UT_os_task_delay_test, UT_os_init_task_delay_test, NULL, "OS_TaskDelay");
     UtTest_Add(UT_os_task_set_priority_test, UT_os_init_task_set_priority_test, NULL, "OS_TaskSetPriority");
-    UtTest_Add(UT_os_task_register_test, UT_os_init_task_register_test, NULL, "OS_TaskRegister");
     UtTest_Add(UT_os_task_get_id_test, UT_os_init_task_get_id_test, NULL, "OS_TaskGetId");
     UtTest_Add(UT_os_task_get_id_by_name_test, UT_os_init_task_get_id_by_name_test, NULL, "OS_TaskGetIdByName");
     UtTest_Add(UT_os_task_get_info_test, UT_os_init_task_get_info_test, NULL, "OS_TaskGetInfo");

--- a/src/ut-stubs/osapi-utstub-task.c
+++ b/src/ut-stubs/osapi-utstub-task.c
@@ -180,31 +180,6 @@ int32 OS_TaskSetPriority(osal_id_t task_id, osal_priority_t new_priority)
 
 /*****************************************************************************/
 /**
-** \brief OS_TaskRegister stub function
-**
-** \par Description
-**        This function is used to mimic the response of the OS API function
-**        OS_TaskRegister.  The user can adjust the response by setting the value
-**        of UT_OS_Fail prior to this function being called.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        Returns either OS_SUCCESS or OS_ERROR.
-**
-******************************************************************************/
-int32 OS_TaskRegister(void)
-{
-    int32 status;
-
-    status = UT_DEFAULT_IMPL(OS_TaskRegister);
-
-    return status;
-}
-
-/*****************************************************************************/
-/**
 ** \brief OS_TaskGetId stub function
 **
 ** \par Description


### PR DESCRIPTION
**Describe the contribution**
The `OS_TaskRegister()` function is no longer needed and has been a no-op since v5.0.0.

This removes the function and all references to it in code, tests, and documentation.

Fixes #853 

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
No impact to behavior, but does affect API and has depenedencies

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Function removal affects API - Needs to be merged with nasa/cfe#1250.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
