### PR TITLE
Fix #929, use test function for osal_id_t

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -175,7 +175,7 @@ void TestCreatRemove(void)
     /* try creating with file name too big, should fail */
     status = OS_OpenCreate(&fd, longfilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status < OS_SUCCESS, "status after create file name too long = %d", (int)status);
-    UtAssert_True(!OS_ObjectIdDefined(fd), "fd == OS_OBJECT_ID_UNDEFINED");
+    UtAssert_True(!OS_ObjectIdDefined(fd), "fd(%lu) not defined", OS_ObjectIdToInteger(fd));
 
     /* try removing with file name too big. Should Fail */
     status = OS_remove(longfilename);
@@ -236,7 +236,7 @@ void TestOpenClose(void)
     /*  open a file that was never in the system */
     status = OS_OpenCreate(&fd, "/drive0/FileNotHere", OS_FILE_FLAG_NONE, OS_READ_ONLY);
     UtAssert_True(status < OS_SUCCESS, "status after open = %d", (int)status);
-    UtAssert_True(!OS_ObjectIdDefined(fd), "fd == OS_OBJECT_ID_UNDEFINED");
+    UtAssert_True(!OS_ObjectIdDefined(fd), "fd(%lu) not defined", OS_ObjectIdToInteger(fd));
 
     /* try removing the file from the drive  to end the function */
     status = OS_remove(filename);

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -173,10 +173,9 @@ void TestCreatRemove(void)
     UtAssert_True(status == OS_SUCCESS, "status after remove max name length file = %d", (int)status);
 
     /* try creating with file name too big, should fail */
-    fd     = ~OS_OBJECT_ID_UNDEFINED;
     status = OS_OpenCreate(&fd, longfilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
     UtAssert_True(status < OS_SUCCESS, "status after create file name too long = %d", (int)status);
-    UtAssert_UINT32_EQ(fd, OS_OBJECT_ID_UNDEFINED);
+    UtAssert_True(!OS_ObjectIdDefined(fd), "fd == OS_OBJECT_ID_UNDEFINED");
 
     /* try removing with file name too big. Should Fail */
     status = OS_remove(longfilename);
@@ -235,10 +234,9 @@ void TestOpenClose(void)
     UtAssert_True(status != OS_SUCCESS, "status after close = %d", (int)status);
 
     /*  open a file that was never in the system */
-    fd     = ~OS_OBJECT_ID_UNDEFINED;
     status = OS_OpenCreate(&fd, "/drive0/FileNotHere", OS_FILE_FLAG_NONE, OS_READ_ONLY);
     UtAssert_True(status < OS_SUCCESS, "status after open = %d", (int)status);
-    UtAssert_UINT32_EQ(fd, OS_OBJECT_ID_UNDEFINED);
+    UtAssert_True(!OS_ObjectIdDefined(fd), "fd == OS_OBJECT_ID_UNDEFINED");
 
     /* try removing the file from the drive  to end the function */
     status = OS_remove(filename);


### PR DESCRIPTION
**Describe the contribution**
Do not initialize or compare osal_id_t directly to integers, use the provided comparison function.

Fixes #929

**Testing performed**
Build and run unit tests

**Expected behavior changes**
System builds and runs again when using a type-safe/non-integer osal_id_t type.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
