### PR TITLE
Fix #934, Remove unused SCRIPT_MODE flag

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,10 +8,6 @@ enable_testing()
 # Each test module is stored within its own subdir
 file(GLOB OSAL_TESTS *-test)
 
-# The original OSAL tests ran forever until CTRL+C, this does not work for scripted testing
-# This SCRIPT_MODE define plus some hooks in the code allow for limited runs
-add_definitions(-DSCRIPT_MODE)
-
 foreach(OSTEST ${OSAL_TESTS})
   get_filename_component(TESTNAME ${OSTEST} NAME)
   set(TESTFILES)


### PR DESCRIPTION
**Describe the contribution**
Fix #934, Removes the flag defined in tests/CMakeLists.txt that isn't used anywhere

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC