### PR TITLE
Fix #844, switch to use CLOCK_REALTIME

### DIFF
--- a/src/os/portable/os-impl-posix-gettime.c
+++ b/src/os/portable/os-impl-posix-gettime.c
@@ -28,6 +28,12 @@
  * The OS-specific code must \#include the correct headers that define the
  * prototypes for these functions before including this implementation file.
  *
+ * NOTE: The OS-specific header must also define which POSIX clock ID to use -
+ * this specifies the clockid_t parameter to use with clock_gettime().  In
+ * most cases this should be CLOCK_REALTIME to allow the clock to be set, and
+ * so the application will also see any manual/administrative clock changes.
+ *
+ * The clock ID is selected by defining the #OSAL_GETTIME_SOURCE_CLOCK macro.
  */
 
 /****************************************************************************************

--- a/src/os/posix/inc/os-impl-gettime.h
+++ b/src/os/posix/inc/os-impl-gettime.h
@@ -31,6 +31,12 @@
 #include "osconfig.h"
 #include <time.h>
 
-#define OSAL_GETTIME_SOURCE_CLOCK CLOCK_MONOTONIC
+/**
+ * \brief Idenfies the clock ID for OSAL clock operations on POSIX
+ *
+ * This is the POSIX clock ID that will be used to implement
+ * OS_GetLocalTime() and OS_SetLocalTime().
+ */
+#define OSAL_GETTIME_SOURCE_CLOCK CLOCK_REALTIME
 
 #endif /* OS_IMPL_GETTIME_H  */

--- a/src/os/rtems/inc/os-impl-gettime.h
+++ b/src/os/rtems/inc/os-impl-gettime.h
@@ -31,6 +31,12 @@
 #include "osconfig.h"
 #include <time.h>
 
-#define OSAL_GETTIME_SOURCE_CLOCK CLOCK_MONOTONIC
+/**
+ * \brief Idenfies the clock ID for OSAL clock operations on RTEMS
+ *
+ * This is the POSIX clock ID that will be used to implement
+ * OS_GetLocalTime() and OS_SetLocalTime().
+ */
+#define OSAL_GETTIME_SOURCE_CLOCK CLOCK_REALTIME
 
 #endif /* OS_IMPL_GETTIME_H  */

--- a/src/os/vxworks/inc/os-impl-gettime.h
+++ b/src/os/vxworks/inc/os-impl-gettime.h
@@ -31,6 +31,12 @@
 #include "osconfig.h"
 #include <time.h>
 
-#define OSAL_GETTIME_SOURCE_CLOCK CLOCK_MONOTONIC
+/**
+ * \brief Idenfies the clock ID for OSAL clock operations on VxWorks
+ *
+ * This is the POSIX clock ID that will be used to implement
+ * OS_GetLocalTime() and OS_SetLocalTime().
+ */
+#define OSAL_GETTIME_SOURCE_CLOCK CLOCK_REALTIME
 
 #endif /* OS_IMPL_GETTIME_H  */


### PR DESCRIPTION
**Describe the contribution**
The portable clock_gettime implementation had been using CLOCK_MONOTONIC to support its use as a PSP timebase for some platforms that used it this way.  However with updates on the PSP side this is not required anymore.

Preference should be to use CLOCK_REALTIME as it better aligns with the described semantics of the OSAL clock function, and makes for a better default.  This can still be easily changed back if the user desires.

Fixes #844

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
OS_GetLocalTime() and OS_SetLocalTime() will work as described.  

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This depends on _not_ using the OSAL clock as a monotonic timebase.  nasa/psp#285 is required to fix this.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
