### PR TITLE
Fix #944, add OS_API_Teardown

### DIFF
--- a/src/os/inc/osapi-common.h
+++ b/src/os/inc/osapi-common.h
@@ -140,6 +140,33 @@ int32 OS_API_Init(void);
 
 /*-------------------------------------------------------------------------------------*/
 /**
+ * @brief Teardown/de-initialization of OSAL API
+ *
+ * This is the inverse of OS_API_Init().  It will release all OS resources and
+ * return the system to a state similar to what it was prior to invoking
+ * OS_API_Init() initially.
+ *
+ * Normally for embedded applications, the OSAL is initialized after boot and will remain
+ * initialized in memory until the processor is rebooted.  However for testing and
+ * developement purposes, it is potentially useful to reset back to initial conditions.
+ *
+ * For testing purposes, this API is designed/intended to be compatible with the
+ * UtTest_AddTeardown() routine provided by the UT-Assert subsystem.
+ *
+ * @note This is a "best-effort" routine and it may not always be possible/guaranteed
+ * to recover all resources, particularly in the case of off-nominal conditions, or if
+ * a resource is used outside of OSAL.
+ *
+ * For example, while this will attempt to unload all dynamically-loaded modules, doing
+ * so may not be possible and/or may induce undefined behavior if resources are in use by
+ * tasks/functions outside of OSAL.
+ *
+ * @return None
+ */
+void OS_API_Teardown(void);
+
+/*-------------------------------------------------------------------------------------*/
+/**
  * @brief Background thread implementation - waits forever for events to occur.
  *
  * This should be called from the BSP main routine or initial thread after all other

--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -221,6 +221,28 @@ int32 OS_API_Init(void)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_API_Teardown
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_API_Teardown(void)
+{
+    /*
+     * This should delete any remaining user-created objects/tasks
+     */
+    OS_DeleteAllObjects();
+
+    /*
+     * This should cause the "internal" objects (e.g. console utility task)
+     * to exit, and will prevent any new objects from being created.
+     */
+    OS_ApplicationShutdown(true);
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_RegisterEventHandler
  *
  *  Purpose: Implemented per public OSAL API

--- a/src/tests/bin-sem-flush-test/bin-sem-flush-test.c
+++ b/src/tests/bin-sem-flush-test/bin-sem-flush-test.c
@@ -177,6 +177,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -186,6 +186,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
+++ b/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
@@ -181,6 +181,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/count-sem-test/count-sem-test.c
+++ b/src/tests/count-sem-test/count-sem-test.c
@@ -151,6 +151,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -57,6 +57,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * This test case requires a fixed virtual dir for one test case.
      * Just map /test to a dir of the same name, relative to current dir.

--- a/src/tests/file-sys-add-fixed-map-api-test/file-sys-add-fixed-map-api-test.c
+++ b/src/tests/file-sys-add-fixed-map-api-test/file-sys-add-fixed-map-api-test.c
@@ -96,6 +96,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/idmap-api-test/idmap-api-test.c
+++ b/src/tests/idmap-api-test/idmap-api-test.c
@@ -348,6 +348,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/mutex-test/mutex-test.c
+++ b/src/tests/mutex-test/mutex-test.c
@@ -217,6 +217,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -658,6 +658,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -96,6 +96,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     UtTest_Add(TestTasks, NULL, NULL, "TASK");
     UtTest_Add(TestQueues, NULL, NULL, "MSGQ");
     UtTest_Add(TestBinaries, NULL, NULL, "BSEM");

--- a/src/tests/queue-test/queue-test.c
+++ b/src/tests/queue-test/queue-test.c
@@ -247,6 +247,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -596,6 +596,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/sem-speed-test/sem-speed-test.c
+++ b/src/tests/sem-speed-test/sem-speed-test.c
@@ -150,6 +150,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/shell-test/shell-test.c
+++ b/src/tests/shell-test/shell-test.c
@@ -101,6 +101,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/symbol-api-test/symbol-api-test.c
+++ b/src/tests/symbol-api-test/symbol-api-test.c
@@ -112,6 +112,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/time-base-api-test/time-base-api-test.c
+++ b/src/tests/time-base-api-test/time-base-api-test.c
@@ -264,6 +264,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/timer-add-api-test/timer-add-api-test.c
+++ b/src/tests/timer-add-api-test/timer-add-api-test.c
@@ -199,6 +199,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the test setup and check routines in UT assert
      */

--- a/src/tests/timer-test/timer-test.c
+++ b/src/tests/timer-test/timer-test.c
@@ -74,6 +74,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * Register the timer test setup and check routines in UT assert
      */

--- a/src/unit-test-coverage/shared/src/coveragetest-common.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-common.c
@@ -128,6 +128,18 @@ void Test_OS_API_Init(void)
     UT_ResetState(UT_KEY(OS_TaskAPI_Init));
 }
 
+void Test_OS_API_Teardown(void)
+{
+    /*
+     * Test Case For:
+     * void OS_API_Teardown(void);
+     */
+
+    /* Just need to call the API for coverage; there are no conditionals
+     * and the internal functions are each tested separately */
+    OS_API_Teardown();
+}
+
 void Test_OS_ApplicationExit(void)
 {
     /*
@@ -325,4 +337,5 @@ void UtTest_Setup(void)
     ADD_TEST(OS_IdleLoopAndShutdown);
     ADD_TEST(OS_ApplicationExit);
     ADD_TEST(OS_NotifyEvent);
+    ADD_TEST(OS_API_Teardown);
 }

--- a/src/unit-tests/oscore-test/ut_oscore_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_test.c
@@ -188,6 +188,9 @@ void UT_os_init_task_get_info_test()
 
 void UtTest_Setup(void)
 {
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     UtTest_Add(UT_os_apiinit_test, NULL, NULL, "OS_API_Init");
 
     UtTest_Add(UT_os_printf_test, NULL, NULL, "OS_printf");

--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -132,6 +132,9 @@ void UT_os_init_file_misc()
 
 void UtTest_Setup(void)
 {
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     UT_os_initfs_test();
 
     if (UT_os_setup_fs() == OS_SUCCESS)

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_test.c
@@ -121,6 +121,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     UT_os_init_fs_misc();
 
     UtTest_Add(UT_os_makefs_test, NULL, NULL, "OS_mkfs");

--- a/src/unit-tests/osloader-test/ut_osloader_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_test.c
@@ -67,6 +67,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     /*
      * This test needs to load the modules from the filesystem, so
      * there must be a virtual path corresponding to the path where

--- a/src/unit-tests/osnetwork-test/ut_osnetwork_test.c
+++ b/src/unit-tests/osnetwork-test/ut_osnetwork_test.c
@@ -65,6 +65,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     UtTest_Add(UT_os_networkgetid_test, NULL, NULL, "OS_NetworkGetID");
     UtTest_Add(UT_os_networkgethostname_test, NULL, NULL, "OS_NetworkGetHostName");
 }

--- a/src/unit-tests/ostimer-test/ut_ostimer_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_test.c
@@ -193,6 +193,9 @@ void UtTest_Setup(void)
         UtAssert_Abort("OS_API_Init() failed");
     }
 
+    /* the test should call OS_API_Teardown() before exiting */
+    UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
+
     UT_os_init_timer_misc();
 
     UtTest_Add(UT_os_timercreate_test, UT_os_setup_timercreate_test, NULL, "OS_TimerCreate");


### PR DESCRIPTION
**Describe the contribution**
This cleans up all OSAL resources as best as possible, ideally leaving the system in a state where OS_API_Init() may be invoked again.

Fixes #944
Fixes #197 

**Testing performed**
Build and run all unit tests, confirm correct behavior
Test in conjunction with fix for #197, confirm test can be run multiple times on VxWorks without reboot

**Expected behavior changes**
Adds OS_API_Teardown API to complement OS_API_Init

**System(s) tested on**
Ubuntu 20.04 (native)
MCP750 vxworks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.