### PR TITLE
Fix #932, Eliminate time and access name collisions with VxWorks

### DIFF
--- a/src/os/inc/osapi-file.h
+++ b/src/os/inc/osapi-file.h
@@ -125,16 +125,16 @@ typedef enum
  * of outputting the ID/descriptor separately from the return value, rather
  * than relying on the user to convert it back.
  *
- * @param[out] filedes  The handle ID (OS_OBJECT_ID_UNDEFINED on failure)
- * @param[in] path      File name to create or open
- * @param[in] flags     The file permissions - see @ref OS_file_flag_t
- * @param[in] access    Intended access mode - see @ref OSFileAccess
+ * @param[out] filedes     The handle ID (OS_OBJECT_ID_UNDEFINED on failure)
+ * @param[in]  path        File name to create or open
+ * @param[in]  flags       The file permissions - see @ref OS_file_flag_t
+ * @param[in]  access_mode Intended access mode - see @ref OSFileAccess
  *
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_ERROR if the command was not executed properly
  */
-int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access);
+int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access_mode);
 
 /*-------------------------------------------------------------------------------------*/
 /**
@@ -259,14 +259,14 @@ int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, size_t nbytes, int32 
 /**
  * @brief Changes the permissions of a file
  *
- * @param[in] path   File to change
- * @param[in] access Desired access mode - see @ref OSFileAccess
+ * @param[in] path        File to change
+ * @param[in] access_mode Desired access mode - see @ref OSFileAccess
  *
  * @note Some file systems do not implement permissions
  *
  * @return Execution status, see @ref OSReturnCodes
  */
-int32 OS_chmod(const char *path, uint32 access);
+int32 OS_chmod(const char *path, uint32 access_mode);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/portable/os-impl-posix-files.c
+++ b/src/os/portable/os-impl-posix-files.c
@@ -67,7 +67,7 @@
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileOpen_Impl(const OS_object_token_t *token, const char *local_path, int32 flags, int32 access)
+int32 OS_FileOpen_Impl(const OS_object_token_t *token, const char *local_path, int32 flags, int32 access_mode)
 {
     int                             os_perm;
     int                             os_mode;
@@ -79,7 +79,7 @@ int32 OS_FileOpen_Impl(const OS_object_token_t *token, const char *local_path, i
     ** Check for a valid access mode
     ** For creating a file, OS_READ_ONLY does not make sense
     */
-    switch (access)
+    switch (access_mode)
     {
         case OS_WRITE_ONLY:
             os_perm = O_WRONLY;
@@ -223,7 +223,7 @@ int32 OS_FileStat_Impl(const char *local_path, os_fstat_t *FileStats)
  *           See prototype for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
+int32 OS_FileChmod_Impl(const char *local_path, uint32 access_mode)
 {
     mode_t      readbits;
     mode_t      writebits;
@@ -282,7 +282,7 @@ int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
             writebits |= S_IWGRP;
         }
 
-        if (access == OS_WRITE_ONLY || access == OS_READ_WRITE)
+        if (access_mode == OS_WRITE_ONLY || access_mode == OS_READ_WRITE)
         {
             /* set all "write" mode bits */
             st.st_mode |= writebits;
@@ -293,7 +293,7 @@ int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
             st.st_mode &= ~writebits;
         }
 
-        if (access == OS_READ_ONLY || access == OS_READ_WRITE)
+        if (access_mode == OS_READ_ONLY || access_mode == OS_READ_WRITE)
         {
             /* set all "read" mode bits */
             st.st_mode |= readbits;

--- a/src/os/portable/os-impl-posix-gettime.c
+++ b/src/os/portable/os-impl-posix-gettime.c
@@ -67,13 +67,13 @@ int32 OS_GetLocalTime_Impl(OS_time_t *time_struct)
 {
     int             Status;
     int32           ReturnCode;
-    struct timespec time;
+    struct timespec TimeSp;
 
-    Status = clock_gettime(OSAL_GETTIME_SOURCE_CLOCK, &time);
+    Status = clock_gettime(OSAL_GETTIME_SOURCE_CLOCK, &TimeSp);
 
     if (Status == 0)
     {
-        *time_struct = OS_TimeAssembleFromNanoseconds(time.tv_sec, time.tv_nsec);
+        *time_struct = OS_TimeAssembleFromNanoseconds(TimeSp.tv_sec, TimeSp.tv_nsec);
         ReturnCode   = OS_SUCCESS;
     }
     else
@@ -97,12 +97,12 @@ int32 OS_SetLocalTime_Impl(const OS_time_t *time_struct)
 {
     int             Status;
     int32           ReturnCode;
-    struct timespec time;
+    struct timespec TimeSp;
 
-    time.tv_sec  = OS_TimeGetTotalSeconds(*time_struct);
-    time.tv_nsec = OS_TimeGetNanosecondsPart(*time_struct);
+    TimeSp.tv_sec  = OS_TimeGetTotalSeconds(*time_struct);
+    TimeSp.tv_nsec = OS_TimeGetNanosecondsPart(*time_struct);
 
-    Status = clock_settime(OSAL_GETTIME_SOURCE_CLOCK, &time);
+    Status = clock_settime(OSAL_GETTIME_SOURCE_CLOCK, &TimeSp);
 
     if (Status == 0)
     {

--- a/src/os/shared/inc/os-shared-file.h
+++ b/src/os/shared/inc/os-shared-file.h
@@ -115,11 +115,11 @@ int32 OS_GenericClose_Impl(const OS_object_token_t *token);
    Function: OS_FileOpen_Impl
 
     Purpose: Opens the file indicated by "local_path" with permission
-             indicated by "access".
+             indicated by "access_mode".
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileOpen_Impl(const OS_object_token_t *token, const char *local_path, int32 flags, int32 access);
+int32 OS_FileOpen_Impl(const OS_object_token_t *token, const char *local_path, int32 flags, int32 access_mode);
 
 /*----------------------------------------------------------------
    Function: OS_ShellOutputToFile_Impl
@@ -181,7 +181,7 @@ int32 OS_FileRename_Impl(const char *old_path, const char *new_path);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_FileChmod_Impl(const char *local_path, uint32 access);
+int32 OS_FileChmod_Impl(const char *local_path, uint32 access_mode);
 
 /*
  * Internal helper function

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -110,7 +110,7 @@ int32 OS_FileAPI_Init(void)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access)
+int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access_mode)
 {
     int32                        return_code;
     char                         local_path[OS_MAX_LOCAL_PATH_LEN];
@@ -126,7 +126,7 @@ int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 acc
     /*
     ** Check for a valid access mode
     */
-    if (access != OS_WRITE_ONLY && access != OS_READ_ONLY && access != OS_READ_WRITE)
+    if (access_mode != OS_WRITE_ONLY && access_mode != OS_READ_ONLY && access_mode != OS_READ_WRITE)
     {
         return OS_ERROR;
     }
@@ -148,7 +148,7 @@ int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 acc
             OS_OBJECT_INIT(token, stream, stream_name, path);
 
             /* Now call the OS-specific implementation.  */
-            return_code = OS_FileOpen_Impl(&token, local_path, flags, access);
+            return_code = OS_FileOpen_Impl(&token, local_path, flags, access_mode);
 
             /* Check result, finalize record, and unlock global table. */
             return_code = OS_ObjectIdFinalizeNew(return_code, &token, filedes);
@@ -274,7 +274,7 @@ int32 OS_write(osal_id_t filedes, const void *buffer, size_t nbytes)
  *           See description in API and header file for detail
  *
  *-----------------------------------------------------------------*/
-int32 OS_chmod(const char *path, uint32 access)
+int32 OS_chmod(const char *path, uint32 access_mode)
 {
     char  local_path[OS_MAX_LOCAL_PATH_LEN];
     int32 return_code;
@@ -282,7 +282,7 @@ int32 OS_chmod(const char *path, uint32 access)
     return_code = OS_TranslatePath(path, local_path);
     if (return_code == OS_SUCCESS)
     {
-        return_code = OS_FileChmod_Impl(local_path, access);
+        return_code = OS_FileChmod_Impl(local_path, access_mode);
     }
 
     return return_code;

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
@@ -41,7 +41,7 @@ void Test_OS_FileOpen_Impl(void)
 {
     /*
      * Test Case For:
-     * int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int32 access)
+     * int32 OS_FileOpen_Impl(uint32 local_id, const char *local_path, int32 flags, int32 access_mode)
      */
     OS_object_token_t token;
 
@@ -101,7 +101,7 @@ void Test_OS_FileChmod_Impl(void)
 {
     /*
      * Test Case For:
-     * int32 OS_FileChmod_Impl(const char *local_path, uint32 access)
+     * int32 OS_FileChmod_Impl(const char *local_path, uint32 access_mode)
      */
     struct OCS_stat RefStat;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-file.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-file.c
@@ -52,7 +52,7 @@ void Test_OS_OpenCreate(void)
 {
     /*
      * Test Case For:
-     * int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access)
+     * int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access_mode)
      */
     int32     expected;
     int32     actual;
@@ -179,7 +179,7 @@ void Test_OS_chmod(void)
 {
     /*
      * Test Case For:
-     * int32 OS_chmod  (const char *path, uint32 access)
+     * int32 OS_chmod  (const char *path, uint32 access_mode)
      */
     int32 expected = OS_SUCCESS;
     int32 actual   = OS_chmod("/cf/file", 0);

--- a/src/unit-test-coverage/ut-stubs/src/osapi-file-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-file-impl-stubs.c
@@ -39,17 +39,18 @@
  * File API abstraction layer
  */
 
-UT_DEFAULT_STUB(OS_FileOpen_Impl, (const OS_object_token_t *token, const char *local_path, int32 flags, int32 access))
+UT_DEFAULT_STUB(OS_FileOpen_Impl,
+                (const OS_object_token_t *token, const char *local_path, int32 flags, int32 access_mode))
 UT_DEFAULT_STUB(OS_FileStat_Impl, (const char *local_path, os_fstat_t *filestat))
 UT_DEFAULT_STUB(OS_FileRemove_Impl, (const char *local_path))
 UT_DEFAULT_STUB(OS_FileRename_Impl, (const char *old_path, const char *new_path))
-UT_DEFAULT_STUB(OS_FileChmod_Impl, (const char *local_path, uint32 access))
+UT_DEFAULT_STUB(OS_FileChmod_Impl, (const char *local_path, uint32 access_mode))
 UT_DEFAULT_STUB(OS_ShellOutputToFile_Impl, (const OS_object_token_t *token, const char *Cmd))
 
 /*
  * Directory API abstraction layer
  */
-UT_DEFAULT_STUB(OS_DirCreate_Impl, (const char *local_path, uint32 access))
+UT_DEFAULT_STUB(OS_DirCreate_Impl, (const char *local_path, uint32 access_mode))
 UT_DEFAULT_STUB(OS_DirOpen_Impl, (const OS_object_token_t *token, const char *local_path))
 UT_DEFAULT_STUB(OS_DirClose_Impl, (const OS_object_token_t *token))
 UT_DEFAULT_STUB(OS_DirRead_Impl, (const OS_object_token_t *token, os_dirent_t *dirent))

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -136,20 +136,7 @@ void UT_os_initfs_test()
 }
 
 /*--------------------------------------------------------------------------------*
-** Syntax: int32 OS_creat(const char *path, int32 access)
-** Purpose: Creates a file of a given name and access mode, if doesn't exist;
-**          then opens it
-** Parameters: *path - pointer to the absolute path name of the file to be created
-**             access - access modes with which to open a file
-** Returns: OS_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERR_PATH_INVALID is the path passed in is invalid
-**          OS_FS_ERR_PATH_TOO_LONG if the absolute path name passed in is too long
-**          OS_FS_ERR_NAME_TOO_LONG if the file name passed in is too long
-**          OS_ERROR if the OS call failed or file access is invalid
-**          OS_FS_ERR_NO_FREE_IDS if there are no more free file descriptors left in
-**                                the File Descriptor table
-**          A file descriptor value if succeeded
-**          OS_ERR_NOT_IMPLEMENTED if not implemented
+** Purpose: Test OS_OpenCreate for creating files
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
@@ -323,21 +310,7 @@ UT_os_createfile_test_exit_tag:
 }
 
 /*--------------------------------------------------------------------------------*
-** Syntax: int32 OS_open(const char *path, int32 access, uint32 mode)
-** Purpose: Opens a file of a given name and access mode; if it doesn't exist,
-**          creates it first
-** Parameters: *path - pointer to the absolute path name of the file to be created
-**             access - access modes with which to open a file
-**             mode - file permission which is not currently used
-** Returns: OS_INVALID_POINTER if the pointer passed in is null
-**          OS_FS_ERR_PATH_INVALID is the path passed in is invalid
-**          OS_FS_ERR_PATH_TOO_LONG if the absolute path name passed in is too long
-**          OS_FS_ERR_NAME_TOO_LONG if the file name passed in is too long
-**          OS_ERROR if the OS call failed or file access is invalid
-**          OS_FS_ERR_NO_FREE_IDS if there are no more free file descriptors left in
-**                                the File Descriptor table
-**          A file descriptor value if succeeded
-**          OS_ERR_NOT_IMPLEMENTED if not implemented
+** Purpose: Tests OS_OpenCreate for opening files
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine
@@ -1129,11 +1102,7 @@ UT_os_lseekfile_test_exit_tag:
 }
 
 /*--------------------------------------------------------------------------------*
-** Syntax: int32 OS_chmod(const char *path, uint32 access)
-** Purpose: Changes access mode of a given file name
-** Parameters: *path - pointer to the path/name of the given file
-**             access - file access flags
-** Returns: OS_ERR_NOT_IMPLEMENTED if not implemented
+** Purpose: Test OS_chmod
 ** -----------------------------------------------------
 ** Test #0: Not-implemented condition
 **   1) Call this routine

--- a/src/ut-stubs/osapi-utstub-file.c
+++ b/src/ut-stubs/osapi-utstub-file.c
@@ -113,12 +113,12 @@ static int32 UT_GenericWriteStub(const char *fname, UT_EntryKey_t fkey, const vo
  * Stub function for OS_OpenCreate()
  *
  *****************************************************************************/
-int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access)
+int32 OS_OpenCreate(osal_id_t *filedes, const char *path, int32 flags, int32 access_mode)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_OpenCreate), filedes);
     UT_Stub_RegisterContext(UT_KEY(OS_OpenCreate), path);
     UT_Stub_RegisterContextGenericArg(UT_KEY(OS_OpenCreate), flags);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_OpenCreate), access);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_OpenCreate), access_mode);
     int32 status;
 
     status = UT_DEFAULT_IMPL(OS_OpenCreate);
@@ -238,10 +238,10 @@ int32 OS_TimedWrite(osal_id_t filedes, const void *buffer, size_t nbytes, int32 
  * Stub function for OS_chmod()
  *
  *****************************************************************************/
-int32 OS_chmod(const char *path, uint32 access)
+int32 OS_chmod(const char *path, uint32 access_mode)
 {
     UT_Stub_RegisterContext(UT_KEY(OS_chmod), path);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_chmod), access);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OS_chmod), access_mode);
 
     int32 Status;
 


### PR DESCRIPTION
**Describe the contribution**
Fix #932 - changed parameter names to avoid collisions

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: Local docker container
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC