### PR TITLE
Fix #964, UtPrintx function

### DIFF
--- a/ut_assert/src/uttools.c
+++ b/ut_assert/src/uttools.c
@@ -190,19 +190,22 @@ void UtPrintx(const void *Memory, uint32 Length)
     uint32       i;
     uint32       j;
     const uint8 *Byte_ptr = Memory;
-    char         OutputLine[50];
+    char         OutputLine[80];
     char *       OutPtr;
 
     i = 0;
-    while (1)
+    while (i < Length)
     {
+        snprintf(OutputLine, sizeof(OutputLine), "%16lx: ", (unsigned long)&Byte_ptr[i]);
         OutPtr = OutputLine;
+        OutPtr += strlen(OutputLine);
         for (j = 0; j < 16 && i < Length; j++, i++)
         {
             sprintf(OutPtr, "%02X  ", Byte_ptr[i]);
             OutPtr += 3;
         }
-        UtPrintf("%s\n", OutputLine);
+
+        UT_BSP_DoText(UTASSERT_CASETYPE_INFO, OutputLine);
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
Fix the UtPrintx() routine such that the loop stops correctly.  Also improves the output to print the address, not just the data.

Note if UtPrintf is used, one sees the file/line of the UtPrintx function, not the actual test location, so it is better to call
UT_BSP_DoText directly so it omits this extraneous info.

Fixes #964 

**Testing performed**
Temporarily Update a test to use UtPrintx() -- this function was not used in any current tests -- and confirm that the output now works as expected.

**Expected behavior changes**
No infinite loop in UtPrintx, and also it now includes the memory address of the data, not just the data itself.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey Vantage Systems, Inc.
