### PR TITLE
Fix #986, Show CodeQL Preview

### DIFF
--- a/.github/workflows/codeql-osal-default.yml
+++ b/.github/workflows/codeql-osal-default.yml
@@ -1,0 +1,57 @@
+name: "CodeQL Analysis OSAL Default Build"
+
+on:
+  push:
+  pull_request:
+
+env:
+  SIMULATION: native
+  ENABLE_UNIT_TESTS: true
+  OMIT_DEPRECATED: true
+  BUILDTYPE: release
+  PERMISSIVE_MODE: true
+
+jobs:
+
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+
+  CodeQL-Build:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout submodule
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+         languages: c
+         queries: +security-extended, security-and-quality
+
+      - name: Set up for build
+        run: |
+          cp Makefile.sample Makefile
+          make prep
+          
+      - name: Build
+        run: make -j 
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
**Describe the contribution**
Fix #986 
Checkout just the osal repository rather than the entire cFS bundle to allow CodeQL to provide a code preview. 
Code preview is not available when the entire cFS bundle is checked out. The osal itself must be the only repository checked out. 
Since the tests require the cFE repo, they are removed.  

**Testing performed**
Tested locally on forked repository 
![image](https://user-images.githubusercontent.com/69638935/117340871-05606500-ae67-11eb-945e-2837306c923d.png)

Tested on this PR. Example of code scanning result found here: https://github.com/nasa/osal/security/code-scanning/142?query=ref%3Arefs%2Fpull%2F987%2Fmerge
**Expected behavior changes**
Code preview should be available in the osal repository. 

**Additional context**
Tests are not used. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
