### PR TITLE
Fix #988, do not require nonblock mode

### DIFF
--- a/src/os/posix/inc/os-impl-sockets.h
+++ b/src/os/posix/inc/os-impl-sockets.h
@@ -39,6 +39,11 @@
 #define OS_NETWORK_SUPPORTS_IPV6
 
 /*
+ * Socket descriptors should be usable with the select() API
+ */
+#define OS_IMPL_SOCKET_SELECTABLE true
+
+/*
  * A full POSIX-compliant I/O layer should support using
  * nonblocking I/O calls in combination with select().
  */

--- a/src/os/rtems/inc/os-impl-sockets.h
+++ b/src/os/rtems/inc/os-impl-sockets.h
@@ -38,6 +38,11 @@
 #include <netinet/in.h>
 
 /*
+ * Socket descriptors should be usable with the select() API
+ */
+#define OS_IMPL_SOCKET_SELECTABLE true
+
+/*
  * A RTEMS socket I/O layer should support using
  * nonblocking I/O calls in combination with select().
  */

--- a/src/os/vxworks/inc/os-impl-sockets.h
+++ b/src/os/vxworks/inc/os-impl-sockets.h
@@ -39,7 +39,19 @@
 #include <hostLib.h>
 
 /*
+ * Socket descriptors should be usable with the select() API
+ */
+#define OS_IMPL_SOCKET_SELECTABLE true
+
+/*
  * Use the O_NONBLOCK flag on sockets
+ *
+ * NOTE: the fcntl() F_GETFL/F_SETFL opcodes that set descriptor flags may not
+ * work correctly on some version of VxWorks.
+ *
+ * This flag is not strictly required, things still mostly work without it,
+ * but lack of this mode does introduce some potential race conditions if more
+ * than one task attempts to use the same descriptor handle at the same time.
  */
 #define OS_IMPL_SOCKET_FLAGS O_NONBLOCK
 

--- a/src/unit-test-coverage/portable/src/coveragetest-bsd-sockets.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-bsd-sockets.c
@@ -108,8 +108,6 @@ void Test_OS_SocketOpen_Impl(void)
     UT_SetDeferredRetcode(UT_KEY(OCS_fcntl), 1, -1);
     OSAPI_TEST_FUNCTION_RC(OS_SocketOpen_Impl, (&token), OS_SUCCESS);
     UtAssert_STUB_COUNT(OCS_fcntl, 1);
-    UtAssert_True(!UT_PortablePosixIOTest_Get_Selectable(token.obj_idx),
-                  "Socket not selectable without O_NONBLOCK flag");
 
     /* Failure in fcntl() SETFL */
     UT_PortablePosixIOTest_ResetImpl(token.obj_idx);
@@ -117,8 +115,6 @@ void Test_OS_SocketOpen_Impl(void)
     UT_SetDeferredRetcode(UT_KEY(OCS_fcntl), 2, -1);
     OSAPI_TEST_FUNCTION_RC(OS_SocketOpen_Impl, (&token), OS_SUCCESS);
     UtAssert_STUB_COUNT(OCS_fcntl, 2);
-    UtAssert_True(!UT_PortablePosixIOTest_Get_Selectable(token.obj_idx),
-                  "Socket not selectable without O_NONBLOCK flag");
 }
 
 void Test_OS_SocketBind_Impl(void)
@@ -266,8 +262,6 @@ void Test_OS_SocketAccept_Impl(void)
     UT_SetDeferredRetcode(UT_KEY(OCS_fcntl), 1, -1);
     OSAPI_TEST_FUNCTION_RC(OS_SocketAccept_Impl, (&sock_token, &conn_token, &addr, 0), OS_SUCCESS);
     UtAssert_STUB_COUNT(OCS_fcntl, 1);
-    UtAssert_True(!UT_PortablePosixIOTest_Get_Selectable(conn_token.obj_idx),
-                  "Socket not selectable without O_NONBLOCK flag");
 
     /* Failure in fcntl() SETFL */
     UT_PortablePosixIOTest_ResetImpl(conn_token.obj_idx);
@@ -275,8 +269,6 @@ void Test_OS_SocketAccept_Impl(void)
     UT_SetDeferredRetcode(UT_KEY(OCS_fcntl), 2, -1);
     OSAPI_TEST_FUNCTION_RC(OS_SocketAccept_Impl, (&sock_token, &conn_token, &addr, 0), OS_SUCCESS);
     UtAssert_STUB_COUNT(OCS_fcntl, 2);
-    UtAssert_True(!UT_PortablePosixIOTest_Get_Selectable(conn_token.obj_idx),
-                  "Socket not selectable without O_NONBLOCK flag");
 }
 
 void Test_OS_SocketRecvFrom_Impl(void)


### PR DESCRIPTION
**Describe the contribution**
In some versions of VxWorks the fcntl F_GETFL/F_SETFL opcodes do not appear to be implemented, and thus it is not possible
to set O_NONBLOCK mode.  However, this mode is not necessarily required, it is more of a backup/failsafe.

The "selectable" flag should not be dependent on whether O_NONBLOCK flag got set.

This also adjust some timeouts and adds some delays to improve the reliability of network-api-test on VxWorks.  The timeouts
were only 10ms, and this is much too short as messages are getting written on a 9600 baud console (avg 1ms/char).  A single log message can easily take 50-60ms alone.

Fixes #988 

**Testing performed**
Execute network-api-test on supported platforms (esp. VxWorks 6.9 in particular)

**Expected behavior changes**
Test now passes reliably.

**System(s) tested on**
Ubuntu 20.04 (native)
VxWorks 6.9 (MCP750)

**Additional context**
This also requires/depends on #992 for reliable operation.  The console mutex is required to ensure that the various information messages from the client/server tasks inside network-api-test do not clobber eachother, but it also helps synchronize them too.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
