### PR TITLE
Fix #994, fixed invalid inputs for OS_mkdir

### DIFF
--- a/src/tests/file-api-test/file-api-test.c
+++ b/src/tests/file-api-test/file-api-test.c
@@ -471,10 +471,10 @@ void TestMkRmDirFreeBytes(void)
                   "Checking Free Blocks: status=%d blocks=%lu", (int)status, (unsigned long)statbuf.blocks_free);
 
     /* make the two directories */
-    status = OS_mkdir(dir1, 0);
+    status = OS_mkdir(dir1, OS_READ_WRITE);
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 1 = %d", (int)status);
 
-    status = OS_mkdir(dir2, 0);
+    status = OS_mkdir(dir2, OS_READ_WRITE);
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 2 = %d", (int)status);
 
     /* now create two files in the two directories (1 file per directory) */
@@ -580,10 +580,10 @@ void TestOpenReadCloseDir(void)
 
     /* make the two directories */
 
-    status = OS_mkdir(dir1, 0);
+    status = OS_mkdir(dir1, OS_READ_WRITE);
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 1 = %d", (int)status);
 
-    status = OS_mkdir(dir2, 0);
+    status = OS_mkdir(dir2, OS_READ_WRITE);
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 2 = %d", (int)status);
 
     /* now create two files in the two directories (1 file per directory) */
@@ -788,7 +788,7 @@ void TestRename(void)
 
     /* make the directory */
 
-    status = OS_mkdir(dir1, 0);
+    status = OS_mkdir(dir1, OS_READ_WRITE);
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 1 = %d", (int)status);
 
     /* now create a file in the directory */
@@ -866,7 +866,7 @@ void TestStat(void)
     strcpy(buffer1, "111111111111");
 
     /* make the directory */
-    status = OS_mkdir(dir1, 0);
+    status = OS_mkdir(dir1, OS_READ_WRITE);
     UtAssert_True(status == OS_SUCCESS, "status after mkdir 1 = %d", (int)status);
 
     /* now create a file  */

--- a/src/unit-test-coverage/shared/src/coveragetest-dir.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-dir.c
@@ -52,7 +52,7 @@ void Test_OS_mkdir(void)
      * int32 OS_mkdir (const char *path, uint32 access)
      */
     int32 expected = OS_SUCCESS;
-    int32 actual   = OS_mkdir("Dir", 0);
+    int32 actual   = OS_mkdir("Dir", OS_READ_WRITE);
 
     UtAssert_True(actual == expected, "OS_mkdir() (%ld) == OS_SUCCESS", (long)actual);
 }

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -125,24 +125,24 @@ void UT_os_makedir_test()
     /*-----------------------------------------------------*/
     /* #1 Null-pointer-arg */
 
-    UT_RETVAL(OS_mkdir(NULL, 755), OS_INVALID_POINTER);
+    UT_RETVAL(OS_mkdir(NULL, OS_READ_WRITE), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
     /* #2 Path-too-long-arg */
 
-    UT_RETVAL(OS_mkdir(g_longPathName, 755), OS_FS_ERR_PATH_TOO_LONG);
+    UT_RETVAL(OS_mkdir(g_longPathName, OS_READ_WRITE), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
     /* #3 Invalid-path-arg */
 
-    UT_RETVAL(OS_mkdir("tmpDir", 755), OS_FS_ERR_PATH_INVALID);
+    UT_RETVAL(OS_mkdir("tmpDir", OS_READ_WRITE), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
     /* #5 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/mkdir_Nominal", g_mntName);
-    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
+    if (UT_SETUP(OS_mkdir(g_dirName, OS_READ_WRITE)))
     {
         memset(g_fileName, '\0', sizeof(g_fileName));
         UT_os_sprintf(g_fileName, "%s/mkdir_File.txt", g_dirName);
@@ -224,7 +224,7 @@ void UT_os_opendir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/opendir_Nominal", g_mntName);
-    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
+    if (UT_SETUP(OS_mkdir(g_dirName, OS_READ_WRITE)))
     {
         UT_NOMINAL(OS_DirectoryOpen(&dirh, g_dirName));
 
@@ -277,7 +277,7 @@ void UT_os_closedir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/closeDir3", g_mntName);
-    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
+    if (UT_SETUP(OS_mkdir(g_dirName, OS_READ_WRITE)))
     {
         if (UT_SETUP(OS_DirectoryOpen(&dirh, g_dirName)))
         {
@@ -350,15 +350,15 @@ void UT_os_readdir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/readdir_Nominal", g_mntName);
-    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
+    if (UT_SETUP(OS_mkdir(g_dirName, OS_READ_WRITE)))
     {
         memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
         UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
-        if (UT_SETUP(OS_mkdir(g_subdirNames[0], 755)))
+        if (UT_SETUP(OS_mkdir(g_subdirNames[0], OS_READ_WRITE)))
         {
             memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
             UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
-            if (UT_SETUP(OS_mkdir(g_subdirNames[1], 755)))
+            if (UT_SETUP(OS_mkdir(g_subdirNames[1], OS_READ_WRITE)))
             {
                 if (UT_SETUP(OS_DirectoryOpen(&dirh, g_dirName)))
                 {
@@ -433,15 +433,15 @@ void UT_os_rewinddir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/rewinddir_Nominal", g_mntName);
-    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
+    if (UT_SETUP(OS_mkdir(g_dirName, OS_READ_WRITE)))
     {
         memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
         UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
-        if (UT_SETUP(OS_mkdir(g_subdirNames[0], 755)))
+        if (UT_SETUP(OS_mkdir(g_subdirNames[0], OS_READ_WRITE)))
         {
             memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
             UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
-            if (UT_SETUP(OS_mkdir(g_subdirNames[1], 755)))
+            if (UT_SETUP(OS_mkdir(g_subdirNames[1], OS_READ_WRITE)))
             {
                 if (UT_SETUP(OS_DirectoryOpen(&dirh, g_dirName)))
                 {
@@ -546,7 +546,7 @@ void UT_os_removedir_test()
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/rmdir_Nominal", g_mntName);
-    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
+    if (UT_SETUP(OS_mkdir(g_dirName, OS_READ_WRITE)))
     {
         memset(g_fileName, '\0', sizeof(g_fileName));
         UT_os_sprintf(g_fileName, "%s/rmdir_File1.txt", g_dirName);


### PR DESCRIPTION
**Describe the contribution**
Fixes #994
Changed tests to use valid inputs for all OS_mkdir calls. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC