### PR TITLE
Fix #999, propagate status code in OS_rmdir

### DIFF
--- a/src/os/shared/src/osapi-dir.c
+++ b/src/os/shared/src/osapi-dir.c
@@ -248,7 +248,7 @@ int32 OS_rmdir(const char *path)
     return_code = OS_TranslatePath(path, local_path);
     if (return_code == OS_SUCCESS)
     {
-        OS_DirRemove_Impl(local_path);
+        return_code = OS_DirRemove_Impl(local_path);
     }
 
     return return_code;


### PR DESCRIPTION
**Describe the contribution**
The status code from the low level implementation needs to be returned from the caller, in case it was not OS_SUCCESS.

Fixes #999 

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
The status returned from `OS_rmdir()` should now be correct if the implementation failed.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
