### PR TITLE
Fix #981, rework "unit-tests" to use macros

### DIFF
--- a/src/unit-tests/oscore-test/ut_oscore_binsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_binsem_test.c
@@ -73,20 +73,15 @@ void UT_os_bin_sem_create_test()
     osal_id_t sem_ids[OS_MAX_BIN_SEMAPHORES + 1];
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemCreate(&sem_ids[0], "Good", 1, 0)))
-        return;
-    UT_TEARDOWN(OS_BinSemDelete(sem_ids[0]));
+    UT_RETVAL(OS_BinSemCreate(NULL, "BinSem1", 1, 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemCreate(NULL, "BinSem1", 1, 0), OS_INVALID_POINTER, "null pointer arg 1");
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemCreate(&sem_ids[0], NULL, 1, 0), OS_INVALID_POINTER, "null pointer arg 2");
+    UT_RETVAL(OS_BinSemCreate(&sem_ids[0], NULL, 1, 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
     memset(long_sem_name, 'X', sizeof(long_sem_name));
     long_sem_name[sizeof(long_sem_name) - 1] = '\0';
-    UT_RETVAL(OS_BinSemCreate(&sem_ids[0], long_sem_name, 1, 0), OS_ERR_NAME_TOO_LONG, "name too long");
+    UT_RETVAL(OS_BinSemCreate(&sem_ids[0], long_sem_name, 1, 0), OS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
     /* Setup */
@@ -103,8 +98,7 @@ void UT_os_bin_sem_create_test()
 
     if (i == OS_MAX_BIN_SEMAPHORES) /* setup was successful */
     {
-        UT_RETVAL(OS_BinSemCreate(&sem_ids[OS_MAX_BIN_SEMAPHORES], "OneTooMany", 1, 0), OS_ERR_NO_FREE_IDS,
-                  "no free ids");
+        UT_RETVAL(OS_BinSemCreate(&sem_ids[OS_MAX_BIN_SEMAPHORES], "OneTooMany", 1, 0), OS_ERR_NO_FREE_IDS);
     }
 
     /* Reset test environment */
@@ -113,7 +107,7 @@ void UT_os_bin_sem_create_test()
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&sem_ids[0], "DUPLICATE", 1, 0)))
     {
-        UT_RETVAL(OS_BinSemCreate(&sem_ids[0], "DUPLICATE", 1, 0), OS_ERR_NAME_TAKEN, "duplicate name");
+        UT_RETVAL(OS_BinSemCreate(&sem_ids[0], "DUPLICATE", 1, 0), OS_ERR_NAME_TAKEN);
 
         /* Reset test environment */
         UT_TEARDOWN(OS_BinSemDelete(sem_ids[0]));
@@ -139,11 +133,7 @@ void UT_os_bin_sem_delete_test()
     osal_id_t bin_sem_id;
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemDelete(OS_OBJECT_ID_UNDEFINED)))
-        return;
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID, "invalid id arg");
+    UT_RETVAL(OS_BinSemDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "DeleteTest", 1, 0)))
@@ -166,11 +156,7 @@ void UT_os_bin_sem_flush_test()
     osal_id_t bin_sem_id;
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemFlush(OS_OBJECT_ID_UNDEFINED)))
-        return;
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemFlush(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID, "invalid id arg");
+    UT_RETVAL(OS_BinSemFlush(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "FlushTest", 1, 0)))
@@ -194,11 +180,7 @@ void UT_os_bin_sem_give_test()
     osal_id_t bin_sem_id;
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemGive(OS_OBJECT_ID_UNDEFINED)))
-        return;
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemGive(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID, "invalid id arg");
+    UT_RETVAL(OS_BinSemGive(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "GiveTest", 1, 0)))
@@ -223,11 +205,7 @@ void UT_os_bin_sem_take_test()
     osal_id_t bin_sem_id;
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemTake(OS_OBJECT_ID_UNDEFINED)))
-        return;
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemTake(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID, "invalid id arg");
+    UT_RETVAL(OS_BinSemTake(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "TakeTest", 1, 0)))
@@ -251,16 +229,12 @@ void UT_os_bin_sem_timed_wait_test()
     osal_id_t bin_sem_id;
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemTimedWait(OS_OBJECT_ID_UNDEFINED, 1000)))
-        return;
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemTimedWait(UT_OBJID_INCORRECT, 1000), OS_ERR_INVALID_ID, "invalid id arg");
+    UT_RETVAL(OS_BinSemTimedWait(UT_OBJID_INCORRECT, 1000), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "TimedWait", 1, 0)) && UT_SETUP(OS_BinSemTake(bin_sem_id)))
     {
-        UT_RETVAL(OS_BinSemTimedWait(bin_sem_id, 1000), OS_SEM_TIMEOUT, "semtake timed out");
+        UT_RETVAL(OS_BinSemTimedWait(bin_sem_id, 1000), OS_SEM_TIMEOUT);
         UT_TEARDOWN(OS_BinSemDelete(bin_sem_id));
     }
 
@@ -288,22 +262,18 @@ void UT_os_bin_sem_get_id_by_name_test()
     char      long_sem_name[UT_OS_NAME_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemGetIdByName(NULL, "InvalidName")))
-        return;
+    UT_RETVAL(OS_BinSemGetIdByName(NULL, "InvalidName"), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemGetIdByName(NULL, "InvalidName"), OS_INVALID_POINTER, "invalid ptr arg 1");
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemGetIdByName(&bin_sem_id, NULL), OS_INVALID_POINTER, "invalid ptr arg 2");
+    UT_RETVAL(OS_BinSemGetIdByName(&bin_sem_id, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
     memset(long_sem_name, 'Y', sizeof(long_sem_name));
     long_sem_name[sizeof(long_sem_name) - 1] = '\0';
-    UT_RETVAL(OS_BinSemGetIdByName(&bin_sem_id, long_sem_name), OS_ERR_NAME_TOO_LONG, "name too long");
+    UT_RETVAL(OS_BinSemGetIdByName(&bin_sem_id, long_sem_name), OS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemGetIdByName(&bin_sem_id, "NameNotFound"), OS_ERR_NAME_NOT_FOUND, "name not found");
+    UT_RETVAL(OS_BinSemGetIdByName(&bin_sem_id, "NameNotFound"), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "GetIDByName", 1, 0)))
@@ -328,16 +298,12 @@ void UT_os_bin_sem_get_info_test()
     OS_bin_sem_prop_t bin_sem_prop;
 
     /*-----------------------------------------------------*/
-    if (!UT_IMPL(OS_BinSemGetInfo(OS_OBJECT_ID_UNDEFINED, &bin_sem_prop)))
-        return;
-
-    /*-----------------------------------------------------*/
-    UT_RETVAL(OS_BinSemGetInfo(UT_OBJID_INCORRECT, &bin_sem_prop), OS_ERR_INVALID_ID, "invalid id");
+    UT_RETVAL(OS_BinSemGetInfo(UT_OBJID_INCORRECT, &bin_sem_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "GetInfo", 1, 0)))
     {
-        UT_RETVAL(OS_BinSemGetInfo(bin_sem_id, NULL), OS_INVALID_POINTER, "invalid ptr");
+        UT_RETVAL(OS_BinSemGetInfo(bin_sem_id, NULL), OS_INVALID_POINTER);
         UT_TEARDOWN(OS_BinSemDelete(bin_sem_id));
     }
 

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.c
@@ -88,8 +88,6 @@
 *--------------------------------------------------------------------------------*/
 void UT_os_apiinit_test()
 {
-    int32             res = 0;
-    const char *      testDesc;
     osal_id_t         qId;
     osal_blockcount_t qDepth = OSAL_BLOCKCOUNT_C(10);
     size_t            qSize  = OSAL_SIZE_C(4);
@@ -98,52 +96,28 @@ void UT_os_apiinit_test()
     uint32            semInitValue = 1, semOptions = 0;
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Init-not-call-first";
+    /* #1 Init-not-call-first */
 
-    if ((OS_QueueCreate(&qId, "Queue A", qDepth, qSize, qFlags) != OS_SUCCESS) &&
-        (OS_BinSemCreate(&semIds[0], "BinSem 1", semInitValue, semOptions) != OS_SUCCESS) &&
-        (OS_CountSemCreate(&semIds[1], "CountSem 1", semInitValue, semOptions) != OS_SUCCESS) &&
-        (OS_MutSemCreate(&semIds[2], "MutexSem 1", semOptions) != OS_SUCCESS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_QueueDelete(qId);
-    OS_BinSemDelete(semIds[0]);
-    OS_CountSemDelete(semIds[1]);
-    OS_MutSemDelete(semIds[2]);
+    UT_RETVAL(OS_QueueCreate(&qId, "Queue A", qDepth, qSize, qFlags), OS_ERROR);
+    UT_RETVAL(OS_BinSemCreate(&semIds[0], "BinSem 1", semInitValue, semOptions), OS_ERROR);
+    UT_RETVAL(OS_CountSemCreate(&semIds[1], "CountSem 1", semInitValue, semOptions), OS_ERROR);
+    UT_RETVAL(OS_MutSemCreate(&semIds[2], "MutexSem 1", semOptions), OS_ERROR);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
+    /* #2 Nominal */
 
-    res = OS_API_Init();
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        testDesc = "API not implemented";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_apiinit_test_exit_tag;
-    }
-    else if ((res == OS_SUCCESS) && (OS_QueueCreate(&qId, "Queue A", qDepth, qSize, qFlags) == OS_SUCCESS) &&
-             (OS_BinSemCreate(&semIds[0], "BinSem 1", semInitValue, semOptions) == OS_SUCCESS) &&
-             (OS_CountSemCreate(&semIds[1], "CountSem 1", semInitValue, semOptions) == OS_SUCCESS) &&
-             (OS_MutSemCreate(&semIds[2], "MutexSem 1", semOptions) == OS_SUCCESS))
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    }
-    else
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
+    UT_NOMINAL(OS_API_Init());
+
+    UT_RETVAL(OS_QueueCreate(&qId, "Queue A", qDepth, qSize, qFlags), OS_SUCCESS);
+    UT_RETVAL(OS_BinSemCreate(&semIds[0], "BinSem 1", semInitValue, semOptions), OS_SUCCESS);
+    UT_RETVAL(OS_CountSemCreate(&semIds[1], "CountSem 1", semInitValue, semOptions), OS_SUCCESS);
+    UT_RETVAL(OS_MutSemCreate(&semIds[2], "MutexSem 1", semOptions), OS_SUCCESS);
 
     /* Reset test environment */
-    OS_QueueDelete(qId);
-    OS_BinSemDelete(semIds[0]);
-    OS_CountSemDelete(semIds[1]);
-    OS_MutSemDelete(semIds[2]);
-
-UT_os_apiinit_test_exit_tag:
-    return;
+    UT_TEARDOWN(OS_QueueDelete(qId));
+    UT_TEARDOWN(OS_BinSemDelete(semIds[0]));
+    UT_TEARDOWN(OS_CountSemDelete(semIds[1]));
+    UT_TEARDOWN(OS_MutSemDelete(semIds[2]));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -161,10 +135,7 @@ UT_os_apiinit_test_exit_tag:
 void UT_os_printf_test()
 {
     OS_printf_enable();
-    UtPrintf("OS_printf() - #1 Nominal [This is the expected stdout output after API call]\n");
-    OS_printf("OS_printf() - #1 Nominal [ This is the expected stdout output after API call]\n");
-
-    UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
+    UT_MIR_VOID(OS_printf("OS_printf() - #1 Nominal [This is the expected stdout output after API call]\n"));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -184,10 +155,7 @@ void UT_os_printfenable_test()
     OS_printf_disable();
 
     OS_printf_enable();
-    UtPrintf("OS_printf_enable() - #1 Nominal [This is the expected stdout output after API call]\n");
-    OS_printf("OS_printf_enable() - #1 Nominal [This is the expected stdout output after API call]\n");
-
-    UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
+    UT_MIR_VOID(OS_printf("OS_printf_enable() - #1 Nominal [This is the expected stdout output after API call]\n"));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -205,19 +173,15 @@ void UT_os_printfenable_test()
 void UT_os_printfdisable_test()
 {
     OS_printf_enable();
-    UtPrintf("OS_printf_disable() - #1 Nominal [This is the expected stdout output before API call]\n");
-    OS_printf("OS_printf_disable() - #1 Nominal [This is the expected stdout output before API call]\n");
+    UT_MIR_VOID(OS_printf("OS_printf_disable() - #1 Nominal [This is the expected stdout output before API call]\n"));
 
     OS_printf_disable();
-    UtPrintf("OS_printf_disable() - #1 Nominal [This is NOT the expected stdout output after API call]\n");
-    OS_printf("OS_printf_disable() - #1 Nominal [This is NOT the expected stdout output after API call]\n");
-
-    UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
+    UT_MIR_VOID(
+        OS_printf("OS_printf_disable() - #1 Nominal [This is NOT the expected stdout output after API call]\n"));
 
     /* Reset test environment */
     OS_printf_enable();
-    UtPrintf("OS_printf_disable() - #1 Nominal [This is the expected stdout output after test reset]\n");
-    OS_printf("OS_printf_disable() - #1 Nominal [This is the expected stdout output after test reset]\n");
+    UT_MIR_VOID(OS_printf("OS_printf_disable() - #1 Nominal [This is the expected stdout output after test reset]\n"));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -253,60 +217,35 @@ void UT_os_printfdisable_test()
 **--------------------------------------------------------------------------------*/
 void UT_os_getlocaltime_test()
 {
-    OS_time_t   time_struct;
-    const char *testDesc;
-    int32       res = 0, i = 0;
+    OS_time_t time_struct;
+    int32     i = 0;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_GetLocalTime(NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_GetLocalTime(NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_getlocaltime_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
-    res      = OS_GetLocalTime(NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    /* #1 Null-pointer-arg */
+    UT_RETVAL(OS_GetLocalTime(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
+    /* #3 Nominal */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
-
-    res = OS_GetLocalTime(&time_struct);
-    if (res == OS_SUCCESS)
+    for (i = 0; i < 5; i++)
     {
-        UtPrintf("\n");
-        for (i = 0; i < 5; i++)
-        {
-            UtPrintf("OS_GetLocalTime() - #3 Nominal ");
-            UtPrintf("[Expecting output after API call to increase over time: %ld.%ld]\n",
-                     (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
+        UT_NOMINAL(OS_GetLocalTime(&time_struct));
+        UtPrintf("[Expecting output after API call to increase over time: %ld.%ld]\n",
+                 (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
 
-            OS_TaskDelay(20);
-            OS_GetLocalTime(&time_struct);
-        }
-
-        testDesc = "#3 Nominal - Manual inspection required";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_MIR);
-    }
-    else
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        OS_TaskDelay(20);
     }
 
-UT_os_getlocaltime_test_exit_tag:
-    return;
+    /* #3 Nominal - Manual inspection required */
+    UT_MIR_STATUS(OS_GetLocalTime(&time_struct));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -342,84 +281,56 @@ UT_os_getlocaltime_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_setlocaltime_test()
 {
-    OS_time_t   time_struct;
-    const char *testDesc;
-    int32       res = 0, i = 0;
+    OS_time_t time_struct;
+    int32     i = 0;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_SetLocalTime(NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_SetLocalTime(NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_setlocaltime_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    res = OS_GetLocalTime(NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_GetLocalTime(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
+    /* #3 Nominal */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
-
-    res = OS_GetLocalTime(&time_struct);
-    if (res == OS_SUCCESS)
+    for (i = 0; i < 5; i++)
     {
-        for (i = 0; i < 5; i++)
-        {
-            UtPrintf("OS_SetLocalTime() - #3 Nominal ");
-            UtPrintf("[Expecting output before API call to increase over time: %ld.%ld]\n",
-                     (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
+        UT_NOMINAL(OS_GetLocalTime(&time_struct));
+        UtPrintf("[Expecting output before API call to increase over time: %ld.%ld]\n",
+                 (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
 
-            OS_TaskDelay(20);
-            OS_GetLocalTime(&time_struct);
-        }
+        OS_TaskDelay(20);
     }
 
     time_struct = OS_TimeAssembleFromNanoseconds(20000, 123000);
 
-    res = OS_SetLocalTime(&time_struct);
-    if (res == OS_SUCCESS)
+    /*
+     * This case is MIR because on some systems this requires permission,
+     * failure is expected if user does not have the required permission
+     */
+    if (UT_MIR_STATUS(OS_SetLocalTime(&time_struct)))
     {
         UtPrintf("OS_SetLocalTime() - #3 Nominal [New time set at %ld.%ld]\n",
                  (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
 
-        res = OS_GetLocalTime(&time_struct);
-        if (res == OS_SUCCESS)
+        for (i = 0; i < 5; i++)
         {
-            for (i = 0; i < 5; i++)
-            {
-                UtPrintf("OS_SetLocalTime() - #3 Nominal ");
-                UtPrintf("[Expecting output after API call to increase over time: %ld.%ld]\n",
-                         (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
+            UT_NOMINAL(OS_GetLocalTime(&time_struct));
+            UtPrintf("[Expecting output before API call to increase over time: %ld.%ld]\n",
+                     (long)OS_TimeGetTotalSeconds(time_struct), (long)OS_TimeGetMicrosecondsPart(time_struct));
 
-                OS_TaskDelay(20);
-                OS_GetLocalTime(&time_struct);
-            }
+            OS_TaskDelay(20);
         }
 
-        testDesc = "#3 Nominal - Manual inspection required";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_MIR);
+        UT_MIR_STATUS(OS_GetLocalTime(&time_struct));
     }
-    else
-    {
-        /* Most likely it is a permission issue - no way to fix - but OK to ignore this failure */
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-    }
-
-UT_os_setlocaltime_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -448,52 +359,29 @@ UT_os_setlocaltime_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_geterrorname_test(void)
 {
-    int32         res = 0;
     os_err_name_t errNames[4];
-    const char *  testDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    res = OS_GetErrorName(OS_SUCCESS, &errNames[0]);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_geterrorname_test_exit_tag;
-    }
+    UT_RETVAL(OS_GetErrorName(OS_ERROR, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Undefined Error */
 
-    res = OS_GetErrorName(OS_ERROR, NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_GetErrorName(12345, &errNames[0]), OS_ERROR);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Undefined Error";
+    /* #3 Nominal */
 
-    if (OS_GetErrorName(12345, &errNames[0]) == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_NOMINAL(OS_GetErrorName(OS_ERR_NAME_TOO_LONG, &errNames[0]));
+    UtAssert_StrCmp(errNames[0], "OS_ERR_NAME_TOO_LONG", "%s == %s", errNames[0], "OS_ERR_NAME_TOO_LONG");
 
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    UT_NOMINAL(OS_GetErrorName(OS_ERR_NAME_TAKEN, &errNames[1]));
+    UtAssert_StrCmp(errNames[1], "OS_ERR_NAME_TAKEN", "%s == %s", errNames[1], "OS_ERR_NAME_TAKEN");
 
-    if ((OS_GetErrorName(OS_ERR_NAME_TOO_LONG, &errNames[0]) == OS_SUCCESS) &&
-        (strcmp(errNames[0], "OS_ERR_NAME_TOO_LONG") == 0) &&
-        (OS_GetErrorName(OS_ERR_NAME_TAKEN, &errNames[1]) == OS_SUCCESS) &&
-        (strcmp(errNames[1], "OS_ERR_NAME_TAKEN") == 0) &&
-        (OS_GetErrorName(OS_ERR_NO_FREE_IDS, &errNames[2]) == OS_SUCCESS) &&
-        (strcmp(errNames[2], "OS_ERR_NO_FREE_IDS") == 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_geterrorname_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_GetErrorName(OS_ERR_NO_FREE_IDS, &errNames[2]));
+    UtAssert_StrCmp(errNames[2], "OS_ERR_NO_FREE_IDS", "%s == %s", errNames[2], "OS_ERR_NO_FREE_IDS");
 }
 
 /*--------------------------------------------------------------------------------*
@@ -528,45 +416,25 @@ UT_os_geterrorname_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_heapgetinfo_test(void)
 {
-    int32          res = 0;
     OS_heap_prop_t heapProp;
-    const char *   testDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_HeapGetInfo(&heapProp);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_HeapGetInfo(&heapProp)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_heapgetinfo_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    res = OS_HeapGetInfo(NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_HeapGetInfo(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
+    /* #3 Nominal */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
-
-    res = OS_HeapGetInfo(&heapProp);
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_heapgetinfo_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_HeapGetInfo(&heapProp));
 }
 
 /*================================================================================*

--- a/src/unit-tests/oscore-test/ut_oscore_queue_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_queue_test.c
@@ -71,126 +71,70 @@
 **--------------------------------------------------------------------------------*/
 void UT_os_queue_create_test()
 {
-    int         i   = 0;
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   queue_id;
-    osal_id_t   queue_id2;
-    char        queue_name[UT_OS_NAME_BUFF_SIZE];
-    char        long_queue_name[UT_OS_NAME_BUFF_SIZE];
-    uint32      test_setup_invalid = 0;
+    int       i = 0;
+    osal_id_t queue_id;
+    osal_id_t queue_id2;
+    char      queue_name[UT_OS_NAME_BUFF_SIZE];
+    char      long_queue_name[UT_OS_NAME_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg-1 */
 
-    res = OS_QueueCreate(&queue_id, "Good", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_queue_create_test_exit_tag;
-    }
-    /* Clean up */
-    OS_QueueDelete(queue_id);
+    UT_RETVAL(OS_QueueCreate(NULL, "Queue1", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg-1";
+    /* #2 Null-pointer-arg-2 */
 
-    res = OS_QueueCreate(NULL, "Queue1", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_QueueCreate(&queue_id, NULL, OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Null-pointer-arg-2";
-
-    res = OS_QueueCreate(&queue_id, NULL, OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Name-too-long";
+    /* #3 Name-too-long */
 
     memset(long_queue_name, 'X', sizeof(long_queue_name));
     long_queue_name[sizeof(long_queue_name) - 1] = '\0';
-    res = OS_QueueCreate(&queue_id, long_queue_name, OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res == OS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_QueueCreate(&queue_id, long_queue_name, OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0),
+              OS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 No-free-IDs";
+    /* #4 No-free-IDs */
 
     /* Setup */
-    for (i = 0; i < OS_MAX_QUEUES; i++)
+    for (i = 0; i <= OS_MAX_QUEUES; i++)
     {
         memset(queue_name, '\0', sizeof(queue_name));
         UT_os_sprintf(queue_name, "QUEUE%d", i);
-        res = OS_QueueCreate(&queue_id, queue_name, OSAL_BLOCKCOUNT_C(2), sizeof(uint32), 0);
-        if (res != OS_SUCCESS)
+        if (i == OS_MAX_QUEUES)
         {
-            testDesc = "#4 No-free-IDs - Queue Create failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-            test_setup_invalid = 1;
+            UT_RETVAL(OS_QueueCreate(&queue_id, "OneTooMany", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0),
+                      OS_ERR_NO_FREE_IDS);
+        }
+        else if (!UT_SETUP(OS_QueueCreate(&queue_id, queue_name, OSAL_BLOCKCOUNT_C(2), sizeof(uint32), 0)))
+        {
             break;
         }
-    }
-
-    if (test_setup_invalid == 0)
-    {
-        res = OS_QueueCreate(&queue_id, "OneTooMany", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-        if (res == OS_ERR_NO_FREE_IDS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
     }
 
     /* Reset test environment */
     OS_DeleteAllObjects();
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 Duplicate-name";
+    /* #5 Duplicate-name */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id2, "DUPLICATE", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id2, "DUPLICATE", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        UT_OS_TEST_RESULT("Queue Create failed", UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueCreate(&queue_id, "DUPLICATE", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-        if (res == OS_ERR_NAME_TAKEN)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_QueueCreate(&queue_id, "DUPLICATE", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0), OS_ERR_NAME_TAKEN);
 
         /* Reset test environment */
-        res = OS_QueueDelete(queue_id2);
+        UT_TEARDOWN(OS_QueueDelete(queue_id2));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#6 OS-call-failure";
+    /* #7 Nominal */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#7 Nominal";
-
-    res = OS_QueueCreate(&queue_id, "Good", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_NOMINAL(OS_QueueCreate(&queue_id, "Good", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0));
 
     /* Reset test environment */
-    res = OS_QueueDelete(queue_id);
-
-UT_os_queue_create_test_exit_tag:
-    return;
+    UT_TEARDOWN(OS_QueueDelete(queue_id));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -203,55 +147,20 @@ UT_os_queue_create_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_queue_delete_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   queue_id;
+    osal_id_t queue_id;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-ID-arg */
 
-    res = OS_QueueDelete(OS_OBJECT_ID_UNDEFINED);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    UT_RETVAL(OS_QueueDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+
+    /*-----------------------------------------------------*/
+    /* #3 Nominal */
+
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "DeleteTest", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_queue_delete_test_exit_tag;
+        UT_NOMINAL(OS_QueueDelete(queue_id));
     }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_QueueDelete(UT_OBJID_INCORRECT);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
-
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "DeleteTest", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueDelete(queue_id);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
-
-UT_os_queue_delete_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -267,244 +176,104 @@ UT_os_queue_delete_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_queue_get_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   queue_id;
-    uint32      queue_data_out;
-    uint32      queue_data_in;
-    size_t      size_copied;
-    size_t      data_size;
+    osal_id_t queue_id;
+    uint32    queue_data_out;
+    uint32    queue_data_in;
+    size_t    size_copied;
+    size_t    data_size;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-ID-arg */
 
-    res = OS_QueueGet(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_queue_get_test_exit_tag;
-    }
+    UT_RETVAL(OS_QueueGet(UT_OBJID_INCORRECT, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK),
+              OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_QueueGet(UT_OBJID_INCORRECT, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg-1";
+    /* #2 Invalid-pointer-arg-1 */
+    /* #3 Invalid-pointer-arg-2 */
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        testDesc = "#2 Invalid-pointer-arg-1 - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueGet(queue_id, NULL, sizeof(uint32), &size_copied, OS_CHECK);
-        if (res == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_QueueGet(queue_id, NULL, sizeof(uint32), &size_copied, OS_CHECK), OS_INVALID_POINTER);
+        UT_RETVAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), NULL, OS_CHECK), OS_INVALID_POINTER);
 
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-pointer-arg-2";
+    /* #4 Queue-empty */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueEmpty", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        testDesc = "#3 Invalid-pointer-arg-2 - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), NULL, OS_CHECK);
-        if (res == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), &data_size, OS_CHECK), OS_QUEUE_EMPTY);
 
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Queue-empty";
+    /* #5 Queue-timed-out */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueEmpty", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueTimeout", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        testDesc = "#4 Queue-empty - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, OS_CHECK);
-        if (res == OS_QUEUE_EMPTY)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), &data_size, 2), OS_QUEUE_TIMEOUT);
 
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 Queue-timed-out";
+    /* #6 Invalid-queue-size */
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueTimeout", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#5 Queue-timed-out - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, 2);
-        if (res == OS_QUEUE_TIMEOUT)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        res = OS_QueueDelete(queue_id);
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#6 Invalid-queue-size";
-
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#6 Invalid-queue-size - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, OSAL_SIZE_C(2), 0);
-        if (res != OS_SUCCESS)
+        if (UT_SETUP(OS_QueuePut(queue_id, &queue_data_out, OSAL_SIZE_C(2), 0)))
         {
-            testDesc = "#6 Invalid-queue-size - Queue Put failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+            UT_RETVAL(OS_QueueGet(queue_id, &queue_data_in, OSAL_SIZE_C(3), &data_size, OS_CHECK),
+                      OS_QUEUE_INVALID_SIZE);
         }
-        else
-        {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, OSAL_SIZE_C(3), &data_size, OS_CHECK);
-            if (res == OS_QUEUE_INVALID_SIZE)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#7 OS-call-failure";
+    /* #8 Nominal Pend */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#8 Nominal Pend";
-
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#8 Nominal Pend - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
-        if (res != OS_SUCCESS)
+        if (UT_SETUP(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32), 0)))
         {
-            testDesc = "#8 Nominal Pend - Queue Put failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+            UT_NOMINAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), &data_size, OS_PEND));
         }
-        else
-        {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, OS_PEND);
-            if (res == OS_SUCCESS)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#9 Nominal timeout";
+    /* #9 Nominal timeout */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#9 Nominal timeout - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
-        if (res != OS_SUCCESS)
+        if (UT_SETUP(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32), 0)))
         {
-            testDesc = "#9 Nominal timeout - Queue Put failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+            UT_NOMINAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), &data_size, 20));
         }
-        else
-        {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, 20);
-            if (res == OS_SUCCESS)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#10 Nominal check";
+    /* #10 Nominal check */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#10 Nominal check - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
-        if (res != OS_SUCCESS)
+        if (UT_SETUP(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32), 0)))
         {
-            testDesc = "#10 Nominal check - Queue Put failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+            UT_NOMINAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), &data_size, OS_CHECK));
         }
-        else
-        {
-            res = OS_QueueGet(queue_id, (void *)&queue_data_in, sizeof(uint32), &data_size, OS_CHECK);
-            if (res == OS_SUCCESS)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
-
-UT_os_queue_get_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -519,107 +288,55 @@ UT_os_queue_get_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_queue_put_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   queue_id;
-    uint32      queue_data_out = 0;
-    int         i;
+    osal_id_t queue_id;
+    uint32    queue_data_out = 0;
+    int       i;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-ID-arg */
 
-    res = OS_QueuePut(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_out, sizeof(uint32), 0);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_queue_put_test_exit_tag;
-    }
+    UT_RETVAL(OS_QueuePut(UT_OBJID_INCORRECT, (void *)&queue_data_out, sizeof(uint32), 0), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_QueuePut(UT_OBJID_INCORRECT, (void *)&queue_data_out, sizeof(uint32), 0);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg";
+    /* #2 Invalid-pointer-arg */
 
     /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        testDesc = "#2 Invalid-pointer-arg - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueuePut(queue_id, NULL, sizeof(uint32), 0);
-        if (res == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        res = OS_QueueDelete(queue_id);
+        UT_RETVAL(OS_QueuePut(queue_id, NULL, sizeof(uint32), 0), OS_INVALID_POINTER);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
+    /* #4 Queue-full */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Queue-full";
-
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#4 Queue-full - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueuePut", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
         queue_data_out = 0x11223344;
-        for (i = 0; i < 100; i++)
+        for (i = 0; i <= 10; i++)
         {
-            res = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
-            if (res == OS_QUEUE_FULL)
+            if (i == 10)
+            {
+                UT_RETVAL(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32), 0), OS_QUEUE_FULL);
+            }
+            else if (!UT_SETUP(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32), 0)))
+            {
                 break;
+            }
         }
 
-        if (res == OS_QUEUE_FULL)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#5 Nominal - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "QueueGet", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
         queue_data_out = 0x11223344;
-        res            = OS_QueuePut(queue_id, (void *)&queue_data_out, sizeof(uint32), 0);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        res = OS_QueueDelete(queue_id);
+        UT_NOMINAL(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32), 0));
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
-
-UT_os_queue_put_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -633,82 +350,40 @@ UT_os_queue_put_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_queue_get_id_by_name_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   queue_id;
-    char        long_queue_name[UT_OS_NAME_BUFF_SIZE];
+    osal_id_t queue_id;
+    char      long_queue_name[UT_OS_NAME_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-pointer-arg-1 */
 
-    res = OS_QueueGetIdByName(0, "InvalidName");
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_queue_get_id_by_name_test_exit_tag;
-    }
+    UT_RETVAL(OS_QueueGetIdByName(NULL, "Name"), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-pointer-arg-1";
+    /* #2 Invalid-pointer-arg-2 */
 
-    res = OS_QueueGetIdByName(NULL, "InvalidName");
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_QueueGetIdByName(&queue_id, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg-2";
-
-    res = OS_QueueGetIdByName(&queue_id, NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Name-too-long";
+    /* #3 Name-too-long */
 
     memset(long_queue_name, 'Y', sizeof(long_queue_name));
     long_queue_name[sizeof(long_queue_name) - 1] = '\0';
-    res                                          = OS_QueueGetIdByName(&queue_id, long_queue_name);
-    if (res == OS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_QueueGetIdByName(&queue_id, long_queue_name), OS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-not-found";
+    /* #4 Name-not-found */
 
-    res = OS_QueueGetIdByName(&queue_id, "NameNotFound");
-    if (res == OS_ERR_NAME_NOT_FOUND)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_QueueGetIdByName(&queue_id, "NameNotFound"), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "GetIDByName", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "GetIDByName", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        testDesc = "#5 Nominal - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueGetIdByName(&queue_id, "GetIDByName");
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_NOMINAL(OS_QueueGetIdByName(&queue_id, "GetIDByName"));
 
-        res = OS_QueueDelete(queue_id);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
-
-UT_os_queue_get_id_by_name_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -721,74 +396,32 @@ UT_os_queue_get_id_by_name_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_queue_get_info_test()
 {
-    int32           res = 0;
-    const char *    testDesc;
     osal_id_t       queue_id;
     OS_queue_prop_t queue_prop;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-ID-arg */
 
-    res = OS_QueueGetInfo(OS_OBJECT_ID_UNDEFINED, &queue_prop);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    UT_RETVAL(OS_QueueGetInfo(UT_OBJID_INCORRECT, &queue_prop), OS_ERR_INVALID_ID);
+
+    /*-----------------------------------------------------*/
+    /* #2 Invalid-pointer-arg */
+
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "GetInfo", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_queue_get_info_test_exit_tag;
+        UT_RETVAL(OS_QueueGetInfo(queue_id, NULL), OS_INVALID_POINTER);
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
+    /* #3 Nominal */
 
-    res = OS_QueueGetInfo(UT_OBJID_INCORRECT, &queue_prop);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg";
-
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "GetInfo", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_QueueCreate(&queue_id, "GetInfo", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0)))
     {
-        testDesc = "#2 Invalid-pointer-arg - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+        UT_NOMINAL(OS_QueueGetInfo(queue_id, &queue_prop));
+
+        UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
-    else
-    {
-        res = OS_QueueGetInfo(queue_id, NULL);
-        if (res == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        res = OS_QueueDelete(queue_id);
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
-
-    /* Setup */
-    res = OS_QueueCreate(&queue_id, "GetInfo", OSAL_BLOCKCOUNT_C(10), sizeof(uint32), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Queue Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_QueueGetInfo(queue_id, &queue_prop);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        res = OS_QueueDelete(queue_id);
-    }
-
-UT_os_queue_get_info_test_exit_tag:
-    return;
 }
 
 /*================================================================================*

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.h
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.h
@@ -54,6 +54,9 @@
 ** Function prototypes
 **--------------------------------------------------------------------------------*/
 
+void UT_os_select_setup_file(void);
+void UT_os_select_teardown_file(void);
+
 void UT_os_select_fd_test(void);
 void UT_os_select_single_test(void);
 void UT_os_select_multi_test(void);

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -55,6 +55,7 @@ extern char  g_long_task_name[UT_OS_NAME_BUFF_SIZE];
 uint32    g_task_result = 0;
 osal_id_t g_task_sync_sem;
 osal_id_t g_task_ids[UT_OS_TASK_LIST_LEN];
+osal_id_t g_task_get_id_result;
 struct
 {
     uint32 words[UT_TASK_STACK_SIZE];
@@ -104,87 +105,57 @@ void generic_test_task(void)
 **--------------------------------------------------------------------------------*/
 void UT_os_task_create_test()
 {
-    int32       i = 0, res = 0;
-    const char *testDesc;
-    char        task_name[UT_OS_NAME_BUFF_SIZE];
+    int32 i = 0;
+    char  task_name[UT_OS_NAME_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg-1 */
 
-    res = OS_TaskCreate(&g_task_ids[0], g_task_names[0], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[0]),
-                        sizeof(g_task_stacks[0]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_create_test_exit_tag;
-    }
-
-    /* Delay to let child task run */
-    OS_TaskDelay(200);
-
-    /* Reset test environment */
-    OS_TaskDelete(g_task_ids[0]);
+    UT_RETVAL(OS_TaskCreate(NULL, g_task_names[1], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
+                            sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0),
+              OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg-1";
+    /* #2 Null-pointer-arg-2 */
 
-    res = OS_TaskCreate(NULL, g_task_names[1], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
-                        sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_TaskCreate(&g_task_ids[2], NULL, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
+                            sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0),
+              OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Null-pointer-arg-2";
+    /* #3 Null-pointer-arg-3 */
 
-    res = OS_TaskCreate(&g_task_ids[2], NULL, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
-                        sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_TaskCreate(&g_task_ids[3], g_task_names[3], NULL, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                            sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0),
+              OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Null-pointer-arg-3";
+    /* #4 Name-too-long */
 
-    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], NULL, OSAL_STACKPTR_C(&g_task_stacks[3]),
-                        sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_TaskCreate(&g_task_ids[4], g_long_task_name, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[4]),
+                            sizeof(g_task_stacks[4]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0),
+              OS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long";
+    /* #6 No-free-IDs */
 
-    res = OS_TaskCreate(&g_task_ids[4], g_long_task_name, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[4]),
-                        sizeof(g_task_stacks[4]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res == OS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#6 No-free-IDs";
-
-    /* Setup */
     for (i = 0; i <= OS_MAX_TASKS; i++)
     {
         memset(task_name, '\0', sizeof(task_name));
         UT_os_sprintf(task_name, "CREATE_TASK%d", (int)i);
-        res = OS_TaskCreate(&g_task_ids[i], task_name, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[i]),
-                            sizeof(g_task_stacks[i]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-        if (res != OS_SUCCESS)
+        if (i == OS_MAX_TASKS)
+        {
+            UT_RETVAL(OS_TaskCreate(&g_task_ids[i], task_name, generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[i]),
+                                    sizeof(g_task_stacks[i]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0),
+                      OS_ERR_NO_FREE_IDS);
+        }
+        else if (!UT_SETUP(OS_TaskCreate(&g_task_ids[i], task_name, generic_test_task,
+                                         OSAL_STACKPTR_C(&g_task_stacks[i]), sizeof(g_task_stacks[i]),
+                                         OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
         {
             break;
         }
     }
-
-    if ((res == OS_ERR_NO_FREE_IDS) && (i == OS_MAX_TASKS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
 
     /* Delay to let child tasks run */
     OS_TaskDelay(500);
@@ -192,59 +163,37 @@ void UT_os_task_create_test()
     /* Reset test environment */
     for (i = 0; i < OS_MAX_TASKS; i++)
     {
-        res = OS_TaskDelete(g_task_ids[i]); /* Ignore errors, does not matter here */
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[i]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#7 Duplicate-name";
+    /* #7 Duplicate-name */
 
-    /* Setup */
-    res = OS_TaskCreate(&g_task_ids[7], g_task_names[7], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[7]),
-                        sizeof(g_task_stacks[7]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[7], g_task_names[7], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[7]),
+                               sizeof(g_task_stacks[7]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
-        testDesc = "#7 Duplicate-name - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_TaskCreate(&g_task_ids[8], g_task_names[7], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[8]),
-                            sizeof(g_task_stacks[8]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-        if (res == OS_ERR_NAME_TAKEN)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_TaskCreate(&g_task_ids[8], g_task_names[7], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[8]),
+                                sizeof(g_task_stacks[8]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0),
+                  OS_ERR_NAME_TAKEN);
 
         /* Delay to let child task run */
         OS_TaskDelay(200);
 
         /* Reset test environment */
-        res = OS_TaskDelete(g_task_ids[7]);
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[7]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#8 OS-call-failure";
+    /* #9 Nominal */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#9 Nominal";
-
-    res = OS_TaskCreate(&g_task_ids[9], g_task_names[9], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[9]),
-                        sizeof(g_task_stacks[9]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_NOMINAL(OS_TaskCreate(&g_task_ids[9], g_task_names[9], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[9]),
+                             sizeof(g_task_stacks[9]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0));
 
     /* Delay to let child task run */
     OS_TaskDelay(200);
 
     /* Reset test environment */
-    res = OS_TaskDelete(g_task_ids[9]);
-
-UT_os_task_create_test_exit_tag:
-    return;
+    UT_TEARDOWN(OS_TaskDelete(g_task_ids[9]));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -257,58 +206,23 @@ UT_os_task_create_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_task_delete_test()
 {
-    int32       res = 0;
-    const char *testDesc;
+    /*-----------------------------------------------------*/
+    /* #1 Invalid-ID-arg */
+
+    UT_RETVAL(OS_TaskDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    res = OS_TaskDelete(UT_OBJID_INCORRECT);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_delete_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_TaskDelete(UT_OBJID_INCORRECT);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
-                        sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                               sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
         /* Delay to let child task run */
         OS_TaskDelay(200);
 
-        res = OS_TaskDelete(g_task_ids[3]);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_NOMINAL(OS_TaskDelete(g_task_ids[3]));
     }
-
-UT_os_task_delete_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -353,74 +267,40 @@ void delete_handler_test_task(void)
 
 void UT_os_task_install_delete_handler_test(void)
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    res = OS_TaskInstallDeleteHandler(&delete_handler_callback);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_install_delete_handler_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
+    /* #1 Invalid-ID-arg */
 
     /*
     ** This test works because it is being called from the main task
     **  which should not be an official OSAL task
     */
-    res = OS_TaskInstallDeleteHandler(&delete_handler_callback);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_TaskInstallDeleteHandler(&delete_handler_callback), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
+    /* #2 Nominal */
 
-    /* Setup */
-    res = OS_BinSemCreate(&g_task_sync_sem, "TaskSync", 1, 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#2 Nominal - Bin-Sem-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_BinSemCreate(&g_task_sync_sem, "TaskSync", 1, 0)))
     {
         OS_BinSemTake(g_task_sync_sem);
 
-        res =
-            OS_TaskCreate(&g_task_ids[2], g_task_names[2], delete_handler_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
-                          sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-        if (res != OS_SUCCESS)
-        {
-            testDesc = "#2 Nominal - Task-Create-failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        }
-        else
+        if (UT_SETUP(OS_TaskCreate(&g_task_ids[2], g_task_names[2], delete_handler_test_task,
+                                   OSAL_STACKPTR_C(&g_task_stacks[2]), sizeof(g_task_stacks[2]),
+                                   OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
         {
             /* Wait for the task to finish the test */
-            OS_BinSemTake(g_task_sync_sem);
+            UT_SETUP(OS_BinSemTake(g_task_sync_sem));
+
             /* Delay to let child task run */
             OS_TaskDelay(500);
 
-            res = OS_TaskDelete(g_task_ids[2]);
+            UT_TEARDOWN(OS_TaskDelete(g_task_ids[2]));
 
-            if (g_task_result == OS_SUCCESS)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+            UtAssert_True(g_task_result == OS_SUCCESS, "OS_TaskInstallDeleteHandler() (%d) == OS_SUCCESS",
+                          (int)g_task_result);
         }
 
-        res = OS_BinSemDelete(g_task_sync_sem);
+        UT_TEARDOWN(OS_BinSemDelete(g_task_sync_sem));
     }
-
-UT_os_task_install_delete_handler_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -456,35 +336,21 @@ void exit_test_task(void)
 
 void UT_os_task_exit_test(void)
 {
-    int32          res = 0;
     OS_task_prop_t task_prop;
-    const char *   testDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Nominal";
+    /* #1 Nominal */
 
-    /* Setup */
-    res = OS_BinSemCreate(&g_task_sync_sem, "TaskSync", 1, 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_BinSemCreate(&g_task_sync_sem, "TaskSync", 1, 0)))
     {
-        testDesc = "#1 Nominal - Bin-Sem-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        OS_BinSemTake(g_task_sync_sem);
+        UT_SETUP(OS_BinSemTake(g_task_sync_sem));
 
-        res = OS_TaskCreate(&g_task_ids[1], g_task_names[1], exit_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
-                            sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-        if (res != OS_SUCCESS)
-        {
-            testDesc = "#1 Nominal - Task-Create failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        }
-        else
+        if (UT_SETUP(OS_TaskCreate(&g_task_ids[1], g_task_names[1], exit_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
+                                   sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
         {
             /* Wait for the task to finish the test */
-            OS_BinSemTake(g_task_sync_sem);
+            UT_SETUP(OS_BinSemTake(g_task_sync_sem));
+
             /* Delay to let the child task run */
             OS_TaskDelay(500);
 
@@ -492,19 +358,11 @@ void UT_os_task_exit_test(void)
             ** The only real way to tell if TaskExit ran is to check to see if the
             ** task ID is valid. It should not be valid
             */
-            res = OS_TaskGetInfo(g_task_ids[1], &task_prop);
-            if (res == OS_ERR_INVALID_ID)
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-            else
-                UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-            OS_TaskDelete(g_task_ids[1]); /* Won't hurt if its already deleted */
+            UT_RETVAL(OS_TaskGetInfo(g_task_ids[1], &task_prop), OS_ERR_INVALID_ID);
         }
 
-        OS_BinSemDelete(g_task_sync_sem);
+        UT_TEARDOWN(OS_BinSemDelete(g_task_sync_sem));
     }
-
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -516,35 +374,10 @@ void UT_os_task_exit_test(void)
 **--------------------------------------------------------------------------------*/
 void UT_os_task_delay_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #2 Nominal */
 
-    res = OS_TaskDelay(100);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_delay_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
-
-    res = OS_TaskDelay(100);
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_task_delay_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_TaskDelay(100));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -558,110 +391,37 @@ UT_os_task_delay_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_task_set_priority_test()
 {
-    int32       res = 0;
-    const char *testDesc;
+    /*-----------------------------------------------------*/
+    /* #1 Invalid-ID-arg */
+
+    UT_RETVAL(OS_TaskSetPriority(UT_OBJID_INCORRECT, OSAL_PRIORITY_C(100)), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #4 Nominal */
 
-    res = OS_TaskCreate(&g_task_ids[0], g_task_names[0], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[0]),
-                        sizeof(g_task_stacks[0]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[4], g_task_names[4], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[4]),
+                               sizeof(g_task_stacks[4]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
-        testDesc = "#0 API not implemented - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_task_set_priority_test_exit_tag;
-    }
-    else
-    {
-        res = OS_TaskSetPriority(g_task_ids[0], OSAL_PRIORITY_C(UT_TASK_PRIORITY));
-        if (res == OS_ERR_NOT_IMPLEMENTED)
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-            goto UT_os_task_set_priority_test_exit_tag;
-        }
+        UT_NOMINAL(OS_TaskSetPriority(g_task_ids[4], OSAL_PRIORITY_C(UT_TASK_PRIORITY - 10)));
 
         /* Delay to let child task run */
         OS_TaskDelay(500);
 
-        /* Clean up */
-        res = OS_TaskDelete(g_task_ids[0]);
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_TaskSetPriority(UT_OBJID_INCORRECT, OSAL_PRIORITY_C(100));
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-priority";
-
-    res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
-                        sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#2 Invalid-priority - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        /* Delay to let child task run */
-        OS_TaskDelay(500);
+        UT_NOMINAL(OS_TaskSetPriority(g_task_ids[4], OSAL_PRIORITY_C(UT_TASK_PRIORITY)));
 
         /* Reset test environment */
-        res = OS_TaskDelete(g_task_ids[2]);
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[4]));
     }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
-
-    res = OS_TaskCreate(&g_task_ids[4], g_task_names[4], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[4]),
-                        sizeof(g_task_stacks[4]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_TaskSetPriority(g_task_ids[4], OSAL_PRIORITY_C(UT_TASK_PRIORITY - 10));
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        /* Delay to let child task run */
-        OS_TaskDelay(500);
-
-        /* Reset test environment */
-        OS_TaskSetPriority(g_task_ids[4], OSAL_PRIORITY_C(UT_TASK_PRIORITY));
-        OS_TaskDelete(g_task_ids[4]);
-    }
-
-UT_os_task_set_priority_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*/
 
 void getid_test_task(void)
 {
-    osal_id_t      task_id;
     OS_task_prop_t task_prop;
 
-    task_id = OS_TaskGetId();
-    OS_TaskGetInfo(task_id, &task_prop);
-
-    UtPrintf("OS_TaskGetId() - #1 Nominal [This is the returned task Id=%lx]\n", OS_ObjectIdToInteger(task_id));
+    g_task_get_id_result = OS_TaskGetId();
+    OS_TaskGetInfo(g_task_get_id_result, &task_prop);
 
     while (1)
     {
@@ -677,35 +437,23 @@ void getid_test_task(void)
 **--------------------------------------------------------------------------------*/
 void UT_os_task_get_id_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*
      * Note this function does not return a normal status code,
      * there is no provision to return/check for OS_ERR_NOT_IMPLEMENTED.
      */
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Nominal";
+    /* #1 Nominal */
 
-    /* Setup */
-    res = OS_TaskCreate(&g_task_ids[1], g_task_names[1], getid_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
-                        sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
-    {
-        testDesc = "#1 Nominal - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[1], g_task_names[1], getid_test_task, OSAL_STACKPTR_C(&g_task_stacks[1]),
+                               sizeof(g_task_stacks[1]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
         OS_TaskDelay(500);
 
-        UtPrintf("OS_TaskGetId() - #1 Nominal [This is the expected task Id=%lx]\n",
-                 OS_ObjectIdToInteger(g_task_ids[1]));
+        UtAssert_True(OS_ObjectIdEqual(g_task_get_id_result, g_task_ids[1]), "OS_TaskGetId() (%lu) == %lu",
+                      OS_ObjectIdToInteger(g_task_get_id_result), OS_ObjectIdToInteger(g_task_ids[1]));
 
-        res = OS_TaskDelete(g_task_ids[1]); /* Won't hurt if its already deleted */
-
-        UT_OS_TEST_RESULT("#1 Nominal - Manual inspection required", UTASSERT_CASETYPE_MIR);
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[1]));
     }
 }
 
@@ -720,80 +468,41 @@ void UT_os_task_get_id_test()
 **--------------------------------------------------------------------------------*/
 void UT_os_task_get_id_by_name_test()
 {
-    int32       res = 0;
-    const char *testDesc;
+    /*-----------------------------------------------------*/
+    /* #1 Invalid-pointer-arg-1 */
+
+    UT_RETVAL(OS_TaskGetIdByName(NULL, "Name"), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #2 Invalid-pointer-arg-2 */
 
-    res = OS_TaskGetIdByName(0, "InvalidName");
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_get_id_by_name_test_exit_tag;
-    }
+    UT_RETVAL(OS_TaskGetIdByName(&g_task_ids[2], NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-pointer-arg-1";
+    /* #3 Name-too-long */
 
-    res = OS_TaskGetIdByName(NULL, "InvalidName");
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_TaskGetIdByName(&g_task_ids[3], g_long_task_name), OS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg-2";
+    /* #4 Name-not-found */
 
-    res = OS_TaskGetIdByName(&g_task_ids[2], NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_TaskGetIdByName(&g_task_ids[4], "NotFound"), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Name-too-long";
-
-    res = OS_TaskGetIdByName(&g_task_ids[3], g_long_task_name);
-    if (res == OS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Name-not-found";
-
-    res = OS_TaskGetIdByName(&g_task_ids[4], "NameNotFound");
-    if (res == OS_ERR_NAME_NOT_FOUND)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[5], g_task_names[5], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[5]),
-                        sizeof(g_task_stacks[5]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[5], g_task_names[5], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[5]),
+                               sizeof(g_task_stacks[5]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
-        testDesc = "#5 Nominal - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_TaskGetIdByName(&g_task_ids[6], g_task_names[5]);
-        if ((res == OS_SUCCESS) && OS_ObjectIdEqual(g_task_ids[5], g_task_ids[6]))
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_NOMINAL(OS_TaskGetIdByName(&g_task_ids[6], g_task_names[5]));
+
+        UtAssert_True(OS_ObjectIdEqual(g_task_ids[5], g_task_ids[6]), "OS_TaskGetIdByName() ID (%lu) == %lu",
+                      OS_ObjectIdToInteger(g_task_ids[5]), OS_ObjectIdToInteger(g_task_ids[6]));
 
         OS_TaskDelay(500); /* Delay to let task run */
-        res = OS_TaskDelete(g_task_ids[5]);
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[5]));
     }
-
-UT_os_task_get_id_by_name_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -806,83 +515,43 @@ UT_os_task_get_id_by_name_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_task_get_info_test()
 {
-    int32          res = 0;
     OS_task_prop_t task_prop;
-    const char *   testDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-ID-arg */
 
-    res = OS_TaskGetInfo(UT_OBJID_INCORRECT, &task_prop);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_task_get_info_test_exit_tag;
-    }
+    UT_RETVAL(OS_TaskGetInfo(UT_OBJID_INCORRECT, &task_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
-
-    res = OS_TaskGetInfo(UT_OBJID_INCORRECT, &task_prop);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg";
+    /* #2 Invalid-pointer-arg */
 
     /* Setup */
-    res = OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
-                        sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[2], g_task_names[2], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[2]),
+                               sizeof(g_task_stacks[2]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
-        testDesc = "#2 Invalid-pointer-arg - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_TaskGetInfo(g_task_ids[2], NULL);
-        if (res == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_TaskGetInfo(g_task_ids[2], NULL), OS_INVALID_POINTER);
 
         /* Delay to let child task run */
         OS_TaskDelay(500);
 
         /* Reset test environment */
-        res = OS_TaskDelete(g_task_ids[2]);
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[2]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
-    /* Setup */
-    res = OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
-                        sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_TaskCreate(&g_task_ids[3], g_task_names[3], generic_test_task, OSAL_STACKPTR_C(&g_task_stacks[3]),
+                               sizeof(g_task_stacks[3]), OSAL_PRIORITY_C(UT_TASK_PRIORITY), 0)))
     {
-        testDesc = "#3 Nominal - Task-Create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_TaskGetInfo(g_task_ids[3], &task_prop);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_NOMINAL(OS_TaskGetInfo(g_task_ids[3], &task_prop));
 
         /* Delay to let child task run */
         OS_TaskDelay(500);
 
         /* Reset test environment */
-        res = OS_TaskDelete(g_task_ids[3]);
+        UT_TEARDOWN(OS_TaskDelete(g_task_ids[3]));
     }
-
-UT_os_task_get_info_test_exit_tag:
-    return;
 }
 
 /*================================================================================*

--- a/src/unit-tests/oscore-test/ut_oscore_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_test.c
@@ -228,9 +228,9 @@ void UtTest_Setup(void)
     UtTest_Add(UT_os_queue_get_id_by_name_test, NULL, NULL, "OS_QueueGetIdByName");
     UtTest_Add(UT_os_queue_get_info_test, NULL, NULL, "OS_QueueGetInfo");
 
-    UtTest_Add(UT_os_select_fd_test, NULL, NULL, "OS_SelectFd");
-    UtTest_Add(UT_os_select_single_test, NULL, NULL, "OS_SelectSingle");
-    UtTest_Add(UT_os_select_multi_test, NULL, NULL, "OS_SelectMultiple");
+    UtTest_Add(UT_os_select_fd_test, UT_os_select_setup_file, UT_os_select_teardown_file, "OS_SelectFd");
+    UtTest_Add(UT_os_select_single_test, UT_os_select_setup_file, UT_os_select_teardown_file, "OS_SelectSingle");
+    UtTest_Add(UT_os_select_multi_test, UT_os_select_setup_file, UT_os_select_teardown_file, "OS_SelectMultiple");
 
     UtTest_Add(NULL, UT_os_init_task_misc, NULL, "UT_os_init_task_misc");
     UtTest_Add(UT_os_task_create_test, UT_os_init_task_create_test, NULL, "OS_TaskCreate");

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -55,7 +55,7 @@ extern char *g_mntName;
 **--------------------------------------------------------------------------------*/
 
 char g_dirName[UT_OS_PATH_BUFF_SIZE];
-char g_fileName[UT_OS_FILE_BUFF_SIZE];
+char g_fileName[UT_OS_PATH_BUFF_SIZE];
 
 char        g_subdirNames[UT_OS_FILE_MAX_DIRS][UT_OS_PATH_BUFF_SIZE];
 const char *g_tgtSubdirs[UT_OS_FILE_MAX_DIRS] = {"subdir1", "subdir2"};
@@ -120,75 +120,39 @@ void UT_os_read_n_sort_dirs(osal_id_t);
 **--------------------------------------------------------------------------------*/
 void UT_os_makedir_test()
 {
-    int32       status;
-    osal_id_t   fileDesc;
-    const char *testDesc;
+    osal_id_t fileDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_mkdir(NULL, 755) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_makedir_test_exit_tag;
-    }
+    UT_RETVAL(OS_mkdir(NULL, 755), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Path-too-long-arg */
 
-    if (OS_mkdir(NULL, 755) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mkdir(g_longPathName, 755), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #3 Invalid-path-arg */
 
-    if (OS_mkdir(g_longPathName, 755) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mkdir("tmpDir", 755), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-path-arg";
-
-    if (OS_mkdir("tmpDir", 755) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/mkdir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
     {
-        testDesc = "#5 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_makedir_test_exit_tag;
+        memset(g_fileName, '\0', sizeof(g_fileName));
+        UT_os_sprintf(g_fileName, "%s/mkdir_File.txt", g_dirName);
+        UT_NOMINAL(OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE));
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_close(fileDesc));
+        UT_TEARDOWN(OS_remove(g_fileName));
+        UT_TEARDOWN(OS_rmdir(g_dirName));
     }
-
-    memset(g_fileName, '\0', sizeof(g_fileName));
-    UT_os_sprintf(g_fileName, "%s/mkdir_File.txt", g_dirName);
-    status = OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (status >= 0)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_close(fileDesc);
-    OS_remove(g_fileName);
-    OS_rmdir(g_dirName);
-
-UT_os_makedir_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -238,70 +202,36 @@ UT_os_makedir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_opendir_test()
 {
-    osal_id_t   dirh;
-    const char *testDesc;
+    osal_id_t dirh;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_DirectoryOpen(&dirh, NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_opendir_test_exit_tag;
-    }
+    UT_RETVAL(OS_DirectoryOpen(&dirh, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Path-too-long-arg */
 
-    if (OS_DirectoryOpen(&dirh, NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_DirectoryOpen(&dirh, g_longPathName), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #3 Invalid-path-arg */
 
-    if (OS_DirectoryOpen(&dirh, g_longPathName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_DirectoryOpen(&dirh, "/drive0/tmpDir"), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-path-arg";
-
-    if (OS_DirectoryOpen(&dirh, "/drive0/tmpDir") != OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/opendir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
     {
-        testDesc = "#5 Nominal - Dir-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_opendir_test_exit_tag;
+        UT_NOMINAL(OS_DirectoryOpen(&dirh, g_dirName));
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_DirectoryClose(dirh));
+        UT_TEARDOWN(OS_rmdir(g_dirName));
     }
-
-    if (OS_DirectoryOpen(&dirh, g_dirName) == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_DirectoryClose(dirh);
-    OS_rmdir(g_dirName);
-
-UT_os_opendir_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -339,59 +269,25 @@ UT_os_opendir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_closedir_test()
 {
-    osal_id_t    dirh;
-    os_dirent_t *dirEntry = NULL;
-    const char * testDesc;
+    osal_id_t   dirh;
+    os_dirent_t dirEntry;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_DirectoryClose(OS_OBJECT_ID_UNDEFINED) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_closedir_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
+    /* #2 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/closeDir3", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
     {
-        testDesc = "#2 Nominal - Dir-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_closedir_test_exit_tag;
+        if (UT_SETUP(OS_DirectoryOpen(&dirh, g_dirName)))
+        {
+            UT_NOMINAL(OS_DirectoryClose(dirh));
+            UT_RETVAL(OS_DirectoryRead(dirh, &dirEntry), OS_ERR_INVALID_ID);
+        }
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_rmdir(g_dirName));
     }
-
-    if (OS_DirectoryOpen(&dirh, g_dirName) != OS_SUCCESS)
-    {
-        testDesc = "#2 Nominal - Dir-open failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_closedir_test_exit_tag;
-    }
-
-    if (OS_DirectoryClose(dirh) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_closedir_test_exit_tag;
-    }
-
-    if (OS_DirectoryRead(dirh, dirEntry) != OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_rmdir(g_dirName);
-
-UT_os_closedir_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -439,89 +335,50 @@ UT_os_closedir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_readdir_test()
 {
-    osal_id_t   dirh = OS_OBJECT_ID_UNDEFINED;
-    const char *testDesc;
+    osal_id_t dirh = OS_OBJECT_ID_UNDEFINED;
 
     strcpy(g_subdirNames[0], " ");
     strcpy(g_subdirNames[1], " ");
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_DirectoryRead(OS_OBJECT_ID_UNDEFINED, NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_readdir_test_exit_tag;
-    }
+    UT_RETVAL(OS_DirectoryRead(OS_OBJECT_ID_UNDEFINED, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
-
-    if (OS_DirectoryRead(OS_OBJECT_ID_UNDEFINED, NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/readdir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
     {
-        testDesc = "#3 Nominal - Dir-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_readdir_test_exit_tag;
+        memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
+        UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
+        if (UT_SETUP(OS_mkdir(g_subdirNames[0], 755)))
+        {
+            memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
+            UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
+            if (UT_SETUP(OS_mkdir(g_subdirNames[1], 755)))
+            {
+                if (UT_SETUP(OS_DirectoryOpen(&dirh, g_dirName)))
+                {
+                    UT_os_read_n_sort_dirs(dirh);
+
+                    UtAssert_StrCmp(g_dirItems[2], g_tgtSubdirs[0], "%s == %s", g_dirItems[2], g_tgtSubdirs[0]);
+                    UtAssert_StrCmp(g_dirItems[3], g_tgtSubdirs[1], "%s == %s", g_dirItems[3], g_tgtSubdirs[1]);
+
+                    /* Reset test environment */
+                    UT_TEARDOWN(OS_DirectoryClose(dirh));
+                }
+
+                UT_TEARDOWN(OS_rmdir(g_subdirNames[1]));
+            }
+
+            UT_TEARDOWN(OS_rmdir(g_subdirNames[0]));
+        }
+
+        UT_TEARDOWN(OS_rmdir(g_dirName));
     }
-
-    memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
-    UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
-    if (OS_mkdir(g_subdirNames[0], 755) != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Dir-create(subdir1) failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_readdir_test_exit_tag;
-    }
-
-    memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
-    UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
-    if (OS_mkdir(g_subdirNames[1], 755) != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Dir-create(subdir2) failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_readdir_test_exit_tag;
-    }
-
-    if (OS_DirectoryOpen(&dirh, g_dirName) != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - Dir-open failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_readdir_test_exit_tag;
-    }
-
-    UT_os_read_n_sort_dirs(dirh);
-
-    if ((strcmp(g_dirItems[2], g_tgtSubdirs[0]) == 0) && (strcmp(g_dirItems[3], g_tgtSubdirs[1]) == 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_readdir_test_exit_tag:
-    /* Reset test environment */
-    OS_DirectoryClose(dirh);
-    OS_rmdir(g_subdirNames[0]);
-    OS_rmdir(g_subdirNames[1]);
-    OS_rmdir(g_dirName);
-
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -566,94 +423,50 @@ UT_os_readdir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_rewinddir_test()
 {
-    osal_id_t   dirh = OS_OBJECT_ID_UNDEFINED;
-    const char *testDesc;
+    osal_id_t dirh = OS_OBJECT_ID_UNDEFINED;
 
     strcpy(g_subdirNames[0], " ");
     strcpy(g_subdirNames[1], " ");
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
-
-    if (OS_DirectoryRewind(OS_OBJECT_ID_UNDEFINED) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_rewinddir_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
+    /* #2 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/rewinddir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
     {
-        testDesc = "#2 Nominal - Dir-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+        memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
+        UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
+        if (UT_SETUP(OS_mkdir(g_subdirNames[0], 755)))
+        {
+            memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
+            UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
+            if (UT_SETUP(OS_mkdir(g_subdirNames[1], 755)))
+            {
+                if (UT_SETUP(OS_DirectoryOpen(&dirh, g_dirName)))
+                {
+                    UT_os_read_n_sort_dirs(dirh);
+                    UtAssert_StrCmp(g_dirItems[2], g_tgtSubdirs[0], "%s == %s", g_dirItems[2], g_tgtSubdirs[0]);
+                    UtAssert_StrCmp(g_dirItems[3], g_tgtSubdirs[1], "%s == %s", g_dirItems[3], g_tgtSubdirs[1]);
 
-        goto UT_os_rewinddir_test_exit_tag;
+                    UT_NOMINAL(OS_DirectoryRewind(dirh));
+
+                    UT_os_read_n_sort_dirs(dirh);
+                    UtAssert_StrCmp(g_dirItems[2], g_tgtSubdirs[0], "%s == %s", g_dirItems[2], g_tgtSubdirs[0]);
+                    UtAssert_StrCmp(g_dirItems[3], g_tgtSubdirs[1], "%s == %s", g_dirItems[3], g_tgtSubdirs[1]);
+
+                    /* Reset test environment */
+                    UT_TEARDOWN(OS_DirectoryClose(dirh));
+                }
+
+                UT_TEARDOWN(OS_rmdir(g_subdirNames[1]));
+            }
+
+            UT_TEARDOWN(OS_rmdir(g_subdirNames[0]));
+        }
+
+        UT_TEARDOWN(OS_rmdir(g_dirName));
     }
-
-    memset(g_subdirNames[0], '\0', sizeof(g_subdirNames[0]));
-    UT_os_sprintf(g_subdirNames[0], "%s/%s", g_dirName, g_tgtSubdirs[0]);
-    if (OS_mkdir(g_subdirNames[0], 755) != OS_SUCCESS)
-    {
-        testDesc = "#2 Nominal - Dir-create(subdir1) failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_rewinddir_test_exit_tag;
-    }
-
-    memset(g_subdirNames[1], '\0', sizeof(g_subdirNames[1]));
-    UT_os_sprintf(g_subdirNames[1], "%s/%s", g_dirName, g_tgtSubdirs[1]);
-    if (OS_mkdir(g_subdirNames[1], 755) != OS_SUCCESS)
-    {
-        testDesc = "#2 Nominal - Dir-create(subdir2) failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_rewinddir_test_exit_tag;
-    }
-
-    if (OS_DirectoryOpen(&dirh, g_dirName) != OS_SUCCESS)
-    {
-        testDesc = "#2 Nominal - Dir-open failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_rewinddir_test_exit_tag;
-    }
-
-    UT_os_read_n_sort_dirs(dirh);
-
-    if ((strcmp(g_dirItems[2], g_tgtSubdirs[0]) != 0) || (strcmp(g_dirItems[3], g_tgtSubdirs[1]) != 0))
-    {
-        testDesc = "#2 Nominal - Dir-read failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        goto UT_os_rewinddir_test_exit_tag;
-    }
-
-    OS_DirectoryRewind(dirh);
-
-    UT_os_read_n_sort_dirs(dirh);
-
-    if ((strcmp(g_dirItems[2], g_tgtSubdirs[0]) != 0) || (strcmp(g_dirItems[3], g_tgtSubdirs[1]) != 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-
-UT_os_rewinddir_test_exit_tag:
-    /* Reset test environment */
-    OS_DirectoryClose(dirh);
-    OS_rmdir(g_subdirNames[0]);
-    OS_rmdir(g_subdirNames[1]);
-    OS_rmdir(g_dirName);
-
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -711,94 +524,53 @@ UT_os_rewinddir_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_removedir_test()
 {
-    int32       status;
-    osal_id_t   fileDesc;
-    const char *testDesc;
+    osal_id_t fileDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_rmdir(NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_removedir_test_exit_tag;
-    }
+    UT_RETVAL(OS_rmdir(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Path-too-long-arg */
 
-    if (OS_rmdir(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rmdir(g_longPathName), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #3 Invalid-path-arg */
 
-    if (OS_rmdir(g_longPathName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rmdir("tmpDir"), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-path-arg";
-
-    if (OS_rmdir("tmpDir") == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
     memset(g_dirName, '\0', sizeof(g_dirName));
     UT_os_sprintf(g_dirName, "%s/rmdir_Nominal", g_mntName);
-    if (OS_mkdir(g_dirName, 755) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkdir(g_dirName, 755)))
     {
-        testDesc = "#5 Nominal - Dir-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_removedir_test_exit_tag;
+        memset(g_fileName, '\0', sizeof(g_fileName));
+        UT_os_sprintf(g_fileName, "%s/rmdir_File1.txt", g_dirName);
+        if (UT_SETUP(OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
+        {
+            UT_RETVAL(OS_rmdir(g_dirName), OS_ERROR);
+
+            /* Must close and remove all files before the directory can be removed */
+            UT_TEARDOWN(OS_close(fileDesc));
+            UT_TEARDOWN(OS_remove(g_fileName));
+
+            UT_NOMINAL(OS_rmdir(g_dirName));
+
+            memset(g_fileName, '\0', sizeof(g_fileName));
+            UT_os_sprintf(g_fileName, "%s/rmdir_File2.txt", g_dirName);
+            UT_RETVAL(OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE),
+                      OS_ERROR);
+        }
     }
-
-    memset(g_fileName, '\0', sizeof(g_fileName));
-    UT_os_sprintf(g_fileName, "%s/rmdir_File1.txt", g_dirName);
-    status = OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (status < 0)
-    {
-        testDesc = "#5 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-
-    /* Must close and remove all files before the directory can be removed */
-    OS_close(fileDesc);
-    OS_remove(g_fileName);
-
-    if (OS_rmdir(g_dirName) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_removedir_test_exit_tag;
-    }
-
-    memset(g_fileName, '\0', sizeof(g_fileName));
-    UT_os_sprintf(g_fileName, "%s/rmdir_File2.txt", g_dirName);
-    status = OS_OpenCreate(&fileDesc, g_fileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (status < 0)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_removedir_test_exit_tag:
-    return;
 }
 
-/*--------------------------------------------------------------------------------*
+/*--------------------------------------------------------------------------------
  * Internal helper function
- **--------------------------------------------------------------------------------*/
+ *--------------------------------------------------------------------------------*/
 void UT_os_read_n_sort_dirs(osal_id_t dirh)
 {
     int         i = 0;

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -105,34 +105,7 @@ char g_writeBuff[UT_OS_IO_BUFF_SIZE];
 *--------------------------------------------------------------------------------*/
 void UT_os_initfs_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Init-not-call-first - Test case not applicable on platform";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
-
-    /* Call to OS_FS_Init is inside OS_API_Init */
-    res = OS_API_Init();
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        testDesc = "API not implemented";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-    }
-    else if (res == OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    }
-    else
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
-
-    return;
+    UT_NOMINAL(OS_API_Init());
 }
 
 /*--------------------------------------------------------------------------------*
@@ -196,117 +169,80 @@ void UT_os_initfs_test()
 **--------------------------------------------------------------------------------*/
 void UT_os_createfile_test()
 {
-    const char *testDesc;
-    int32       res = 0, i = 0, j = 0;
-    osal_id_t   fd;
+    int32     i = 0, j = 0;
+    osal_id_t fd;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_OpenCreate(NULL, NULL, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_createfile_test_exit_tag;
-    }
+    UT_RETVAL(OS_OpenCreate(NULL, "file", OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE),
+              OS_INVALID_POINTER);
+    UT_RETVAL(OS_OpenCreate(&fd, NULL, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_OpenCreate(NULL, "file", OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    if (OS_OpenCreate(&fd, NULL, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_OpenCreate(&fd, g_invalidPath, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE),
+              OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_OpenCreate(&fd, g_invalidPath, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE) ==
-        OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_OpenCreate(&fd, g_longPathName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE),
+              OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #4 Name-too-long-arg */
 
-    if (OS_OpenCreate(&fd, g_longPathName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE) ==
-        OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_OpenCreate(&fd, g_longFileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE),
+              OS_FS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long-arg";
-
-    if (OS_OpenCreate(&fd, g_longFileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE) ==
-        OS_FS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Invalid-permission-arg";
+    /* #5 Invalid-permission-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Create_InvPerm.txt", g_mntName);
-    res = OS_OpenCreate(&fd, g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, 123);
-    if (res == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
+    UT_RETVAL(OS_OpenCreate(&fd, g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, 123), OS_ERROR);
 
     /*-----------------------------------------------------*/
-    testDesc = "#6 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#7 File-descriptors-full";
+    /* #7 File-descriptors-full */
 
     for (i = 0; i <= OS_MAX_NUM_OPEN_FILES; i++)
     {
         memset(g_fNames[i], '\0', sizeof(g_fNames[i]));
         UT_os_sprintf(g_fNames[i], "%s/tmpFile%d.txt", g_mntName, (int)i);
-        g_fStatus[i] =
-            OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-        if (g_fStatus[i] < 0)
+        if (i == OS_MAX_NUM_OPEN_FILES)
+        {
+            UT_RETVAL(
+                OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+                OS_ERR_NO_FREE_IDS);
+        }
+        else if (!UT_SETUP(OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE,
+                                         OS_WRITE_ONLY)))
+        {
             break;
+        }
     }
 
-    if ((i == OS_MAX_NUM_OPEN_FILES) && (g_fStatus[i] == OS_ERR_NO_FREE_IDS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
     /* Reset test environment */
-    for (j = 0; j < i; j++)
+    for (j = 0; j < i && j < OS_MAX_NUM_OPEN_FILES; j++)
     {
-        OS_close(g_fDescs[j]);
-        OS_remove(g_fNames[j]);
+        UT_TEARDOWN(OS_close(g_fDescs[j]));
+        UT_TEARDOWN(OS_remove(g_fNames[j]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#8 Nominal";
+    /* #8 Nominal */
 
-    g_fStatus[5] = OS_OpenCreate(&g_fDescs[5], g_fNames[5], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-    g_fStatus[6] = OS_OpenCreate(&g_fDescs[6], g_fNames[6], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
+    UT_NOMINAL(OS_OpenCreate(&g_fDescs[5], g_fNames[5], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY));
+    UT_NOMINAL(OS_OpenCreate(&g_fDescs[6], g_fNames[6], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY));
 
-    if ((OS_close(g_fDescs[5]) != OS_SUCCESS) || (OS_close(g_fDescs[6]) != OS_SUCCESS) ||
-        (OS_remove(g_fNames[5]) != OS_SUCCESS) || (OS_remove(g_fNames[6]) != OS_SUCCESS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
+    /* Reset test environment */
+    UT_TEARDOWN(OS_close(g_fDescs[5]));
+    UT_TEARDOWN(OS_close(g_fDescs[6]));
 
-UT_os_createfile_test_exit_tag:
-    return;
+    UT_TEARDOWN(OS_remove(g_fNames[5]));
+    UT_TEARDOWN(OS_remove(g_fNames[6]));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -370,154 +306,107 @@ UT_os_createfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_openfile_test()
 {
-    const char *testDesc;
-    int32       res = 0, i = 0, j = 0, continueFlg = 0;
-    osal_id_t   fd;
+    int32     i = 0, j = 0;
+    osal_id_t fd;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_OpenCreate(&fd, NULL, OS_FILE_FLAG_NONE, OS_READ_WRITE) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_openfile_test_exit_tag;
-    }
+    UT_RETVAL(OS_OpenCreate(&fd, NULL, OS_FILE_FLAG_NONE, OS_READ_WRITE), OS_INVALID_POINTER);
+    UT_RETVAL(OS_OpenCreate(NULL, "file", OS_FILE_FLAG_NONE, OS_READ_WRITE), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_OpenCreate(&fd, NULL, OS_FILE_FLAG_NONE, OS_READ_WRITE) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    if (OS_OpenCreate(NULL, "file", OS_FILE_FLAG_NONE, OS_READ_WRITE) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_OpenCreate(&fd, g_invalidPath, OS_FILE_FLAG_NONE, OS_READ_WRITE), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_OpenCreate(&fd, g_invalidPath, OS_FILE_FLAG_NONE, OS_READ_WRITE) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_OpenCreate(&fd, g_longPathName, OS_FILE_FLAG_NONE, OS_READ_WRITE), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #4 Name-too-long-arg */
 
-    if (OS_OpenCreate(&fd, g_longPathName, OS_FILE_FLAG_NONE, OS_READ_WRITE) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_OpenCreate(&fd, g_longFileName, OS_FILE_FLAG_NONE, OS_READ_WRITE), OS_FS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long-arg";
-
-    if (OS_OpenCreate(&fd, g_longFileName, OS_FILE_FLAG_NONE, OS_READ_WRITE) == OS_FS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Invalid-permission-arg";
+    /* #5 Invalid-permission-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Open_InvPerm.txt", g_mntName);
-    res = OS_OpenCreate(&fd, g_fNames[0], OS_FILE_FLAG_NONE, 123);
-    if (res == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
+    UT_RETVAL(OS_OpenCreate(&fd, g_fNames[0], OS_FILE_FLAG_NONE, 123), OS_ERROR);
 
     /*-----------------------------------------------------*/
-    testDesc = "#6 OS-call-failure";
+    /* #7 File-descriptors-full */
 
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#7 File-descriptors-full";
-
-    continueFlg = 1;
+    /* This first needs to create all the files */
     for (i = 0; i < OS_MAX_NUM_OPEN_FILES; i++)
     {
         memset(g_fNames[i], '\0', sizeof(g_fNames[i]));
         UT_os_sprintf(g_fNames[i], "%s/tmpFile%d.txt", g_mntName, (int)i);
-        g_fStatus[i] =
-            OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-        if (g_fStatus[i] < OS_SUCCESS)
+        if (!UT_SETUP(
+                OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY)))
         {
-            testDesc = "#7 File-descriptors-full - File-create failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-            continueFlg = 0;
             break;
         }
 
-        if (continueFlg && (OS_close(g_fDescs[i]) != OS_SUCCESS))
+        if (!UT_SETUP(OS_close(g_fDescs[i]) != OS_SUCCESS))
         {
-            testDesc = "#7 File-descriptors-full - File-close failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-            continueFlg = 0;
             break;
         }
     }
 
-    if (continueFlg)
+    if (i < OS_MAX_NUM_OPEN_FILES)
     {
-        for (i = 0; i <= OS_MAX_NUM_OPEN_FILES; i++)
-        {
-            g_fStatus[i] = OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_NONE, OS_WRITE_ONLY);
-            if (g_fStatus[i] < 0)
-                break;
-        }
+        /* setup failure, stop test now (already reported) */
+        return;
+    }
 
-        if ((i == OS_MAX_NUM_OPEN_FILES) && (g_fStatus[i] < OS_SUCCESS))
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        /* Reset test environment */
-        for (j = 0; j < i; j++)
+    for (i = 0; i <= OS_MAX_NUM_OPEN_FILES; i++)
+    {
+        if (i == OS_MAX_NUM_OPEN_FILES)
         {
-            OS_close(g_fDescs[j]);
-            OS_remove(g_fNames[j]);
+            UT_RETVAL(OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_NONE, OS_WRITE_ONLY), OS_ERR_NO_FREE_IDS);
         }
+        else if (!UT_SETUP(OS_OpenCreate(&g_fDescs[i], g_fNames[i], OS_FILE_FLAG_NONE, OS_WRITE_ONLY)))
+        {
+            break;
+        }
+    }
+
+    /* Reset test environment */
+    for (j = 0; j < i && j < OS_MAX_NUM_OPEN_FILES; j++)
+    {
+        UT_TEARDOWN(OS_close(g_fDescs[j]));
+        UT_TEARDOWN(OS_remove(g_fNames[j]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#8 Nominal";
+    /* #8 Nominal */
 
-    g_fStatus[5] = OS_OpenCreate(&g_fDescs[5], g_fNames[5], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    g_fStatus[6] = OS_OpenCreate(&g_fDescs[6], g_fNames[6], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-    if ((g_fStatus[5] < OS_SUCCESS) || (g_fStatus[6] < OS_SUCCESS))
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[5], g_fNames[5], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#8 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_openfile_test_exit_tag;
+        UT_SETUP(OS_close(g_fDescs[5]));
+
+        if (UT_SETUP(
+                OS_OpenCreate(&g_fDescs[6], g_fNames[6], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY)))
+        {
+            UT_SETUP(OS_close(g_fDescs[6]));
+
+            UT_NOMINAL(
+                OS_OpenCreate(&g_fDescs[5], g_fNames[5], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE));
+            UT_NOMINAL(
+                OS_OpenCreate(&g_fDescs[6], g_fNames[6], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY));
+
+            UT_TEARDOWN(OS_close(g_fDescs[5]));
+            UT_TEARDOWN(OS_close(g_fDescs[6]));
+
+            UT_TEARDOWN(OS_remove(g_fNames[6]));
+        }
+
+        UT_TEARDOWN(OS_remove(g_fNames[5]));
     }
-
-    if ((OS_close(g_fDescs[5]) != OS_SUCCESS) || (OS_close(g_fDescs[6]) != OS_SUCCESS))
-    {
-        testDesc = "#8 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_openfile_test_exit_tag;
-    }
-
-    g_fStatus[5] = OS_OpenCreate(&g_fDescs[5], g_fNames[5], OS_FILE_FLAG_NONE, OS_READ_WRITE);
-    g_fStatus[6] = OS_OpenCreate(&g_fDescs[6], g_fNames[6], OS_FILE_FLAG_NONE, OS_WRITE_ONLY);
-
-    if ((OS_close(g_fDescs[5]) != OS_SUCCESS) || (OS_close(g_fDescs[6]) != OS_SUCCESS) ||
-        (OS_remove(g_fNames[5]) != OS_SUCCESS) || (OS_remove(g_fNames[6]) != OS_SUCCESS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-
-UT_os_openfile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -560,57 +449,29 @@ UT_os_openfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_closefile_test()
 {
-    const char *testDesc;
-    char        tmpBuff[UT_OS_IO_BUFF_SIZE];
+    char tmpBuff[UT_OS_IO_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Invalid-file-desc-arg */
 
-    if (OS_close(UT_OBJID_INCORRECT) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_closefile_test_exit_tag;
-    }
+    UT_RETVAL(OS_close(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-file-desc-arg";
-
-    if (OS_close(UT_OBJID_INCORRECT) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Close_Nominal.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#3 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_closefile_test_exit_tag;
+        UT_NOMINAL(OS_close(g_fDescs[0]));
+
+        UT_RETVAL(OS_write(g_fDescs[0], tmpBuff, sizeof(tmpBuff)), OS_ERR_INVALID_ID);
+        UT_RETVAL(OS_read(g_fDescs[0], tmpBuff, sizeof(tmpBuff)), OS_ERR_INVALID_ID);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    if ((OS_close(g_fDescs[0]) != OS_SUCCESS) ||
-        (OS_write(g_fDescs[0], tmpBuff, sizeof(tmpBuff)) != OS_ERR_INVALID_ID) ||
-        (OS_read(g_fDescs[0], tmpBuff, sizeof(tmpBuff)) != OS_ERR_INVALID_ID))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-
-UT_os_closefile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -668,122 +529,53 @@ UT_os_closefile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_readfile_test()
 {
-    const char *testDesc;
-
-    /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_read(UT_OBJID_INCORRECT, NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_readfile_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    size_t expected_len;
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Read_NullPtr.txt", g_mntName);
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#1 Null-pointer-arg - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        if (OS_read(g_fDescs[0], NULL, sizeof(g_readBuff)) == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        /*-----------------------------------------------------*/
+        /* #1 Null-pointer-arg */
+        UT_RETVAL(OS_read(g_fDescs[0], NULL, sizeof(g_readBuff)), OS_INVALID_POINTER);
 
         /* Reset test environment */
-        OS_close(g_fDescs[0]);
-        OS_remove(g_fNames[0]);
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-file-desc-arg";
-
-    if (OS_read(UT_OBJID_INCORRECT, g_readBuff, sizeof(g_readBuff)) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    /* #2 Invalid-file-desc-arg */
+    UT_RETVAL(OS_read(UT_OBJID_INCORRECT, g_readBuff, sizeof(g_readBuff)), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Read_Nominal.txt", g_mntName);
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#4 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_readfile_test_exit_tag;
-    }
+        memset(g_writeBuff, '\0', sizeof(g_writeBuff));
+        strcpy(g_writeBuff, "A HORSE! A HORSE! MY KINGDOM FOR A HORSE!");
+        expected_len = strlen(g_writeBuff);
 
-    memset(g_writeBuff, '\0', sizeof(g_writeBuff));
-    strcpy(g_writeBuff, "A HORSE! A HORSE! MY KINGDOM FOR A HORSE!");
-    if (OS_write(g_fDescs[0], g_writeBuff, strlen(g_writeBuff)) != strlen(g_writeBuff))
-    {
-        testDesc = "#4 Nominal - File-write failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+        UT_RETVAL(OS_write(g_fDescs[0], g_writeBuff, expected_len), expected_len);
+
+        UT_SETUP(OS_close(g_fDescs[0]));
+
+        if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_NONE, OS_READ_WRITE)))
+        {
+            memset(g_readBuff, '\0', sizeof(g_readBuff));
+            UT_RETVAL(OS_read(g_fDescs[0], g_readBuff, sizeof(g_readBuff)), expected_len);
+            UtAssert_StrCmp(g_readBuff, g_writeBuff, "%s == %s", g_readBuff, g_writeBuff);
+
+            UT_TEARDOWN(OS_close(g_fDescs[0]));
+        }
 
         /* Reset test environment */
-        OS_close(g_fDescs[0]);
-        OS_remove(g_fNames[0]);
-
-        goto UT_os_readfile_test_exit_tag;
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        /* Reset test environment */
-        OS_remove(g_fNames[0]);
-
-        goto UT_os_readfile_test_exit_tag;
-    }
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_NONE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
-    {
-        testDesc = "#4 Nominal - File-open failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        /* Reset test environment */
-        OS_remove(g_fNames[0]);
-
-        goto UT_os_readfile_test_exit_tag;
-    }
-
-    memset(g_readBuff, '\0', sizeof(g_readBuff));
-    if ((OS_read(g_fDescs[0], g_readBuff, strlen(g_writeBuff)) == strlen(g_writeBuff)) &&
-        (strncmp(g_readBuff, g_writeBuff, strlen(g_writeBuff)) == 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_close(g_fDescs[0]);
-    OS_remove(g_fNames[0]);
-
-    UtPrintf("OS_read() success test -- Write to file:\n\t%s\n", g_writeBuff);
-    ;
-    UtPrintf("OS_read() success test -- Read from file:\n\t%s\n", g_readBuff);
-    ;
-
-UT_os_readfile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -840,121 +632,52 @@ UT_os_readfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_writefile_test()
 {
-    const char *testDesc;
+    size_t expected_len;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_write(UT_OBJID_INCORRECT, NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_writefile_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Write_NullPtr.txt", g_mntName);
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#1 Null-pointer-arg - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        if (OS_write(g_fDescs[0], NULL, sizeof(g_writeBuff)) == OS_INVALID_POINTER)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_write(g_fDescs[0], NULL, sizeof(g_writeBuff)), OS_INVALID_POINTER);
 
         /* Reset test environment */
-        OS_close(g_fDescs[0]);
-        OS_remove(g_fNames[0]);
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-file-desc-arg";
+    /* #2 Invalid-file-desc-arg */
 
-    if (OS_write(UT_OBJID_INCORRECT, g_writeBuff, sizeof(g_writeBuff)) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_write(UT_OBJID_INCORRECT, g_writeBuff, sizeof(g_writeBuff)), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Write_Nominal.txt", g_mntName);
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < OS_SUCCESS)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY)))
     {
-        testDesc = "#4 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_writefile_test_exit_tag;
+        memset(g_writeBuff, '\0', sizeof(g_writeBuff));
+        strcpy(g_writeBuff, "TO BE OR NOT TO BE, THAT IS A QUESTION.");
+        expected_len = strlen(g_writeBuff);
+        UT_RETVAL(OS_write(g_fDescs[0], g_writeBuff, expected_len), expected_len);
+
+        UT_SETUP(OS_close(g_fDescs[0]));
+
+        if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_NONE, OS_READ_ONLY)))
+        {
+            memset(g_readBuff, '\0', sizeof(g_readBuff));
+            UT_RETVAL(OS_read(g_fDescs[0], g_readBuff, sizeof(g_readBuff)), expected_len);
+            UtAssert_StrCmp(g_readBuff, g_writeBuff, "%s == %s", g_readBuff, g_writeBuff);
+
+            /* Reset test environment */
+            UT_TEARDOWN(OS_close(g_fDescs[0]));
+        }
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    memset(g_writeBuff, '\0', sizeof(g_writeBuff));
-    strcpy(g_writeBuff, "TO BE OR NOT TO BE, THAT IS A QUESTION.");
-    if (OS_write(g_fDescs[0], g_writeBuff, strlen(g_writeBuff)) != strlen(g_writeBuff))
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-        /* Reset test environment */
-        OS_close(g_fDescs[0]);
-        OS_remove(g_fNames[0]);
-
-        goto UT_os_writefile_test_exit_tag;
-    }
-
-    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        /* Reset test environment */
-        OS_remove(g_fNames[0]);
-
-        goto UT_os_writefile_test_exit_tag;
-    }
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_NONE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
-    {
-        testDesc = "#4 Nominal - File-open failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
-        /* Reset test environment */
-        OS_remove(g_fNames[0]);
-
-        goto UT_os_writefile_test_exit_tag;
-    }
-
-    memset(g_readBuff, '\0', sizeof(g_readBuff));
-    if ((OS_read(g_fDescs[0], g_readBuff, strlen(g_writeBuff)) == strlen(g_writeBuff)) &&
-        (strncmp(g_readBuff, g_writeBuff, strlen(g_writeBuff)) == 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_close(g_fDescs[0]);
-    OS_remove(g_fNames[0]);
-
-    UtPrintf("OS_write() success test -- Write to file:\n\t%s\n", g_writeBuff);
-    ;
-    UtPrintf("OS_write() success test -- Read from file:\n\t%s\n", g_readBuff);
-    ;
-
-UT_os_writefile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1009,96 +732,51 @@ UT_os_writefile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_lseekfile_test()
 {
-    const char *testDesc;
-    size_t      buffLen;
-    int32       pos1 = 0, pos2 = 0, pos3 = 0;
+    size_t buffLen;
+    int32  pos1 = 0, pos2 = 0, pos3 = 0;
+
+    UT_RETVAL(OS_lseek(UT_OBJID_INCORRECT, 0, OS_SEEK_SET), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_lseek(UT_OBJID_INCORRECT, 0, OS_SEEK_CUR) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_lseekfile_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-file-desc-arg";
-
-    if (OS_lseek(UT_OBJID_INCORRECT, 0, OS_SEEK_SET) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-whence-arg";
+    /* #2 Invalid-whence-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Seek_InvWhence.txt", g_mntName);
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#2 Invalid-whence-arg - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        if (OS_lseek(g_fDescs[0], 0, 123456) == OS_ERROR)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_lseek(g_fDescs[0], 0, 123456), OS_ERROR);
 
-        OS_close(g_fDescs[0]);
+        /* Reset test environment */
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
 
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Seek_Nominal.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#4 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_lseekfile_test_exit_tag;
+        memset(g_writeBuff, '\0', sizeof(g_writeBuff));
+        strcpy(g_writeBuff, "THE BROWN FOX JUMPS OVER THE LAZY DOG.");
+        buffLen = strlen(g_writeBuff);
+
+        UT_RETVAL(OS_write(g_fDescs[0], g_writeBuff, buffLen), buffLen);
+
+        UT_RETVAL(pos1 = OS_lseek(g_fDescs[0], 10, OS_SEEK_SET), 10);
+        UT_RETVAL(pos2 = OS_lseek(g_fDescs[0], 7, OS_SEEK_CUR), 17);
+        UT_RETVAL(pos3 = OS_lseek(g_fDescs[0], -16, OS_SEEK_END), 22);
+
+        UtAssert_INT32_EQ(g_writeBuff[pos1], 'F');
+        UtAssert_INT32_EQ(g_writeBuff[pos2], 'P');
+        UtAssert_INT32_EQ(g_writeBuff[pos3], 'E');
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    memset(g_writeBuff, '\0', sizeof(g_writeBuff));
-    strcpy(g_writeBuff, "THE BROWN FOX JUMPS OVER THE LAZY DOG.");
-    buffLen = strlen(g_writeBuff);
-
-    if (OS_write(g_fDescs[0], g_writeBuff, buffLen) != buffLen)
-    {
-        testDesc = "#4 Nominal - File-write failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_lseekfile_test_exit_tag;
-    }
-
-    pos1 = OS_lseek(g_fDescs[0], 10, OS_SEEK_SET);
-    pos2 = OS_lseek(g_fDescs[0], 7, OS_SEEK_CUR);
-    pos3 = OS_lseek(g_fDescs[0], -16, OS_SEEK_END);
-    if ((pos1 < 0) || (g_writeBuff[pos1] != 'F') || (pos2 < 0) || (g_writeBuff[pos2] != 'P') || (pos3 < 0) ||
-        (g_writeBuff[pos3] != 'E'))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-
-    /* Reset test environment */
-    OS_close(g_fDescs[0]);
-    OS_remove(g_fNames[0]);
-
-UT_os_lseekfile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1111,19 +789,12 @@ UT_os_lseekfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_chmodfile_test()
 {
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_chmod(NULL, 0644) == OS_ERR_NOT_IMPLEMENTED)
+    /* API not implemented */
+    if (!UT_IMPL(OS_chmod(NULL, 0644)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_chmodfile_test_exit_tag;
+        return;
     }
-
-UT_os_chmodfile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1184,99 +855,55 @@ UT_os_chmodfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_statfile_test()
 {
-    const char *testDesc;
-    os_fstat_t  fstats1, fstats2;
+    os_fstat_t fstats1, fstats2;
+    size_t     expected_len;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    if (OS_stat(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_stat(NULL, NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_statfile_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
-
-    if ((OS_stat(NULL, &fstats1) == OS_INVALID_POINTER) && (OS_stat(g_fNames[0], NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    /* #1 Null-pointer-arg */
+    UT_RETVAL(OS_stat(NULL, &fstats1), OS_INVALID_POINTER);
+    UT_RETVAL(OS_stat(g_fNames[0], NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_stat(g_invalidPath, &fstats1) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_stat(g_invalidPath, &fstats1), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_stat(g_longPathName, &fstats1) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_stat(g_longPathName, &fstats1), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
+    /* #5 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Stat_Nominal.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#5 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_statfile_test_exit_tag;
+        UT_NOMINAL(OS_stat(g_fNames[0], &fstats1));
+        UtAssert_UINT32_EQ(fstats1.FileSize, 0);
+
+        memset(g_writeBuff, '\0', sizeof(g_writeBuff));
+        strcpy(g_writeBuff, "HOW NOW, BROWN COW?");
+        expected_len = strlen(g_writeBuff);
+        UT_RETVAL(OS_write(g_fDescs[0], g_writeBuff, expected_len), expected_len);
+        UT_SETUP(OS_close(g_fDescs[0]));
+
+        UT_NOMINAL(OS_stat(g_fNames[0], &fstats2));
+        UtAssert_UINT32_EQ(fstats1.FileSize, 0);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    if (OS_stat(g_fNames[0], &fstats1) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_statfile_test_exit_tag;
-    }
-
-    memset(g_writeBuff, '\0', sizeof(g_writeBuff));
-    strcpy(g_writeBuff, "HOW NOW, BROWN COW?");
-    if (OS_write(g_fDescs[0], g_writeBuff, strlen(g_writeBuff)) != strlen(g_writeBuff))
-    {
-        testDesc = "#5 Nominal - File-write failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_statfile_test_exit_tag;
-    }
-
-    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-    {
-        testDesc = "#5 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_statfile_test_exit_tag;
-    }
-
-    if (OS_stat(g_fNames[0], &fstats2) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_statfile_test_exit_tag;
-    }
-
-    if (memcmp(&fstats1, &fstats2, sizeof(fstats1)) != 0)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-
-UT_os_statfile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1335,84 +962,42 @@ UT_os_statfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_removefile_test()
 {
-    os_fstat_t  fstats;
-    const char *testDesc;
+    os_fstat_t fstats;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    if (OS_remove(NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_removefile_test_exit_tag;
-    }
+    UT_RETVAL(OS_remove(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_remove(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_remove(g_invalidPath), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_remove(g_invalidPath) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_remove(g_longPathName), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #4 Name-too-long-arg */
 
-    if (OS_remove(g_longPathName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_remove(g_longFileName), OS_FS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long-arg";
-
-    if (OS_remove(g_longFileName) == OS_FS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#6 Nominal";
+    /* #6 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Remove_Nominal.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#6 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_removefile_test_exit_tag;
+        UT_SETUP(OS_close(g_fDescs[0]));
+
+        UT_NOMINAL(OS_remove(g_fNames[0]));
     }
 
-    OS_close(g_fDescs[0]);
-
-    if (OS_remove(g_fNames[0]) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_removefile_test_exit_tag;
-    }
-
-    if (OS_stat(g_fNames[0], &fstats) == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_removefile_test_exit_tag:
-    return;
+    UT_RETVAL(OS_stat(g_fNames[0], &fstats), OS_ERROR);
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1471,93 +1056,53 @@ UT_os_removefile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_renamefile_test()
 {
-    os_fstat_t  fstats;
-    const char *testDesc;
+    os_fstat_t fstats;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_rename(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_renamefile_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[1], '\0', sizeof(g_fNames[1]));
     UT_os_sprintf(g_fNames[0], "%s/oldName.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/newName.txt", g_mntName);
 
-    if ((OS_rename(NULL, g_fNames[1]) == OS_INVALID_POINTER) && (OS_rename(g_fNames[0], NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rename(NULL, g_fNames[1]), OS_INVALID_POINTER);
+    UT_RETVAL(OS_rename(g_fNames[0], NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_rename(g_invalidPath, g_invalidPath) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rename(g_invalidPath, g_invalidPath), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_rename(g_longPathName, g_longPathName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rename(g_longPathName, g_longPathName), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long-arg";
+    /* #4 Name-too-long-arg */
 
-    if (OS_rename(g_longFileName, g_longFileName) == OS_FS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rename(g_longFileName, g_longFileName), OS_FS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#6 Nominal";
+    /* #6 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[0], '\0', sizeof(g_fNames[1]));
     UT_os_sprintf(g_fNames[0], "%s/Rename_Nom_Old.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/Rename_Nom_New.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#6 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_renamefile_test_exit_tag;
+        UT_SETUP(OS_close(g_fDescs[0]));
+        UT_NOMINAL(OS_rename(g_fNames[0], g_fNames[1]));
+
+        UT_RETVAL(OS_stat(g_fNames[0], &fstats), OS_ERROR);
+        UT_RETVAL(OS_stat(g_fNames[1], &fstats), OS_SUCCESS);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_remove(g_fNames[1]));
     }
-
-    if (OS_rename(g_fNames[0], g_fNames[1]) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_renamefile_test_exit_tag;
-    }
-
-    if (OS_stat(g_fNames[0], &fstats) == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_close(g_fDescs[0]);
-    OS_remove(g_fNames[1]);
-
-UT_os_renamefile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1620,107 +1165,61 @@ UT_os_renamefile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_copyfile_test()
 {
-    os_fstat_t  fstats;
-    const char *testDesc;
+    os_fstat_t fstats;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_cp(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_copyfile_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[1], '\0', sizeof(g_fNames[1]));
     UT_os_sprintf(g_fNames[0], "%s/oldName.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/newName.txt", g_mntName);
 
-    if ((OS_cp(NULL, g_fNames[1]) == OS_INVALID_POINTER) && (OS_cp(g_fNames[0], NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_cp(NULL, g_fNames[1]), OS_INVALID_POINTER);
+    UT_RETVAL(OS_cp(g_fNames[0], NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_cp(g_invalidPath, g_invalidPath) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_cp(g_invalidPath, g_fNames[1]), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_cp(g_longPathName, g_longPathName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_cp(g_longPathName, g_fNames[1]), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long-arg";
+    /* #4 Name-too-long-arg */
 
-    if (OS_cp(g_longFileName, g_longFileName) == OS_FS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_cp(g_longFileName, g_fNames[1]), OS_FS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#6 Nominal";
+    /* #6 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[1], '\0', sizeof(g_fNames[1]));
     UT_os_sprintf(g_fNames[0], "%s/Cp_Nom_Old.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/Cp_Nom_New.txt", g_mntName);
 
-    if (OS_stat(g_fNames[1], &fstats) != OS_ERROR)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#6 Nominal - File-stat failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_copyfile_test_exit_tag;
+        UT_SETUP(OS_close(g_fDescs[0]));
+
+        /* validate pass-thru codes on second arg (must be done with a valid 1st arg) */
+
+        UT_RETVAL(OS_cp(g_fNames[0], g_invalidPath), OS_FS_ERR_PATH_INVALID);
+        UT_RETVAL(OS_cp(g_fNames[0], g_longPathName), OS_FS_ERR_PATH_TOO_LONG);
+        UT_RETVAL(OS_cp(g_fNames[0], g_longFileName), OS_FS_ERR_NAME_TOO_LONG);
+
+        UT_NOMINAL(OS_cp(g_fNames[0], g_fNames[1]));
+
+        UT_RETVAL(OS_stat(g_fNames[0], &fstats), OS_SUCCESS);
+        UT_RETVAL(OS_stat(g_fNames[1], &fstats), OS_SUCCESS);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[1]));
     }
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
-    {
-        testDesc = "#6 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_copyfile_test_exit_tag;
-    }
-
-    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-    {
-        testDesc = "#6 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_copyfile_test_exit_tag;
-    }
-
-    if (OS_cp(g_fNames[0], g_fNames[1]) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_copyfile_test_exit_tag;
-    }
-
-    if (OS_stat(g_fNames[1], &fstats) == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-    OS_remove(g_fNames[1]);
-
-UT_os_copyfile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1786,107 +1285,60 @@ UT_os_copyfile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_movefile_test()
 {
-    os_fstat_t  fstats;
-    const char *testDesc;
+    os_fstat_t fstats;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_mv(NULL, NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_movefile_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[1], '\0', sizeof(g_fNames[1]));
     UT_os_sprintf(g_fNames[0], "%s/oldName.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/newName.txt", g_mntName);
 
-    if ((OS_mv(NULL, g_fNames[1]) == OS_INVALID_POINTER) && (OS_mv(g_fNames[0], NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mv(NULL, g_fNames[1]), OS_INVALID_POINTER);
+    UT_RETVAL(OS_mv(g_fNames[0], NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
+    /* #2 Invalid-path-arg */
 
-    if (OS_mv(g_invalidPath, g_invalidPath) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mv(g_invalidPath, g_fNames[1]), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Path-too-long-arg";
+    /* #3 Path-too-long-arg */
 
-    if (OS_mv(g_longPathName, g_longPathName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mv(g_longPathName, g_fNames[1]), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Name-too-long-arg";
+    /* #4 Name-too-long-arg */
 
-    if (OS_mv(g_longFileName, g_longFileName) == OS_FS_ERR_NAME_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mv(g_longFileName, g_fNames[1]), OS_FS_ERR_NAME_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#6 Nominal";
+    /* #6 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[0], '\0', sizeof(g_fNames[1]));
     UT_os_sprintf(g_fNames[0], "%s/Mv_Nom_Old.txt", g_mntName);
     UT_os_sprintf(g_fNames[1], "%s/Mv_Nom_New.txt", g_mntName);
 
-    if (OS_stat(g_fNames[1], &fstats) != OS_ERROR)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#6 Nominal - File-stat failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_movefile_test_exit_tag;
+        /* Close file before moving */
+        UT_SETUP(OS_close(g_fDescs[0]));
+
+        /* validate pass-thru codes on second arg (must be done with a valid 1st arg) */
+        UT_RETVAL(OS_mv(g_fNames[0], g_invalidPath), OS_FS_ERR_PATH_INVALID);
+        UT_RETVAL(OS_mv(g_fNames[0], g_longPathName), OS_FS_ERR_PATH_TOO_LONG);
+        UT_RETVAL(OS_mv(g_fNames[0], g_longFileName), OS_FS_ERR_NAME_TOO_LONG);
+
+        UT_NOMINAL(OS_mv(g_fNames[0], g_fNames[1]));
+
+        UT_RETVAL(OS_stat(g_fNames[0], &fstats), OS_ERROR);
+        UT_RETVAL(OS_stat(g_fNames[1], &fstats), OS_SUCCESS);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_remove(g_fNames[1]));
     }
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
-    {
-        testDesc = "#6 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_movefile_test_exit_tag;
-    }
-
-    /* Close file before moving */
-    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-    {
-        testDesc = "#6 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_movefile_test_exit_tag;
-    }
-
-    if (OS_mv(g_fNames[0], g_fNames[1]) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_movefile_test_exit_tag;
-    }
-
-    if ((OS_stat(g_fNames[1], &fstats) == OS_SUCCESS) && (OS_stat(g_fNames[0], &fstats) != OS_SUCCESS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[1]);
-
-UT_os_movefile_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1942,97 +1394,39 @@ UT_os_movefile_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_outputtofile_test()
 {
-    int         res;
-    const char *cmd = NULL;
-    const char *testDesc;
+    /*-----------------------------------------------------*/
+    /* #1 Null-pointer-arg */
+
+    UT_RETVAL(OS_ShellOutputToFile(NULL, OS_OBJECT_ID_UNDEFINED), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #2 Invalid-file-desc-arg */
 
-    if (OS_ShellOutputToFile(NULL, OS_OBJECT_ID_UNDEFINED) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_outputtofile_test_exit_tag;
-    }
+    UT_RETVAL(OS_ShellOutputToFile("ls", UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
-
-    if (OS_ShellOutputToFile(NULL, OS_OBJECT_ID_UNDEFINED) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-file-desc-arg";
-
-    if (OS_ShellOutputToFile("ls", UT_OBJID_INCORRECT) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Output_Nominal.txt", g_mntName);
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#4 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_outputtofile_test_exit_tag;
-    }
-
-    cmd = "echo \"UT_os_outputtofile_test\"";
-    res = OS_ShellOutputToFile(cmd, g_fDescs[0]);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_outputtofile_test_exit_tag;
-    }
-
-    if (res != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_outputtofile_test_exit_tag;
-    }
-
-    if (OS_lseek(g_fDescs[0], 0, OS_SEEK_SET) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-lseek failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
-    else
-    {
-        memset(g_readBuff, '\0', sizeof(g_readBuff));
-        if (OS_read(g_fDescs[0], g_readBuff, sizeof(g_readBuff)) <= 0)
+        /* #4 Nominal - File-create failed */
+        if (UT_NOMINAL_OR_NOTIMPL(OS_ShellOutputToFile("echo \"UT_os_outputtofile_test\"", g_fDescs[0])))
         {
-            testDesc = "#4 Nominal - File-read failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+            UT_RETVAL(OS_lseek(g_fDescs[0], 0, OS_SEEK_SET), 0);
+            memset(g_readBuff, '\0', sizeof(g_readBuff));
+            if (UT_SETUP(OS_read(g_fDescs[0], g_readBuff, sizeof(g_readBuff))))
+            {
+                UtAssert_True(strstr(g_readBuff, "UT_os_outputtofile_test") != NULL,
+                              "Output file contains UT_os_outputtofile_test");
+            }
         }
-        else if (strstr(g_readBuff, "UT_os_outputtofile_test") != NULL)
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        }
-        else
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-UT_os_outputtofile_test_exit_tag:
-
-    /* Reset test environment */
-    OS_close(g_fDescs[0]);
-    OS_remove(g_fNames[0]);
-
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -2086,96 +1480,41 @@ UT_os_outputtofile_test_exit_tag:
 void UT_os_getfdinfo_test()
 {
     OS_file_prop_t fdProps;
-    const char *   testDesc;
     const char *   fileName = "GetInfo_Nom.txt";
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_FDGetInfo(OS_OBJECT_ID_UNDEFINED, NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_getfdinfo_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/GetInfo_Null.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#1 Null-pointer-arg - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+        /* #1 Null-pointer-arg */
+        UT_RETVAL(OS_FDGetInfo(g_fDescs[0], NULL), OS_INVALID_POINTER);
+
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-    else
-    {
-        if (OS_FDGetInfo(g_fDescs[0], NULL) != OS_INVALID_POINTER)
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-        else
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        }
-
-        OS_close(g_fDescs[0]);
-    }
-    OS_remove(g_fNames[0]);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-file-desc-arg";
+    /* #2 Invalid-file-desc-arg */
 
-    if (OS_FDGetInfo(UT_OBJID_INCORRECT, &fdProps) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FDGetInfo(UT_OBJID_INCORRECT, &fdProps), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/%s", g_mntName, fileName);
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#4 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_getfdinfo_test_exit_tag;
+        UT_NOMINAL(OS_FDGetInfo(g_fDescs[0], &fdProps));
+
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
+
+        UT_RETVAL(OS_FDGetInfo(g_fDescs[0], &fdProps), OS_ERR_INVALID_ID);
     }
-
-    memset(&fdProps, 0x00, sizeof(fdProps));
-    if (OS_FDGetInfo(g_fDescs[0], &fdProps) != OS_SUCCESS || strcmp(fdProps.Path, g_fNames[0]) != 0)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_getfdinfo_test_exit_tag;
-    }
-
-    if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-close failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_getfdinfo_test_exit_tag;
-    }
-
-    memset(&fdProps, 0x00, sizeof(fdProps));
-    if (OS_FDGetInfo(g_fDescs[0], &fdProps) == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-
-UT_os_getfdinfo_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -2212,82 +1551,33 @@ UT_os_getfdinfo_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_checkfileopen_test()
 {
-    const char *testDesc;
+    /*-----------------------------------------------------*/
+    /* #1 Null-pointer-arg */
+
+    UT_RETVAL(OS_FileOpenCheck(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_FileOpenCheck(NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_checkfileopen_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
-
-    if (OS_FileOpenCheck(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 File-not-opened";
+    /* #2 File-not-opened */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/FChk_UnOpened.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
-    {
-        testDesc = "#2 File-not-opened - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        if (OS_close(g_fDescs[0]) != OS_SUCCESS)
-        {
-            testDesc = "#2 File-not-opened - File-close failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        }
-        else if (OS_FileOpenCheck(g_fNames[0]) != OS_ERROR)
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        }
-        else
-        {
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        }
-    }
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
+    UT_RETVAL(OS_FileOpenCheck(g_fNames[0]), OS_ERROR);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/FileChk_Nominal.txt", g_mntName);
-
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#3 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_checkfileopen_test_exit_tag;
+        UT_NOMINAL(OS_FileOpenCheck(g_fNames[0]));
+
+        UT_TEARDOWN(OS_close(g_fDescs[0]));
+        UT_RETVAL(OS_FileOpenCheck(g_fNames[0]), OS_ERROR);
+
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    if (OS_FileOpenCheck(g_fNames[0]) == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_close(g_fDescs[0]);
-    OS_remove(g_fNames[0]);
-
-UT_os_checkfileopen_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -2322,24 +1612,8 @@ UT_os_checkfileopen_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_closeallfiles_test()
 {
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
-
-    if (OS_CloseAllFiles() == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_closeallfiles_test_exit_tag;
-    }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#1 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
+    /* #2 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     memset(g_fNames[1], '\0', sizeof(g_fNames[1]));
@@ -2348,35 +1622,26 @@ void UT_os_closeallfiles_test()
     UT_os_sprintf(g_fNames[1], "%s/CloseAll_Nom_2.txt", g_mntName);
     UT_os_sprintf(g_fNames[2], "%s/CloseAll_Nom_3.txt", g_mntName);
 
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    g_fStatus[1] = OS_OpenCreate(&g_fDescs[1], g_fNames[1], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    g_fStatus[2] = OS_OpenCreate(&g_fDescs[2], g_fNames[2], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if ((g_fStatus[0] < 0) || (g_fStatus[1] < 0) || (g_fStatus[2] < 0))
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#2 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_closeallfiles_test_exit_tag;
+        if (UT_SETUP(
+                OS_OpenCreate(&g_fDescs[1], g_fNames[1], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
+        {
+            if (UT_SETUP(OS_OpenCreate(&g_fDescs[2], g_fNames[2], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE,
+                                       OS_READ_WRITE)))
+            {
+                UT_NOMINAL(OS_CloseAllFiles());
+
+                UT_RETVAL(OS_FileOpenCheck(g_fNames[0]), OS_ERROR);
+                UT_RETVAL(OS_FileOpenCheck(g_fNames[1]), OS_ERROR);
+                UT_RETVAL(OS_FileOpenCheck(g_fNames[2]), OS_ERROR);
+
+                UT_TEARDOWN(OS_remove(g_fNames[2]));
+            }
+            UT_TEARDOWN(OS_remove(g_fNames[1]));
+        }
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    if (OS_CloseAllFiles() != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_closeallfiles_test_exit_tag;
-    }
-
-    if ((OS_FileOpenCheck(g_fNames[0]) == OS_ERROR) && (OS_FileOpenCheck(g_fNames[1]) == OS_ERROR) &&
-        (OS_FileOpenCheck(g_fNames[2]) == OS_ERROR))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-    OS_remove(g_fNames[1]);
-    OS_remove(g_fNames[2]);
-
-UT_os_closeallfiles_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -2423,67 +1688,28 @@ UT_os_closeallfiles_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_closefilebyname_test()
 {
-    const char *testDesc;
+    /*-----------------------------------------------------*/
+    /* #1 Null-pointer-arg */
+    UT_RETVAL(OS_CloseFileByName(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #2 Invalid-path-arg */
 
-    if (OS_CloseFileByName(NULL) == OS_ERR_NOT_IMPLEMENTED)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_closefilebyname_test_exit_tag;
-    }
+    UT_RETVAL(OS_CloseFileByName(g_invalidPath), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
-
-    if (OS_CloseFileByName(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path-arg";
-
-    if (OS_CloseFileByName(g_invalidPath) == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
     memset(g_fNames[0], '\0', sizeof(g_fNames[0]));
     UT_os_sprintf(g_fNames[0], "%s/Close_Nominal.txt", g_mntName);
-    g_fStatus[0] = OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE);
-    if (g_fStatus[0] < 0)
+    if (UT_SETUP(OS_OpenCreate(&g_fDescs[0], g_fNames[0], OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_READ_WRITE)))
     {
-        testDesc = "#4 Nominal - File-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_closefilebyname_test_exit_tag;
+        UT_NOMINAL(OS_CloseFileByName(g_fNames[0]));
+        UT_RETVAL(OS_FileOpenCheck(g_fNames[0]), OS_ERROR);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_remove(g_fNames[0]));
     }
-
-    if (OS_CloseFileByName(g_fNames[0]) != OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_closefilebyname_test_exit_tag;
-    }
-
-    if (OS_FileOpenCheck(g_fNames[0]) == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_remove(g_fNames[0]);
-
-UT_os_closefilebyname_test_exit_tag:
-    return;
 }
 
 /*================================================================================*

--- a/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
+++ b/src/unit-tests/osfilesys-test/ut_osfilesys_diskio_test.c
@@ -125,44 +125,33 @@ extern char g_mntNames[UT_OS_FILESYS_LIST_LEN][UT_OS_FILE_BUFF_SIZE];
 **--------------------------------------------------------------------------------*/
 void UT_os_initfs_test()
 {
-    const char *testDesc;
-    int32       res = 0, i = 0, j = 0;
+    int32 i = 0, j = 0;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_initfs(NULL, NULL, NULL, g_blkSize, g_blkCnt);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_initfs(NULL, NULL, NULL, g_blkSize, g_blkCnt)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_initfs_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if ((OS_initfs(g_fsAddrPtr, NULL, g_volNames[1], OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER) &&
-        (OS_initfs(g_fsAddrPtr, g_devNames[1], NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_initfs(g_fsAddrPtr, NULL, g_volNames[1], OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)), OS_INVALID_POINTER);
+    UT_RETVAL(OS_initfs(g_fsAddrPtr, g_devNames[1], NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #2 Path-too-long-arg */
 
-    if ((OS_initfs(g_fsAddrPtr, g_fsLongName, g_volNames[2], g_blkSize, g_blkCnt) == OS_FS_ERR_PATH_TOO_LONG) &&
-        (OS_initfs(g_fsAddrPtr, g_devNames[2], g_fsLongName, g_blkSize, g_blkCnt) == OS_FS_ERR_PATH_TOO_LONG))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_initfs(g_fsAddrPtr, g_fsLongName, g_volNames[2], g_blkSize, g_blkCnt), OS_FS_ERR_PATH_TOO_LONG);
+    UT_RETVAL(OS_initfs(g_fsAddrPtr, g_devNames[2], g_fsLongName, g_blkSize, g_blkCnt), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #3 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Disk-full";
+    /* #4 Disk-full */
 
     for (i = 0; i <= OS_MAX_FILE_SYSTEMS; i++)
     {
@@ -170,37 +159,30 @@ void UT_os_initfs_test()
         UT_os_sprintf(g_devNames[i], "/ramdev%d", (int)i);
         memset(g_volNames[i], '\0', sizeof(g_volNames[i]));
         UT_os_sprintf(g_volNames[i], "RAM%d", (int)i);
-        res = OS_initfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt);
-        if (res != OS_SUCCESS)
-            break;
-    }
 
-    /* Only need to check the last call to OS_initfs() */
-    if (res == OS_FS_ERR_DEVICE_NOT_FREE)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        /* Only need to check the last call to OS_initfs() */
+        if (i == OS_MAX_FILE_SYSTEMS)
+        {
+            UT_RETVAL(OS_initfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt),
+                      OS_FS_ERR_DEVICE_NOT_FREE);
+        }
+        else if (!UT_SETUP(OS_initfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt)))
+        {
+            break;
+        }
+    }
 
     /* Reset test environment */
-    for (j = 0; j < i; j++)
-        OS_rmfs(g_devNames[j]);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
-
-    if (OS_initfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    for (j = 0; j < OS_MAX_FILE_SYSTEMS; j++)
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_initfs_test_exit_tag;
+        UT_TEARDOWN(OS_rmfs(g_devNames[j]));
     }
 
-    if (OS_rmfs(g_devNames[5]) == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    /*-----------------------------------------------------*/
+    /* #5 Nominal */
 
-UT_os_initfs_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_initfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt));
+    UT_TEARDOWN(OS_rmfs(g_devNames[5]));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -258,44 +240,30 @@ UT_os_initfs_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_makefs_test()
 {
-    const char *testDesc;
-    int32       res = 0, i = 0, j = 0;
+    int32 i = 0, j = 0;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_mkfs(g_fsAddrPtr, NULL, NULL, g_blkSize, g_blkCnt);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_mkfs(g_fsAddrPtr, NULL, NULL, g_blkSize, g_blkCnt)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_makefs_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if ((OS_mkfs(g_fsAddrPtr, NULL, g_volNames[1], OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER) &&
-        (OS_mkfs(g_fsAddrPtr, g_devNames[1], NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mkfs(g_fsAddrPtr, NULL, g_volNames[1], OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)), OS_INVALID_POINTER);
+    UT_RETVAL(OS_mkfs(g_fsAddrPtr, g_devNames[1], NULL, OSAL_SIZE_C(0), OSAL_BLOCKCOUNT_C(0)), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #2 Path-too-long-arg */
 
-    if ((OS_mkfs(g_fsAddrPtr, g_fsLongName, g_volNames[2], g_blkSize, g_blkCnt) == OS_FS_ERR_PATH_TOO_LONG) &&
-        (OS_mkfs(g_fsAddrPtr, g_devNames[2], g_fsLongName, g_blkSize, g_blkCnt) == OS_FS_ERR_PATH_TOO_LONG))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mkfs(g_fsAddrPtr, g_fsLongName, g_volNames[2], g_blkSize, g_blkCnt), OS_FS_ERR_PATH_TOO_LONG);
+    UT_RETVAL(OS_mkfs(g_fsAddrPtr, g_devNames[2], g_fsLongName, g_blkSize, g_blkCnt), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Disk-full";
+    /* #4 Disk-full */
 
     for (i = 0; i <= OS_MAX_FILE_SYSTEMS; i++)
     {
@@ -303,37 +271,31 @@ void UT_os_makefs_test()
         UT_os_sprintf(g_devNames[i], "/ramdev%d", (int)i);
         memset(g_volNames[i], '\0', sizeof(g_volNames[i]));
         UT_os_sprintf(g_volNames[i], "RAM%d", (int)i);
-        res = OS_mkfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt);
-        if (res != OS_SUCCESS)
-            break;
-    }
 
-    /* Only need to check the last call to OS_mkfs() */
-    if (res == OS_FS_ERR_DEVICE_NOT_FREE)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        /* Only need to check the last call to OS_mkfs() */
+        if (i == OS_MAX_FILE_SYSTEMS)
+        {
+            UT_RETVAL(OS_mkfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt),
+                      OS_FS_ERR_DEVICE_NOT_FREE);
+        }
+        else if (!UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[i], g_volNames[i], g_blkSize, g_blkCnt)))
+        {
+            break;
+        }
+    }
 
     /* Reset test environment */
-    for (j = 0; j < i; j++)
-        OS_rmfs(g_devNames[j]);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#5 Nominal";
-
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    for (j = 0; j < OS_MAX_FILE_SYSTEMS; j++)
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-        goto UT_os_makefs_test_exit_tag;
+        UT_TEARDOWN(OS_rmfs(g_devNames[j]));
     }
 
-    if (OS_rmfs(g_devNames[5]) == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    /*-----------------------------------------------------*/
+    /* #5 Nominal */
 
-UT_os_makefs_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt));
+
+    UT_TEARDOWN(OS_rmfs(g_devNames[5]));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -375,56 +337,35 @@ UT_os_makefs_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_removefs_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_rmfs(NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_rmfs(NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_removefs_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if (OS_rmfs(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rmfs(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-device-arg";
+    /* #2 Invalid-device-arg */
 
-    if (OS_rmfs(g_devNames[2]) == OS_ERR_NAME_NOT_FOUND)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_rmfs(g_devNames[2]), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) != OS_SUCCESS)
-    {
-        testDesc = "#3 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_removefs_test_exit_tag;
-    }
+    UT_NOMINAL(OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt));
 
-    if ((OS_rmfs(g_devNames[3]) == OS_SUCCESS) &&
-        (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) == OS_SUCCESS))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_TEARDOWN(OS_rmfs(g_devNames[3]));
+
+    UT_NOMINAL(OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt));
 
     /* Reset test environment */
-    OS_rmfs(g_devNames[3]);
-
-UT_os_removefs_test_exit_tag:
-    return;
+    UT_TEARDOWN(OS_rmfs(g_devNames[3]));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -471,57 +412,37 @@ UT_os_removefs_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_mount_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_mount(NULL, NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_mount(NULL, NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_mount_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if ((OS_mount(NULL, g_mntNames[1]) == OS_INVALID_POINTER) && (OS_mount(g_devNames[1], NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mount(NULL, g_mntNames[1]), OS_INVALID_POINTER);
+    UT_RETVAL(OS_mount(g_devNames[1], NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-device-arg";
+    /* #2 Invalid-device-arg */
 
-    if (OS_mount("ramdev0", g_mntNames[2]) == OS_ERR_NAME_NOT_FOUND)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_mount("ramdev0", g_mntNames[2]), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[3], g_volNames[3], g_blkSize, g_blkCnt)))
     {
-        testDesc = "#3 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_mount_test_exit_tag;
+        UT_NOMINAL(OS_mount(g_devNames[3], g_mntNames[3]));
+        UT_RETVAL(OS_mount(g_devNames[3], g_mntNames[3]), OS_ERR_NAME_NOT_FOUND);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_unmount(g_mntNames[3]));
+        UT_TEARDOWN(OS_rmfs(g_devNames[3]));
     }
-
-    if ((OS_mount(g_devNames[3], g_mntNames[3]) == OS_SUCCESS) &&
-        (OS_mount(g_devNames[3], g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_unmount(g_mntNames[3]);
-    OS_rmfs(g_devNames[3]);
-
-UT_os_mount_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -575,64 +496,41 @@ UT_os_mount_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_unmount_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_unmount(NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_unmount(NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_unmount_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if (OS_unmount(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_unmount(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #2 Path-too-long-arg */
 
-    if (OS_unmount(g_fsLongName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_unmount(g_fsLongName), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-mount-point-arg";
+    /* #3 Invalid-mount-point-arg */
 
-    if (OS_unmount(g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_unmount(g_mntNames[3]), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt)))
     {
-        testDesc = "#3 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_unmount_test_exit_tag;
+        UT_NOMINAL(OS_mount(g_devNames[4], g_mntNames[4]));
+        UT_NOMINAL(OS_unmount(g_mntNames[4]));
+        UT_RETVAL(OS_unmount(g_mntNames[4]), OS_ERR_NAME_NOT_FOUND);
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_rmfs(g_devNames[4]));
     }
-
-    if ((OS_mount(g_devNames[4], g_mntNames[4]) == OS_SUCCESS) && (OS_unmount(g_mntNames[4]) == OS_SUCCESS) &&
-        (OS_unmount(g_mntNames[4]) == OS_ERR_NAME_NOT_FOUND))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_rmfs(g_devNames[4]);
-
-UT_os_unmount_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -685,75 +583,50 @@ UT_os_unmount_test_exit_tag:
 ** --------------------------------------------------------------------------------*/
 void UT_os_getphysdrivename_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    char        physDevName[UT_OS_PHYS_NAME_BUFF_SIZE];
+    char physDevName[UT_OS_PHYS_NAME_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_FS_GetPhysDriveName(NULL, NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_FS_GetPhysDriveName(NULL, NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_getphysicaldrivename_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if ((OS_FS_GetPhysDriveName(NULL, g_mntNames[1]) == OS_INVALID_POINTER) &&
-        (OS_FS_GetPhysDriveName(physDevName, NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FS_GetPhysDriveName(NULL, g_mntNames[1]), OS_INVALID_POINTER);
+    UT_RETVAL(OS_FS_GetPhysDriveName(physDevName, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #2 Path-too-long-arg */
 
-    if (OS_FS_GetPhysDriveName(physDevName, g_fsLongName) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FS_GetPhysDriveName(physDevName, g_fsLongName), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-mount-point-arg";
+    /* #3 Invalid-mount-point-arg */
 
-    if (OS_FS_GetPhysDriveName(physDevName, g_mntNames[3]) == OS_ERR_NAME_NOT_FOUND)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FS_GetPhysDriveName(physDevName, g_mntNames[3]), OS_ERR_NAME_NOT_FOUND);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt)))
     {
-        testDesc = "#4 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_getphysicaldrivename_test_exit_tag;
+        if (UT_SETUP(OS_mount(g_devNames[4], g_mntNames[4])))
+        {
+            memset(physDevName, '\0', sizeof(physDevName));
+            UT_NOMINAL(OS_FS_GetPhysDriveName(physDevName, g_mntNames[4]));
+
+            /* This just checks that the output string is not empty */
+            UtAssert_True(physDevName[0] != 0, "physDevName (%s)", physDevName);
+
+            UT_TEARDOWN(OS_unmount(g_mntNames[4]));
+        }
+
+        UT_TEARDOWN(OS_rmfs(g_devNames[4]));
     }
-
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-system-mount failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_getphysicaldrivename_test_exit_tag;
-    }
-
-    memset(physDevName, '\0', sizeof(physDevName));
-    if ((OS_FS_GetPhysDriveName(physDevName, g_mntNames[4]) == OS_SUCCESS) &&
-        (strncmp(physDevName, g_physDriveName, strlen(g_physDriveName)) == 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_unmount(g_mntNames[4]);
-    OS_rmfs(g_devNames[4]);
-
-UT_os_getphysicaldrivename_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -781,37 +654,24 @@ UT_os_getphysicaldrivename_test_exit_tag:
 void UT_os_getfsinfo_test(void)
 {
     os_fsinfo_t fsInfo;
-    int32       res = 0;
-    const char *testDesc;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    res = OS_GetFsInfo(&fsInfo);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_GetFsInfo(&fsInfo)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_getfsinfo_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if (OS_GetFsInfo(NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_GetFsInfo(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
+    /* #2 Nominal */
 
-    if (OS_GetFsInfo(&fsInfo) == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_getfsinfo_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_GetFsInfo(&fsInfo));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -863,79 +723,45 @@ UT_os_getfsinfo_test_exit_tag:
 ** --------------------------------------------------------------------------------*/
 void UT_os_translatepath_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    char        localPath[UT_OS_LOCAL_PATH_BUFF_SIZE];
+    char localPath[UT_OS_LOCAL_PATH_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* #1 Null-pointer-arg */
 
-    res = OS_TranslatePath(NULL, NULL);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    UT_RETVAL(OS_TranslatePath(NULL, localPath), OS_INVALID_POINTER);
+    UT_RETVAL(OS_TranslatePath(g_mntNames[1], NULL), OS_INVALID_POINTER);
+
+    /*-----------------------------------------------------*/
+    /* #2 Path-too-long-arg */
+
+    UT_RETVAL(OS_TranslatePath(g_fsLongName, localPath), OS_FS_ERR_PATH_TOO_LONG);
+
+    /*-----------------------------------------------------*/
+    /* #3 Invalid-virtual-path-arg */
+
+    UT_RETVAL(OS_TranslatePath("cf", localPath), OS_FS_ERR_PATH_INVALID);
+    UT_RETVAL(OS_TranslatePath("/foobar", localPath), OS_FS_ERR_PATH_INVALID);
+
+    /*-----------------------------------------------------*/
+    /* #4 Nominal */
+
+    if (UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_translatepath_test_exit_tag;
-    }
+        if (UT_SETUP(OS_mount(g_devNames[4], g_mntNames[4])))
+        {
+            memset(localPath, 0, sizeof(localPath));
 
-    /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+            UT_NOMINAL(OS_TranslatePath(g_mntNames[4], localPath));
 
-    if ((OS_TranslatePath(NULL, localPath) == OS_INVALID_POINTER) &&
-        (OS_TranslatePath(g_mntNames[1], NULL) == OS_INVALID_POINTER))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+            /* This just checks that the output string is not empty */
+            UtAssert_True(localPath[0] != 0, "localPath (%s)", localPath);
 
-    /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
-
-    if (OS_TranslatePath(g_fsLongName, localPath) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Invalid-virtual-path-arg";
-
-    if ((OS_TranslatePath("cf", localPath) == OS_FS_ERR_PATH_INVALID) &&
-        (OS_TranslatePath("/foobar", localPath) == OS_FS_ERR_PATH_INVALID))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
-
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_translatepath_test_exit_tag;
-    }
-
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-system-mount failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-
+            /* Reset test environment */
+            UT_TEARDOWN(OS_unmount(g_mntNames[4]));
+        }
         /* Reset test environment */
-        OS_rmfs(g_devNames[4]);
-
-        goto UT_os_translatepath_test_exit_tag;
+        UT_TEARDOWN(OS_rmfs(g_devNames[4]));
     }
-
-    if ((OS_TranslatePath(g_mntNames[4], localPath) == OS_SUCCESS) &&
-        (strncmp(localPath, g_physDriveName, strlen(g_physDriveName)) == 0))
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_unmount(g_mntNames[4]);
-    OS_rmfs(g_devNames[4]);
-
-UT_os_translatepath_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -976,81 +802,48 @@ UT_os_translatepath_test_exit_tag:
 ** --------------------------------------------------------------------------------*/
 void UT_os_checkfs_test()
 {
-    const char *testDesc;
-    int         res;
-    char        driveName[UT_OS_PATH_BUFF_SIZE];
+    char driveName[UT_OS_PATH_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    if (OS_chkfs(NULL, 0) == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_TranslatePath(NULL, NULL)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_checkfs_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    if (OS_chkfs(NULL, 0) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_chkfs(NULL, 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #2 Path-too-long-arg */
 
     memset(driveName, 'A', sizeof(driveName));
     driveName[sizeof(driveName) - 1] = '\0';
 
-    if (OS_chkfs(driveName, 0) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_chkfs(driveName, 0), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #3 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[5], g_volNames[5], g_blkSize, g_blkCnt)))
     {
-        testDesc = "#4 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_checkfs_test_exit_tag;
-    }
+        if (UT_SETUP(OS_mount(g_devNames[5], g_mntNames[5])))
+        {
+            UT_NOMINAL_OR_NOTIMPL(OS_chkfs(g_mntNames[5], 0));
 
-    if (OS_mount(g_devNames[5], g_mntNames[5]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-system-mount failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_checkfs_test_exit_tag;
-    }
+            /* Reset test environment */
+            UT_TEARDOWN(OS_unmount(g_mntNames[5]));
+        }
 
-    res = OS_chkfs(g_mntNames[5], 0);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        testDesc = "#4 Nominal - Not implemented in API";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
+        /* Reset test environment */
+        UT_TEARDOWN(OS_rmfs(g_devNames[5]));
     }
-    else if (res == OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    }
-    else
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
-
-    /* Reset test environment */
-    OS_unmount(g_mntNames[5]);
-    OS_rmfs(g_devNames[5]);
-
-UT_os_checkfs_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -1099,75 +892,50 @@ UT_os_checkfs_test_exit_tag:
 ** --------------------------------------------------------------------------------*/
 void UT_os_fsstatvolume_test(void)
 {
-    const char * testDesc;
     OS_statvfs_t statbuf;
 
     /*-----------------------------------------------------*/
-    testDesc = "API not implemented";
+    /* API not implemented */
 
-    if (OS_FileSysStatVolume("/cf", &statbuf) == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_FileSysStatVolume("/cf", &statbuf)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_fsstatvolume_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1a Null-pointer-arg";
+    /* #1a Null-pointer-arg */
 
-    if (OS_FileSysStatVolume(NULL, &statbuf) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FileSysStatVolume(NULL, &statbuf), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#1b Null-pointer-arg";
+    /* #1b Null-pointer-arg */
 
-    if (OS_FileSysStatVolume("/cf", NULL) == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FileSysStatVolume("/cf", NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Path-too-long-arg";
+    /* #2 Path-too-long-arg */
 
-    if (OS_FileSysStatVolume(g_fsLongName, &statbuf) == OS_FS_ERR_PATH_TOO_LONG)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_FileSysStatVolume(g_fsLongName, &statbuf), OS_FS_ERR_PATH_TOO_LONG);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #3 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
-    if (OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt) != OS_SUCCESS)
+    if (UT_SETUP(OS_mkfs(g_fsAddrPtr, g_devNames[4], g_volNames[4], g_blkSize, g_blkCnt)))
     {
-        testDesc = "#4 Nominal - File-system-create failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_fsstatvolume_test_exit_tag;
+        if (UT_SETUP(OS_mount(g_devNames[4], g_mntNames[4])))
+        {
+            UT_NOMINAL(OS_FileSysStatVolume(g_mntNames[4], &statbuf));
+
+            /* Reset test environment */
+            UT_TEARDOWN(OS_unmount(g_mntNames[4]));
+        }
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_rmfs(g_devNames[4]));
     }
-
-    if (OS_mount(g_devNames[4], g_mntNames[4]) != OS_SUCCESS)
-    {
-        testDesc = "#4 Nominal - File-system-mount failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-        goto UT_os_fsstatvolume_test_exit_tag;
-    }
-
-    if (OS_FileSysStatVolume(g_mntNames[4], &statbuf) >= 0)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    OS_unmount(g_mntNames[4]);
-    OS_rmfs(g_devNames[4]);
-
-UT_os_fsstatvolume_test_exit_tag:
-    return;
 }
 
 /*================================================================================*

--- a/src/unit-tests/osloader-test/ut_osloader_module_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_module_test.c
@@ -67,122 +67,82 @@
 **--------------------------------------------------------------------------------*/
 void UT_os_module_load_test()
 {
-    int         i;
-    int32       res = 0;
-    const char *testDesc;
-    uint32      test_setup_invalid = 0;
-    osal_id_t   module_id;
-    osal_id_t   module_id2;
-    char        module_name[UT_OS_NAME_BUFF_SIZE];
-    char        module_file_name[UT_OS_PATH_BUFF_SIZE];
+    int       i;
+    osal_id_t module_id;
+    osal_id_t module_id2;
+    char      module_name[UT_OS_NAME_BUFF_SIZE];
+    char      module_file_name[UT_OS_PATH_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_module_load_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg-1";
+    /* #1 Null-pointer-arg-1 */
 
-    res = OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleLoad(0, "TestModule", UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS),
+              OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Null-pointer-arg-2";
+    /* #2 Null-pointer-arg-2 */
 
-    res = OS_ModuleLoad(&module_id, 0, UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleLoad(&module_id, 0, UT_OS_GENERIC_MODULE_NAME1, OS_MODULE_FLAG_LOCAL_SYMBOLS),
+              OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Null-pointer-arg-3";
+    /* #3 Null-pointer-arg-3 */
 
-    res = OS_ModuleLoad(&module_id, "TestModule", 0, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleLoad(&module_id, "TestModule", 0, OS_MODULE_FLAG_LOCAL_SYMBOLS), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 No-free-IDs";
+    /* #4 No-free-IDs */
 
-    /* Setup */
-    for (i = 0; i < OS_MAX_MODULES; i++)
+    for (i = 0; i <= OS_MAX_MODULES; i++)
     {
         snprintf(module_name, sizeof(module_name), UT_OS_GENERIC_MODULE_NAME_TEMPLATE, i);
         snprintf(module_file_name, sizeof(module_file_name), UT_OS_GENERIC_MODULE_FILE_TEMPLATE, i);
-        res = OS_ModuleLoad(&module_id, module_name, module_file_name, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-        if (res != OS_SUCCESS)
+
+        if (i == OS_MAX_MODULES)
         {
-            testDesc = "#4 No-free-IDs - Module Load failed";
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-            test_setup_invalid = 1;
+            UT_RETVAL(OS_ModuleLoad(&module_id, module_name, module_file_name, OS_MODULE_FLAG_LOCAL_SYMBOLS),
+                      OS_ERR_NO_FREE_IDS);
+        }
+        else if (!UT_SETUP(OS_ModuleLoad(&module_id, module_name, module_file_name, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
+        {
             break;
         }
     }
 
-    if (test_setup_invalid == 0)
-    {
-        res = OS_ModuleLoad(&module_id, "OneTooMany", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-        if (res == OS_ERR_NO_FREE_IDS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
     /* Reset test environment */
     OS_DeleteAllObjects();
 
     /*-----------------------------------------------------*/
-    testDesc = "#5 Duplicate-name";
+    /* #5 Duplicate-name */
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id2, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_ModuleLoad(&module_id2, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
     {
-        testDesc = "#5 Duplicate-name - Module Load failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_ModuleLoad(&module_id, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-        if (res == OS_ERR_NAME_TAKEN)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_RETVAL(OS_ModuleLoad(&module_id, "DUPLICATE", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS),
+                  OS_ERR_NAME_TAKEN);
 
         /* Reset test environment */
-        res = OS_ModuleUnload(module_id2);
+        UT_TEARDOWN(OS_ModuleUnload(module_id2));
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#6 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #6 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#7 Nominal";
+    /* #7 Nominal */
 
-    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_NOMINAL(OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS));
 
     /* Reset test environment */
-    res = OS_ModuleUnload(module_id);
-
-UT_os_module_load_test_exit_tag:
-    return;
+    UT_TEARDOWN(OS_ModuleUnload(module_id));
 }
 
 /*--------------------------------------------------------------------------------*
@@ -195,55 +155,32 @@ UT_os_module_load_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_module_unload_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    osal_id_t   module_id;
+    osal_id_t module_id;
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_ModuleUnload(OS_OBJECT_ID_UNDEFINED);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_ModuleUnload(OS_OBJECT_ID_UNDEFINED)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_module_unload_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-ID-arg";
+    /* #1 Invalid-ID-arg */
 
-    res = OS_ModuleUnload(UT_OBJID_INCORRECT);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleUnload(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #2 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
     {
-        testDesc = "#3 Nominal - Module Load failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
+        UT_NOMINAL(OS_ModuleUnload(module_id));
     }
-    else
-    {
-        res = OS_ModuleUnload(module_id);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
-
-UT_os_module_unload_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -256,62 +193,37 @@ UT_os_module_unload_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_module_info_test()
 {
-    int32            res = 0;
-    const char *     testDesc;
     osal_id_t        module_id;
     OS_module_prop_t module_info;
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_ModuleInfo(OS_OBJECT_ID_UNDEFINED, &module_info);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_ModuleInfo(OS_OBJECT_ID_UNDEFINED, &module_info)))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_module_info_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-pointer-arg";
+    /* #1 Invalid-pointer-arg */
 
-    res = OS_ModuleInfo(OS_OBJECT_ID_UNDEFINED, NULL);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleInfo(OS_OBJECT_ID_UNDEFINED, NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-ID-arg";
+    /* #2 Invalid-ID-arg */
 
-    res = OS_ModuleInfo(UT_OBJID_INCORRECT, &module_info);
-    if (res == OS_ERR_INVALID_ID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleInfo(UT_OBJID_INCORRECT, &module_info), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
     /* Setup */
-    res = OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_ModuleLoad(&module_id, "Good", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
     {
-        testDesc = "#3 Nominal - Module Load failed";
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_ModuleInfo(module_id, &module_info);
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        UT_NOMINAL(OS_ModuleInfo(module_id, &module_info));
 
-        res = OS_ModuleUnload(module_id);
+        UT_TEARDOWN(OS_ModuleUnload(module_id));
     }
-
-UT_os_module_info_test_exit_tag:
-    return;
 }
 
 /*================================================================================*

--- a/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
@@ -66,73 +66,44 @@
 
 void UT_os_symbol_lookup_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    cpuaddr     symbol_addr;
-    osal_id_t   module_id;
+    cpuaddr   symbol_addr;
+    osal_id_t module_id;
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_SymbolLookup(&symbol_addr, "main");
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_SymbolLookup(&symbol_addr, "main")))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_symbol_lookup_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-pointer-arg-1";
+    /* #1 Invalid-pointer-arg-1 */
 
-    res = OS_SymbolLookup(0, "main");
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_SymbolLookup(0, "Sym"), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg-2";
+    /* #2 Invalid-pointer-arg-2 */
 
-    res = OS_SymbolLookup(&symbol_addr, 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_SymbolLookup(&symbol_addr, 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Symbol-not-found";
-
-    res = OS_SymbolLookup(&symbol_addr, "ThisSymbolIsNotFound");
-    if (res == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal, Global Symbols";
-
-    /* Setup */
-    res = OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_GLOBAL_SYMBOLS);
-    if (res != OS_SUCCESS)
+    /* Setup for remainder of tests */
+    if (UT_SETUP(OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_GLOBAL_SYMBOLS)))
     {
-        UT_OS_TEST_RESULT("#4 Nominal - Module Load failed", UTASSERT_CASETYPE_TSF);
-    }
-    else
-    {
-        res = OS_SymbolLookup(&symbol_addr, "module1");
-        if (res == OS_SUCCESS)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-        else if (res == OS_ERR_NOT_IMPLEMENTED)
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        else
-            UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+        /*-----------------------------------------------------*/
+        /* #3 Symbol-not-found */
+
+        UT_RETVAL(OS_SymbolLookup(&symbol_addr, "NotFound"), OS_ERROR);
+
+        /*-----------------------------------------------------*/
+        /* #4 Nominal, Global Symbols */
+
+        UT_NOMINAL(OS_SymbolLookup(&symbol_addr, "module1"));
 
         /* Reset test environment */
-        res = OS_ModuleUnload(module_id);
+        UT_TEARDOWN(OS_ModuleUnload(module_id));
     }
-
-UT_os_symbol_lookup_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -146,71 +117,44 @@ UT_os_symbol_lookup_test_exit_tag:
 
 void UT_os_module_symbol_lookup_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    cpuaddr     symbol_addr;
-    osal_id_t   module_id;
+    cpuaddr   symbol_addr;
+    osal_id_t module_id;
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, "main");
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, "main")))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_module_symbol_lookup_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-pointer-arg-1";
+    /* #1 Invalid-pointer-arg-1 */
 
-    res = OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, 0, "main");
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, 0, "Sym"), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-pointer-arg-2";
+    /* #2 Invalid-pointer-arg-2 */
 
-    res = OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
     /* Setup for remainder of tests */
-    res = OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS);
-    if (res != OS_SUCCESS)
+    if (UT_SETUP(OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
     {
-        UT_OS_TEST_RESULT("Module Load failed", UTASSERT_CASETYPE_TSF);
-        goto UT_os_module_symbol_lookup_test_exit_tag;
+        /*-----------------------------------------------------*/
+        /* #3 Symbol-not-found */
+
+        UT_RETVAL(OS_ModuleSymbolLookup(module_id, &symbol_addr, "NotFound"), OS_ERROR);
+
+        /*-----------------------------------------------------*/
+        /* #4 Nominal, Local Symbols */
+
+        UT_NOMINAL(OS_ModuleSymbolLookup(module_id, &symbol_addr, "module1"));
+
+        /* Reset test environment */
+        UT_TEARDOWN(OS_ModuleUnload(module_id));
     }
-
-    /*-----------------------------------------------------*/
-    testDesc = "#3 Symbol-not-found";
-
-    res = OS_ModuleSymbolLookup(module_id, &symbol_addr, "ThisSymbolIsNotFound");
-    if (res == OS_ERROR)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal, Local Symbols";
-
-    res = OS_ModuleSymbolLookup(module_id, &symbol_addr, "module1");
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-    /* Reset test environment */
-    res = OS_ModuleUnload(module_id);
-
-UT_os_module_symbol_lookup_test_exit_tag:
-    return;
 }
 
 /*--------------------------------------------------------------------------------*
@@ -224,9 +168,6 @@ UT_os_module_symbol_lookup_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_symbol_table_dump_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*
      * Note that even if the functionality is not implemented,
      * the API still validates the input pointers (not null) and
@@ -234,40 +175,19 @@ void UT_os_symbol_table_dump_test()
      */
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Invalid-pointer-arg";
+    /* #1 Invalid-pointer-arg */
 
-    res = OS_SymbolTableDump(0, 10000);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_SymbolTableDump(0, 10000), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Invalid-path";
+    /* #2 Invalid-path */
 
-    res = OS_SymbolTableDump("/this/path/is/invalid.dat", 10000);
-    if (res == OS_FS_ERR_PATH_INVALID)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_SymbolTableDump("/this/path/is/invalid.dat", 10000), OS_FS_ERR_PATH_INVALID);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 Nominal";
+    /* #3 Nominal */
 
-    res = OS_SymbolTableDump(UT_OS_GENERIC_MODULE_DIR "SymbolFile.dat", 32000);
-    if (res == OS_ERR_NOT_IMPLEMENTED)
-    {
-        /* allowed, not applicable on this system */
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-    }
-    else if (res == OS_SUCCESS)
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    }
-    else
-    {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-    }
+    UT_NOMINAL_OR_NOTIMPL(OS_SymbolTableDump(UT_OS_GENERIC_MODULE_DIR "SymbolFile.dat", 32000));
 }
 
 /*================================================================================*

--- a/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
+++ b/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
@@ -80,36 +80,23 @@
 **--------------------------------------------------------------------------------*/
 void UT_os_networkgetid_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_NetworkGetID();
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_NetworkGetID()))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_networkgetid_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #1 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Nominal";
-
-    res = OS_NetworkGetID();
+    /* #2 Nominal */
 
     /* NOTE: This API does not return error codes.
      * Any return value could be valid */
-    UtPrintf("OS_NetworkGetID() return value=%ld", (long)res);
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_MIR);
-
-UT_os_networkgetid_test_exit_tag:
-    return;
+    UT_MIR_STATUS(OS_NetworkGetID());
 }
 
 /*--------------------------------------------------------------------------------*
@@ -150,54 +137,33 @@ UT_os_networkgetid_test_exit_tag:
 **--------------------------------------------------------------------------------*/
 void UT_os_networkgethostname_test()
 {
-    int32       res = 0;
-    const char *testDesc;
-    char        buffer[UT_OS_IO_BUFF_SIZE];
+    char buffer[UT_OS_IO_BUFF_SIZE];
 
     /*-----------------------------------------------------*/
-    testDesc = "API Not implemented";
+    /* API Not implemented */
 
-    res = OS_NetworkGetHostName(buffer, sizeof(buffer));
-    if (res == OS_ERR_NOT_IMPLEMENTED)
+    if (!UT_IMPL(OS_NetworkGetHostName(buffer, sizeof(buffer))))
     {
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_NA);
-        goto UT_os_networkgethostname_test_exit_tag;
+        return;
     }
 
     /*-----------------------------------------------------*/
-    testDesc = "#1 Null-pointer-arg";
+    /* #1 Null-pointer-arg */
 
-    res = OS_NetworkGetHostName(NULL, 0);
-    if (res == OS_INVALID_POINTER)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_NetworkGetHostName(NULL, 0), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
-    testDesc = "#2 Zero-name-length-arg";
+    /* #2 Zero-name-length-arg */
 
-    res = OS_NetworkGetHostName(buffer, 0);
-    if (res == OS_ERR_INVALID_SIZE)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
+    UT_RETVAL(OS_NetworkGetHostName(buffer, 0), OS_ERR_INVALID_SIZE);
 
     /*-----------------------------------------------------*/
-    testDesc = "#3 OS-call-failure";
-
-    UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_INFO);
+    /* #3 OS-call-failure */
 
     /*-----------------------------------------------------*/
-    testDesc = "#4 Nominal";
+    /* #4 Nominal */
 
-    res = OS_NetworkGetHostName(buffer, sizeof(buffer));
-    if (res == OS_SUCCESS)
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_PASS);
-    else
-        UT_OS_TEST_RESULT(testDesc, UTASSERT_CASETYPE_FAILURE);
-
-UT_os_networkgethostname_test_exit_tag:
-    return;
+    UT_NOMINAL(OS_NetworkGetHostName(buffer, sizeof(buffer)));
 }
 
 /*================================================================================*


### PR DESCRIPTION
**Describe the contribution**
Update most of the conditions in the "unit tests" to use the support macros whenever possible.  The macros display the
function being called as well as the return value being checked for, and therefore this makes it so the test log file can be
cross referenced back to the documentation to ensure the documented return codes are being tested.

As a nice side effect this also removes quite a bit of repetition in the test programs.

Fixes #981

**Testing performed**
Build and run all OSAL unit tests

**Expected behavior changes**
Log file produced has much more detail, and can now be cross referenced back to documentation.

**System(s) tested on**
Ubuntu 20.04 (native)
RTEMS 4.11 (pc686+qemu)

**Additional context**
See gist of complete test output log for "osal_core_UT": https://gist.github.com/jphickey/ccb739d1f1cf6b36caca73e5ee9205cf
Dependency note: PR #1000 fixes the OS_rmdir test.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
