### PR TITLE
Fix #1002, remove extra newlines in utassert logs

### DIFF
--- a/ut_assert/src/utbsp.c
+++ b/ut_assert/src/utbsp.c
@@ -108,6 +108,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
 {
     const char *Prefix;
     char        Buffer[16];
+    size_t      MsgLen;
     uint32      TermModeBits = OS_BSP_CONSOLEMODE_NORMAL;
     uint32      MsgEnabled   = BSP_UT_Global.CurrVerbosity >> MessageType;
 
@@ -182,8 +183,12 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
         }
 
         OS_BSP_ConsoleOutput_Impl(" ", 1);
-        OS_BSP_ConsoleOutput_Impl(OutputMessage, strlen(OutputMessage));
-        OS_BSP_ConsoleOutput_Impl("\n", 1);
+        MsgLen = strlen(OutputMessage);
+        OS_BSP_ConsoleOutput_Impl(OutputMessage, MsgLen);
+        if (MsgLen == 0 || OutputMessage[MsgLen - 1] != '\n')
+        {
+            OS_BSP_ConsoleOutput_Impl("\n", 1);
+        }
 
         OS_BSP_Unlock_Impl();
     }


### PR DESCRIPTION
**Describe the contribution**
If messages (e.g. from UtPrintf, etc) already have a newline, do not add another.

Fixes #1002

**Testing performed**
Build and run OSAL unit tests

**Expected behavior changes**
Extra blank lines in test log are removed.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This should preserve extra newlines in the event that the test case was intentionally adding whitespace, by only appending one if it was _not_ there to begin with.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
