### PR TITLE
Fix #1009, add missing clock retcode tests

### DIFF
--- a/src/os/inc/osapi-clock.h
+++ b/src/os/inc/osapi-clock.h
@@ -80,9 +80,10 @@ enum
  *
  * @note Mission time management typically uses the cFE Time Service
  *
- * @param[out]  time_struct An OS_time_t that will be set to the current time
+ * @param[out]  time_struct An OS_time_t that will be set to the current time @nonnull
  *
  * @return Get local time status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if time_struct is null
  */
 int32 OS_GetLocalTime(OS_time_t *time_struct);
@@ -95,9 +96,10 @@ int32 OS_GetLocalTime(OS_time_t *time_struct);
  *
  * @note Mission time management typically uses the cFE Time Services
  *
- * @param[in]  time_struct An OS_time_t containing the current time
+ * @param[in]  time_struct An OS_time_t containing the current time @nonnull
  *
  * @return Set local time status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_INVALID_POINTER if time_struct is null
  */
 int32 OS_SetLocalTime(const OS_time_t *time_struct);

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.c
@@ -295,7 +295,7 @@ void UT_os_setlocaltime_test()
     /*-----------------------------------------------------*/
     /* #1 Null-pointer-arg */
 
-    UT_RETVAL(OS_GetLocalTime(NULL), OS_INVALID_POINTER);
+    UT_RETVAL(OS_SetLocalTime(NULL), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */


### PR DESCRIPTION
**Describe the contribution**
Corrects unit test retval discrepancies in clock code

Note that the success case for OS_SetLocalTime is tested, but is marked as a MIR test case because it requires
elevated permission, it is expected to fail when running as a normal user on Linux.

Fixes #1009 

**Testing performed**
Run all unit tests, confirm documented return values are checked, and checked return values are documented.

**Expected behavior changes**
No change to FSW, test/doc only

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
