### PR TITLE
Fix #1035, Rename CodeQL cFE Build and add Duplicate Job

### DIFF
--- a/.github/workflows/codeql-cfe-build.yml
+++ b/.github/workflows/codeql-cfe-build.yml
@@ -1,4 +1,4 @@
-name: "CodeQL Analysis"
+name: "CodeQL cFE Build Analysis"
 
 on:
   push:
@@ -11,8 +11,23 @@ env:
   BUILDTYPE: release
 
 jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   CodeQL-Build:
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-18.04
     timeout-minutes: 15
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #1035 
Rename codeql-build.yml to codeql-cfe-build.yml for clarity of what the workflow does. Changed from CodeQL Analysis to CodeQL cFE Build as workflow name. 

**Expected behavior changes**
Users can differentiate between this workflow and the osal default workflow.

**Third party code**
Skip duplicate actions license: https://github.com/fkirc/skip-duplicate-actions/blob/master/LICENSE

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
