### PR TITLE
Fix #1025, Implement Coding Standard Rules in CodeQL

### DIFF
--- a/.github/workflows/codeql-cfe-build.yml
+++ b/.github/workflows/codeql-cfe-build.yml
@@ -25,7 +25,7 @@ jobs:
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
-  CodeQL-Build:
+  CodeQL-Security-Build:
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-18.04
@@ -50,7 +50,49 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
          languages: c
-         queries: +security-extended, security-and-quality
+         config-file: nasa/cFS/.github/codeql/codeql-security.yml@main
+
+      - name: Set up for build
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+          make prep
+
+      - name: Build
+        run: make -j native/default_cpu1/osal/
+
+      - name: Run tests
+        run: (cd build/native/default_cpu1/osal && make test)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+  CodeQL-Coding-Standard-Build:
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout bundle
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+          submodules: true
+
+      - name: Checkout submodule
+        uses: actions/checkout@v2
+        with:
+          path: osal
+
+      - name: Check versions
+        run: git submodule
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+         languages: c
+         config-file: nasa/cFS/.github/codeql/codeql-coding-standard.yml@main
 
       - name: Set up for build
         run: |

--- a/.github/workflows/codeql-osal-default.yml
+++ b/.github/workflows/codeql-osal-default.yml
@@ -26,9 +26,8 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-
-
-  CodeQL-Build:
+          
+  CodeQL-Security-Build:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
@@ -43,7 +42,35 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
          languages: c
-         queries: +security-extended, security-and-quality
+         config-file: nasa/cFS/.github/codeql/codeql-security.yml@main
+
+      - name: Set up for build
+        run: |
+          cp Makefile.sample Makefile
+          make prep
+          
+      - name: Build
+        run: make -j 
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+  CodeQL-Coding-Standard-Build:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout submodule
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+         languages: c
+         config-file: nasa/cFS/.github/codeql/codeql-coding-standard.yml@main
 
       - name: Set up for build
         run: |


### PR DESCRIPTION
**Describe the contribution**
Fix #1025 
Created two configuration files, one for default queries and security queries and another for jpl rules. Waiting for https://github.com/nasa/osal/pull/1039 to be merged to add these queries in the newly created workflow, codeql-cfe-build.yml. 
**Testing performed**
Testing done on cFE forked repository, ArielSAdamsNASA/cFE which used the same files, but with different configuration paths.

Jobs were failing when the entire path of the configuration file were not used. Have to use nasa/cFE/.github/codeql/config-name@branch-name. The branch must be included in the path. 

The CodeQL analysis workflow will fail for this PR since it is calling for a configuration file in main the main branch. It will not work until the configuration files are merged into main. 

In the screenshot is the same workflow as in this pull request, but the configuration path is changed to the forked repo and tested branch. 

![image](https://user-images.githubusercontent.com/69638935/119024913-36fa2580-b969-11eb-9aac-ede0002804a0.png)

**Expected behavior changes**
There should be one job for security queries and one job for JPL and MISRA queries. 

**Describe alternatives you've considered**
Can allow all branches to run CodeQL for pull requests as seen in cFE and PSP instead of just the main branch like cFS. 

**Third party code**
Skip duplicate workflows license: https://github.com/fkirc/skip-duplicate-actions/blob/master/LICENSE

CodeQL license: https://github.com/github/codeql-action/blob/main/LICENSE

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal