### PR TITLE
Fix #1048, filter only whole words for keyword match

### DIFF
--- a/src/ut-stubs/osapi-timebase-stubs.c
+++ b/src/ut-stubs/osapi-timebase-stubs.c
@@ -38,13 +38,13 @@ extern void UT_DefaultHandler_OS_TimeBaseGetInfo(void *, UT_EntryKey_t, const UT
  * Generated stub function for OS_TimeBaseCreate()
  * ----------------------------------------------------
  */
-int32 OS_TimeBaseCreate(osal_id_t *timebase_id, const char *timebase_name, OS_TimerSync_t al_sync)
+int32 OS_TimeBaseCreate(osal_id_t *timebase_id, const char *timebase_name, OS_TimerSync_t external_sync)
 {
     UT_GenStub_SetupReturnBuffer(OS_TimeBaseCreate, int32);
 
     UT_GenStub_AddParam(OS_TimeBaseCreate, osal_id_t *, timebase_id);
     UT_GenStub_AddParam(OS_TimeBaseCreate, const char *, timebase_name);
-    UT_GenStub_AddParam(OS_TimeBaseCreate, OS_TimerSync_t, al_sync);
+    UT_GenStub_AddParam(OS_TimeBaseCreate, OS_TimerSync_t, external_sync);
 
     UT_GenStub_Execute(OS_TimeBaseCreate, Basic, UT_DefaultHandler_OS_TimeBaseCreate);
 

--- a/ut_assert/scripts/generate_stubs.pl
+++ b/ut_assert/scripts/generate_stubs.pl
@@ -155,20 +155,20 @@ foreach my $hdr (@hdrlist)
 
     # Now Find function prototypes
     foreach (@lines) {
-        next if (/typedef/);        # ignore typedefs
-        next if (/static inline/);  # ignore
+        next if (/\btypedef\b/);        # ignore typedefs
+        next if (/\bstatic inline\b/);  # ignore
 
 
         # discard "extern" qualifier
         # (but other qualifiers like "const" are OK and should be preserved, as
         # it is part of return type).
-        s/extern//;
+        s/\bextern\b//;
 
         # The following macros are defined in OSAL common_types.h as function attributes
         # They may appear on other function declarations, and should be ignored here.
-        s/_EXTENSION_//;
-        s/OS_USED//;
-        s/OS_PRINTF\(.*?\)//;
+        s/\b_EXTENSION_\b//;
+        s/\bOS_USED\b//;
+        s/\bOS_PRINTF\(.*?\)//;
 
         # scrub whitespace for consistency - multiple spaces become single space
         # and trim leading/trailing spaces again

--- a/ut_assert/scripts/generate_stubs.pl
+++ b/ut_assert/scripts/generate_stubs.pl
@@ -129,6 +129,12 @@ foreach my $hdr (@hdrlist)
     }
     close(HDR);
 
+    foreach (@lines)
+    {
+        # Truncate each line at C++-style comment
+        s/\/\/.*$//;
+    }
+
     # combine all content into a single string
     # this eases processing of multi-line constructs
     $file = join('', @lines);


### PR DESCRIPTION
**Describe the contribution**
In the stub generator script, filter only whole words when ignoring keywords.  Do not match if the word appears as a substring inside a larger word.

Fixes #1048

**Testing performed**
Regenerate stubs, and build and run all unit tests.

**Expected behavior changes**
Corrects the argument name in OS_TimeBaseCreate stub (only occurrence discovered so far)

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
