### PR TITLE
Fix #1015, resolve discrepancies between idmap API and unit tests

### DIFF
--- a/src/os/inc/osapi-idmap.h
+++ b/src/os/inc/osapi-idmap.h
@@ -151,13 +151,14 @@ static inline bool OS_ObjectIdDefined(osal_id_t object_id)
  * allows application code to retrieve the name of any valid OSAL object ID.
  *
  * @param[in]  object_id The object ID to operate on
- * @param[out] buffer Buffer in which to store the name
- * @param[in]  buffer_size Size of the output storage buffer
+ * @param[out] buffer Buffer in which to store the name @nonnull
+ * @param[in]  buffer_size Size of the output storage buffer @nonzero
  *
- * @returns #OS_SUCCESS if successful
- *          #OS_ERR_INVALID_ID if the passed-in ID is not a valid OSAL ID
- *          #OS_INVALID_POINTER if the passed-in buffer is invalid
- *          #OS_ERR_NAME_TOO_LONG if the name will not fit in the buffer provided
+ * @returns Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS  @copybrief OS_SUCCESS
+ * @retval #OS_ERR_INVALID_ID if the passed-in ID is not a valid OSAL ID
+ * @retval #OS_INVALID_POINTER if the passed-in buffer is invalid
+ * @retval #OS_ERR_NAME_TOO_LONG if the name will not fit in the buffer provided
  */
 int32 OS_GetResourceName(osal_id_t object_id, char *buffer, size_t buffer_size);
 
@@ -192,11 +193,12 @@ osal_objtype_t OS_IdentifyObject(osal_id_t object_id);
  * @sa OS_ObjectIdToArrayIndex
  *
  * @param[in]  object_id    The object ID to operate on
- * @param[out] *ArrayIndex  The Index to return
+ * @param[out] *ArrayIndex  The Index to return @nonnull
  *
- * @return Execution status, see @ref OSReturnCodes
- * @retval #OS_SUCCESS                 @copybrief OS_SUCCESS
- * @retval #OS_ERR_INCORRECT_OBJ_TYPE  @copybrief OS_ERR_INCORRECT_OBJ_TYPE
+ * @returns Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
+ * @retval #OS_ERR_INVALID_ID if the object_id argument is not valid
+ * @retval #OS_INVALID_POINTER if the ArrayIndex is NULL
  */
 int32 OS_ConvertToArrayIndex(osal_id_t object_id, osal_index_t *ArrayIndex);
 
@@ -223,11 +225,10 @@ int32 OS_ConvertToArrayIndex(osal_id_t object_id, osal_index_t *ArrayIndex);
  *
  * @param[in]  idtype       The object type to convert
  * @param[in]  object_id    The object ID to operate on
- * @param[out] *ArrayIndex  The Index to return
+ * @param[out] *ArrayIndex  The Index to return @nonnull
  *
- * @return Execution status, see @ref OSReturnCodes
- * @retval #OS_SUCCESS                 @copybrief OS_SUCCESS
- * @retval #OS_ERR_INCORRECT_OBJ_TYPE  @copybrief OS_ERR_INCORRECT_OBJ_TYPE
+ * @returns Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_ERR_INVALID_ID if the object_id argument is not valid
  * @retval #OS_INVALID_POINTER if the ArrayIndex is NULL
  * */
@@ -243,7 +244,7 @@ int32 OS_ObjectIdToArrayIndex(osal_objtype_t idtype, osal_id_t object_id, osal_i
  * @param[in]  creator_id   Filter objects to those created by a specific task
  *                          This may be passed as OS_OBJECT_CREATOR_ANY to return all objects
  * @param[in]  callback_ptr Function to invoke for each matching object ID
- * @param[in]  callback_arg Opaque Argument to pass to callback function
+ * @param[in]  callback_arg Opaque Argument to pass to callback function (may be NULL)
  */
 void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg);
 
@@ -258,7 +259,7 @@ void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void 
  * @param[in]  creator_id   Filter objects to those created by a specific task
  *                          This may be passed as OS_OBJECT_CREATOR_ANY to return all objects
  * @param[in]  callback_ptr Function to invoke for each matching object ID
- * @param[in]  callback_arg Opaque Argument to pass to callback function
+ * @param[in]  callback_arg Opaque Argument to pass to callback function (may be NULL)
  */
 void OS_ForEachObjectOfType(osal_objtype_t objtype, osal_id_t creator_id, OS_ArgCallback_t callback_ptr,
                             void *callback_arg);

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -331,7 +331,7 @@ int32 OS_ObjectIdTransactionInit(OS_lock_mode_t lock_mode, osal_objtype_t idtype
      */
     if (OS_GetMaxForObjectType(idtype) == 0)
     {
-        return OS_ERR_INCORRECT_OBJ_TYPE;
+        return OS_ERR_INVALID_ID;
     }
 
     token->lock_mode = lock_mode;
@@ -1473,10 +1473,8 @@ int32 OS_GetResourceName(osal_id_t object_id, char *buffer, size_t buffer_size)
     OS_object_token_t   token;
 
     /* sanity check the passed-in buffer and size */
-    if (buffer == NULL || buffer_size == 0)
-    {
-        return OS_INVALID_POINTER;
-    }
+    OS_CHECK_POINTER(buffer);
+    OS_CHECK_SIZE(buffer_size);
 
     /*
      * Initially set the output string to empty.

--- a/src/tests/idmap-api-test/idmap-api-test.c
+++ b/src/tests/idmap-api-test/idmap-api-test.c
@@ -43,6 +43,7 @@ osal_id_t mutex_id1;
 osal_id_t mutex_id2;
 osal_id_t mutex_id3;
 osal_id_t time_base_id;
+osal_id_t badid;
 
 #define UT_EXIT_LOOP_MAX 100
 
@@ -135,24 +136,23 @@ void TestIdMapApi_Setup(void)
         loopcnt++;
     }
     UtAssert_True(loopcnt < UT_EXIT_LOOP_MAX, "Task exited after %ld iterations", (long)loopcnt);
-}
-/* *************************************** MAIN ************************************** */
-
-void TestIdMapApi(void)
-{
-    int32                  expected;
-    int32                  actual;
-    osal_index_t           TestArrayIndex;
-    osal_index_t           TestMutex1Index;
-    osal_index_t           TestMutex2Index;
-    osal_id_t              badid;
-    Test_OS_ObjTypeCount_t Count;
 
     /*
      * manufacture a "bad" ID value which is neither valid
      * nor equivalent to OS_OBJECT_ID_UNDEFINED
+     *
+     * This can be created by flipping the bits of a valid ID.
      */
-    memset(&badid, 0xFF, sizeof(badid));
+    badid = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(mutex_id2) ^ 0xFFFFFFFF);
+}
+/* *************************************** MAIN ************************************** */
+
+void Test_OS_IdentifyObject(void)
+{
+    /*
+     * Test Case For:
+     * int32 OS_IdentifyObject(void)
+     */
 
     /*
      * NOTE: The following objects were not created and tested:
@@ -165,36 +165,15 @@ void TestIdMapApi(void)
      */
 
     /*
-     * Test Case For:
-     * int32 OS_IdentifyObject(void)
-     */
-
-    /*
      * Test with nominal values
      */
-    expected = OS_OBJECT_TYPE_OS_TASK;
-    actual   = OS_IdentifyObject(task_id);
-    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);
-
-    expected = OS_OBJECT_TYPE_OS_QUEUE;
-    actual   = OS_IdentifyObject(queue_id);
-    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);
-
-    expected = OS_OBJECT_TYPE_OS_COUNTSEM;
-    actual   = OS_IdentifyObject(count_sem_id);
-    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);
-
-    expected = OS_OBJECT_TYPE_OS_BINSEM;
-    actual   = OS_IdentifyObject(bin_sem_id);
-    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);
-
-    expected = OS_OBJECT_TYPE_OS_MUTEX;
-    actual   = OS_IdentifyObject(mutex_id1);
-    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);
-
-    expected = OS_OBJECT_TYPE_OS_TIMEBASE;
-    actual   = OS_IdentifyObject(time_base_id);
-    UtAssert_True(actual == expected, "OS_IdentifyObject() (%ld) == %ld", (long)actual, (long)expected);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(task_id), OS_OBJECT_TYPE_OS_TASK);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(queue_id), OS_OBJECT_TYPE_OS_QUEUE);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(count_sem_id), OS_OBJECT_TYPE_OS_COUNTSEM);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(bin_sem_id), OS_OBJECT_TYPE_OS_BINSEM);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(mutex_id1), OS_OBJECT_TYPE_OS_MUTEX);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(time_base_id), OS_OBJECT_TYPE_OS_TIMEBASE);
+    UtAssert_UINT32_EQ(OS_IdentifyObject(OS_OBJECT_ID_UNDEFINED), OS_OBJECT_TYPE_UNDEFINED);
 
     /*
      * Test with extreme cases using min and max values
@@ -202,14 +181,18 @@ void TestIdMapApi(void)
      * here.  The only check is that the function doesn't return
      * an error when called
      */
-    OS_IdentifyObject(OS_OBJECT_ID_UNDEFINED);
     OS_IdentifyObject(badid);
+}
 
+void Test_OS_ConvertToArrayIndex(void)
+{
     /*
      * Test Case For:
      * int32 OS_ConvertToArrayIndex(void)
      */
-    expected = OS_SUCCESS;
+    osal_index_t TestArrayIndex;
+    osal_index_t TestMutex1Index;
+    osal_index_t TestMutex2Index;
 
     /*
      * Check different id types and verify array indices
@@ -221,40 +204,33 @@ void TestIdMapApi(void)
     /*
      * Test with nominal values
      */
-    actual = OS_ConvertToArrayIndex(task_id, &TestArrayIndex);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(task_id, &TestArrayIndex), OS_SUCCESS);
     UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_TASKS, "0 < TestArrayIndex(%lu)  <= OS_MAX_TASKS",
                   (long)TestArrayIndex);
 
-    actual = OS_ConvertToArrayIndex(queue_id, &TestArrayIndex);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(queue_id, &TestArrayIndex), OS_SUCCESS);
     UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_QUEUES, "0 < TestArrayIndex(%lu)  <= OS_MAX_QUEUES",
                   (long)TestArrayIndex);
 
-    actual = OS_ConvertToArrayIndex(count_sem_id, &TestArrayIndex);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(count_sem_id, &TestArrayIndex), OS_SUCCESS);
     UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_COUNT_SEMAPHORES,
                   "0 < TestArrayIndex(%lu)  <= OS_MAX_COUNT_SEMAPHORES", (long)TestArrayIndex);
 
-    actual = OS_ConvertToArrayIndex(bin_sem_id, &TestArrayIndex);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(bin_sem_id, &TestArrayIndex), OS_SUCCESS);
     UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_BIN_SEMAPHORES,
                   "0 < TestArrayIndex(%lu)  <= OS_MAX_BIN_SEMAPHORES", (long)TestArrayIndex);
 
-    actual = OS_ConvertToArrayIndex(mutex_id1, &TestMutex1Index);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(mutex_id1, &TestMutex1Index), OS_SUCCESS);
     UtAssert_True(TestMutex1Index >= 0 && TestMutex1Index < OS_MAX_MUTEXES,
                   "0 < TestMutex1Index(%lu)  <= OS_MAX_MUTEXES", (long)TestMutex1Index);
 
-    actual = OS_ConvertToArrayIndex(mutex_id2, &TestMutex2Index);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(mutex_id2, &TestMutex2Index), OS_SUCCESS);
     UtAssert_True(TestMutex2Index >= 0 && TestMutex2Index < OS_MAX_MUTEXES,
                   "0 < TestMutex2Index(%lu)  <= OS_MAX_MUTEXES", (long)TestMutex2Index);
     UtAssert_True(TestMutex1Index != TestMutex2Index, "TestMutex1Index(%lu) !=  TestMutex2Index(%lu)",
                   (long)TestMutex1Index, (long)TestMutex2Index);
 
-    actual = OS_ConvertToArrayIndex(time_base_id, &TestArrayIndex);
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(time_base_id, &TestArrayIndex), OS_SUCCESS);
     UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_TIMEBASES,
                   "0 < TestArrayIndex(%lu)  <= OS_MAX_TIMEBASES", (long)TestArrayIndex);
 
@@ -262,18 +238,83 @@ void TestIdMapApi(void)
      * Test with extreme cases using invalid inputs and checking
      * for an error return code
      */
-    actual   = OS_ConvertToArrayIndex(OS_OBJECT_ID_UNDEFINED, &TestArrayIndex);
-    expected = OS_ERR_INVALID_ID;
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(OS_OBJECT_ID_UNDEFINED, &TestArrayIndex), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(badid, &TestArrayIndex), OS_ERR_INVALID_ID);
 
-    actual   = OS_ConvertToArrayIndex(badid, &TestArrayIndex);
-    expected = OS_ERR_INVALID_ID;
-    UtAssert_True(actual == expected, "OS_ConvertToArrayIndex() (%ld) == %ld ", (long)actual, (long)expected);
+    /* Check with null pointer */
+    UtAssert_INT32_EQ(OS_ConvertToArrayIndex(bin_sem_id, NULL), OS_INVALID_POINTER);
+}
 
+void Test_OS_ObjectIdToArrayIndex(void)
+{
+    /*
+     * Test case for:
+     * int32 OS_ObjectIdToArrayIndex(osal_objtype_t idtype, osal_id_t object_id, osal_index_t *ArrayIndex);
+     */
+    osal_index_t TestArrayIndex;
+    osal_index_t TestMutex1Index;
+    osal_index_t TestMutex2Index;
+
+    /* Test with nominal (correct) object types */
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TASK, task_id, &TestArrayIndex), OS_SUCCESS);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_TASKS, "0 < TestArrayIndex(%lu)  <= OS_MAX_TASKS",
+                  (long)TestArrayIndex);
+
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_QUEUE, queue_id, &TestArrayIndex), OS_SUCCESS);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_QUEUES, "0 < TestArrayIndex(%lu)  <= OS_MAX_QUEUES",
+                  (long)TestArrayIndex);
+
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_COUNTSEM, count_sem_id, &TestArrayIndex), OS_SUCCESS);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_COUNT_SEMAPHORES,
+                  "0 < TestArrayIndex(%lu)  <= OS_MAX_COUNT_SEMAPHORES", (long)TestArrayIndex);
+
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_BINSEM, bin_sem_id, &TestArrayIndex), OS_SUCCESS);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_BIN_SEMAPHORES,
+                  "0 < TestArrayIndex(%lu)  <= OS_MAX_BIN_SEMAPHORES", (long)TestArrayIndex);
+
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_MUTEX, mutex_id1, &TestMutex1Index), OS_SUCCESS);
+    UtAssert_True(TestMutex1Index >= 0 && TestMutex1Index < OS_MAX_MUTEXES,
+                  "0 < TestMutex1Index(%lu)  <= OS_MAX_MUTEXES", (long)TestMutex1Index);
+
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_MUTEX, mutex_id2, &TestMutex2Index), OS_SUCCESS);
+    UtAssert_True(TestMutex2Index >= 0 && TestMutex2Index < OS_MAX_MUTEXES,
+                  "0 < TestMutex2Index(%lu)  <= OS_MAX_MUTEXES", (long)TestMutex2Index);
+    UtAssert_True(TestMutex1Index != TestMutex2Index, "TestMutex1Index(%lu) !=  TestMutex2Index(%lu)",
+                  (long)TestMutex1Index, (long)TestMutex2Index);
+
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TIMEBASE, time_base_id, &TestArrayIndex), OS_SUCCESS);
+    UtAssert_True(TestArrayIndex >= 0 && TestArrayIndex < OS_MAX_TIMEBASES,
+                  "0 < TestArrayIndex(%lu)  <= OS_MAX_TIMEBASES", (long)TestArrayIndex);
+
+    /* Check cases where the object type and the ID are _not_ matched */
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_QUEUE, task_id, &TestArrayIndex), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_COUNTSEM, queue_id, &TestArrayIndex),
+                      OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_BINSEM, count_sem_id, &TestArrayIndex),
+                      OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_MUTEX, bin_sem_id, &TestArrayIndex), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TIMEBASE, mutex_id2, &TestMutex2Index),
+                      OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TASK, time_base_id, &TestArrayIndex),
+                      OS_ERR_INVALID_ID);
+
+    /* Check with bad object IDs */
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TASK, OS_OBJECT_ID_UNDEFINED, &TestArrayIndex),
+                      OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_MUTEX, badid, &TestArrayIndex), OS_ERR_INVALID_ID);
+
+    /* Check with null pointer */
+    UtAssert_INT32_EQ(OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_BINSEM, bin_sem_id, NULL), OS_INVALID_POINTER);
+}
+
+void Test_OS_ForEachObject(void)
+{
     /*
      * Test Case For:
      * void OS_ForEachObject (uint32 creator_id, OS_ArgCallback_t callback_ptr, void *callback_arg);
      */
+    Test_OS_ObjTypeCount_t Count;
+
     memset(&Count, 0, sizeof(Count));
 
     OS_ForEachObject(OS_OBJECT_CREATOR_ANY, &ObjTypeCounter, &Count);
@@ -287,6 +328,41 @@ void TestIdMapApi(void)
                   (unsigned long)Count.BinSemCount);
     UtAssert_True(Count.MutexCount == 3, "OS_ForEachObject() MutexCount (%lu) == 3", (unsigned long)Count.MutexCount);
     UtAssert_True(Count.TimeBaseCount == 1, "OS_ForEachObject() TimeBaseCount (%lu) == 1",
+                  (unsigned long)Count.TimeBaseCount);
+
+    /* OS_ForEachObjectOfType() is similar but only iterates one type */
+    memset(&Count, 0, sizeof(Count));
+    OS_ForEachObjectOfType(OS_OBJECT_TYPE_OS_MUTEX, OS_OBJECT_CREATOR_ANY, &ObjTypeCounter, &Count);
+
+    /* Verify Outputs */
+    UtAssert_True(Count.TaskCount == 0, "OS_ForEachObject() TaskCount (%lu) == 0", (unsigned long)Count.TaskCount);
+    UtAssert_True(Count.QueueCount == 0, "OS_ForEachObject() QueueCount (%lu) == 1", (unsigned long)Count.QueueCount);
+    UtAssert_True(Count.CountSemCount == 0, "OS_ForEachObject() CountSemCount (%lu) == 1",
+                  (unsigned long)Count.CountSemCount);
+    UtAssert_True(Count.BinSemCount == 0, "OS_ForEachObject() BinSemCount (%lu) == 2",
+                  (unsigned long)Count.BinSemCount);
+    UtAssert_True(Count.MutexCount == 3, "OS_ForEachObject() MutexCount (%lu) == 3", (unsigned long)Count.MutexCount);
+    UtAssert_True(Count.TimeBaseCount == 0, "OS_ForEachObject() TimeBaseCount (%lu) == 1",
+                  (unsigned long)Count.TimeBaseCount);
+
+    /*
+     * Pass an invalid input, and verify that object counts are not increased
+     */
+    memset(&Count, 0, sizeof(Count));
+    OS_ForEachObject(badid, &ObjTypeCounter, &Count);
+
+    /* Verify Outputs */
+    UtAssert_True(Count.TaskCount == 0, "OS_ForEachObject() TaskCount Invalid Input (%lu) == 0",
+                  (unsigned long)Count.TaskCount);
+    UtAssert_True(Count.QueueCount == 0, "OS_ForEachObject() QueueCount Invalid Input (%lu) == 0",
+                  (unsigned long)Count.QueueCount);
+    UtAssert_True(Count.CountSemCount == 0, "OS_ForEachObject() CountSemCount Invalid Input (%lu) == 0",
+                  (unsigned long)Count.CountSemCount);
+    UtAssert_True(Count.BinSemCount == 0, "OS_ForEachObject() BinSemCount Invalid Input (%lu) == 0",
+                  (unsigned long)Count.BinSemCount);
+    UtAssert_True(Count.MutexCount == 0, "OS_ForEachObject() MutexCount Invalid Input (%lu) == 0",
+                  (unsigned long)Count.MutexCount);
+    UtAssert_True(Count.TimeBaseCount == 0, "OS_ForEachObject() TimeBaseCount Invalid Input (%lu) == 0",
                   (unsigned long)Count.TimeBaseCount);
 
     /*
@@ -319,27 +395,40 @@ void TestIdMapApi(void)
                   (unsigned long)Count.MutexCount);
     UtAssert_True(Count.TimeBaseCount == 0, "OS_ForEachObject() TimeBaseCount After Delete (%lu) == 0",
                   (unsigned long)Count.TimeBaseCount);
+}
 
+void Test_OS_GetResourceName(void)
+{
     /*
-     * Pass an invalid input, and verify that object counts are not increased
+     * Test case for:
+     * int32 OS_GetResourceName(osal_id_t object_id, char *buffer, size_t buffer_size)
      */
-    OS_ForEachObject(badid, &ObjTypeCounter, &Count);
+    char name[OS_MAX_API_NAME];
 
-    /* Verify Outputs */
-    UtAssert_True(Count.TaskCount == 0, "OS_ForEachObject() TaskCount Invalid Input (%lu) == 0",
-                  (unsigned long)Count.TaskCount);
-    UtAssert_True(Count.QueueCount == 0, "OS_ForEachObject() QueueCount Invalid Input (%lu) == 0",
-                  (unsigned long)Count.QueueCount);
-    UtAssert_True(Count.CountSemCount == 0, "OS_ForEachObject() CountSemCount Invalid Input (%lu) == 0",
-                  (unsigned long)Count.CountSemCount);
-    UtAssert_True(Count.BinSemCount == 0, "OS_ForEachObject() BinSemCount Invalid Input (%lu) == 0",
-                  (unsigned long)Count.BinSemCount);
-    UtAssert_True(Count.MutexCount == 0, "OS_ForEachObject() MutexCount Invalid Input (%lu) == 0",
-                  (unsigned long)Count.MutexCount);
-    UtAssert_True(Count.TimeBaseCount == 0, "OS_ForEachObject() TimeBaseCount Invalid Input (%lu) == 0",
-                  (unsigned long)Count.TimeBaseCount);
+    /* Nominal cases */
+    UtAssert_INT32_EQ(OS_GetResourceName(queue_id, name, sizeof(name)), OS_SUCCESS);
+    UtAssert_StrCmp(name, "Queue", "%s == %s", name, "Queue");
+    UtAssert_INT32_EQ(OS_GetResourceName(count_sem_id, name, sizeof(name)), OS_SUCCESS);
+    UtAssert_StrCmp(name, "CountSem", "%s == %s", name, "CountSem");
+    UtAssert_INT32_EQ(OS_GetResourceName(bin_sem_id, name, sizeof(name)), OS_SUCCESS);
+    UtAssert_StrCmp(name, "BinSem", "%s == %s", name, "BinSem");
+    UtAssert_INT32_EQ(OS_GetResourceName(mutex_id1, name, sizeof(name)), OS_SUCCESS);
+    UtAssert_StrCmp(name, "Mutex1", "%s == %s", name, "Mutex1");
+    UtAssert_INT32_EQ(OS_GetResourceName(time_base_id, name, sizeof(name)), OS_SUCCESS);
+    UtAssert_StrCmp(name, "TimeBase", "%s == %s", name, "TimeBase");
 
-} /* end TestIdMapApi */
+    /* Error cases */
+    /* note the task has exited, so the task ID is no longer valid */
+    UtAssert_INT32_EQ(OS_GetResourceName(task_id, name, sizeof(name)), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_GetResourceName(badid, name, sizeof(name)), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_GetResourceName(OS_OBJECT_ID_UNDEFINED, name, sizeof(name)), OS_ERR_INVALID_ID);
+
+    UtAssert_INT32_EQ(OS_GetResourceName(time_base_id, name, 2), OS_ERR_NAME_TOO_LONG);
+    UtAssert_StrCmp(name, "T", "%s == %s", name, "T");
+
+    UtAssert_INT32_EQ(OS_GetResourceName(queue_id, NULL, sizeof(name)), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_GetResourceName(queue_id, name, 0), OS_ERR_INVALID_SIZE);
+}
 
 void UtTest_Setup(void)
 {
@@ -354,5 +443,10 @@ void UtTest_Setup(void)
     /*
      * Register the test setup and check routines in UT assert
      */
-    UtTest_Add(TestIdMapApi, TestIdMapApi_Setup, NULL, "TestIdMapApi");
+    UtTest_Add(NULL, TestIdMapApi_Setup, NULL, "TestIdMapApi");
+    UtTest_Add(Test_OS_IdentifyObject, NULL, NULL, "OS_IdentifyObject");
+    UtTest_Add(Test_OS_ConvertToArrayIndex, NULL, NULL, "OS_ConvertToArrayIndex");
+    UtTest_Add(Test_OS_ObjectIdToArrayIndex, NULL, NULL, "OS_ObjectIdToArrayIndex");
+    UtTest_Add(Test_OS_GetResourceName, NULL, NULL, "OS_GetResourceName");
+    UtTest_Add(Test_OS_ForEachObject, NULL, NULL, "OS_ForEachObject");
 }

--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -665,7 +665,7 @@ void TestGenericQueries(void)
 
     /* Test the OS_GetResourceName() API function */
     status = OS_GetResourceName(mut_0, ResourceName, OSAL_SIZE_C(0));
-    UtAssert_True(status == OS_INVALID_POINTER, "OS_GetResourceName (%lx,%ld) == OS_INVALID_POINTER",
+    UtAssert_True(status == OS_ERR_INVALID_SIZE, "OS_GetResourceName (%lx,%ld) == OS_ERR_INVALID_SIZE",
                   OS_ObjectIdToInteger(mut_0), (long)status);
 
     status = OS_GetResourceName(msgq_0, ResourceName, sizeof(ResourceName));
@@ -674,7 +674,7 @@ void TestGenericQueries(void)
     UtAssert_StrCmp(ResourceName, "q 0", "Output value correct");
 
     status = OS_GetResourceName(OS_OBJECT_ID_UNDEFINED, ResourceName, sizeof(ResourceName));
-    UtAssert_True(status == OS_ERR_INCORRECT_OBJ_TYPE, "OS_GetResourceName (%lx,%ld) == OS_ERR_INCORRECT_OBJ_TYPE",
+    UtAssert_True(status == OS_ERR_INVALID_ID, "OS_GetResourceName (%lx,%ld) == OS_ERR_INVALID_ID",
                   OS_ObjectIdToInteger(OS_OBJECT_ID_UNDEFINED), (long)status);
 
     status = OS_GetResourceName(bin_0, ResourceName, OSAL_SIZE_C(1));

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -524,9 +524,9 @@ void Test_OS_ObjectIdGetById(void)
     OS_SharedGlobalVars.GlobalState = OS_INIT_MAGIC_NUMBER;
 
     /* attempt to get lock for invalid type object should fail */
-    expected = OS_ERR_INCORRECT_OBJ_TYPE;
+    expected = OS_ERR_INVALID_ID;
     actual   = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, 0xFFFF, refobjid, &token1);
-    UtAssert_True(actual == expected, "OS_ObjectIdGetById() (%ld) == OS_ERR_INCORRECT_OBJ_TYPE", (long)actual);
+    UtAssert_True(actual == expected, "OS_ObjectIdGetById() (%ld) == OS_ERR_INVALID_ID", (long)actual);
 
     /* clear out state entry */
     memset(&OS_global_task_table[local_idx], 0, sizeof(OS_global_task_table[local_idx]));
@@ -730,9 +730,9 @@ void Test_OS_ObjectIdAllocateNew(void)
     OS_SharedGlobalVars.GlobalState = OS_INIT_MAGIC_NUMBER;
     UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_ERR_INCORRECT_OBJ_STATE", (long)actual);
 
-    expected = OS_ERR_INCORRECT_OBJ_TYPE;
+    expected = OS_ERR_INVALID_ID;
     actual   = OS_ObjectIdAllocateNew(0xFFFF, "UT_alloc", &token);
-    UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_ERR_INCORRECT_OBJ_TYPE", (long)actual);
+    UtAssert_True(actual == expected, "OS_ObjectIdAllocate() (%ld) == OS_ERR_INVALID_ID", (long)actual);
 
     /*
      * Test late-stage failure path -
@@ -823,7 +823,7 @@ void Test_OS_ObjectIdTransaction(void)
 
     /* bad object type */
     OSAPI_TEST_FUNCTION_RC(OS_ObjectIdTransactionInit(OS_LOCK_MODE_GLOBAL, OS_OBJECT_TYPE_UNDEFINED, &token),
-                           OS_ERR_INCORRECT_OBJ_TYPE);
+                           OS_ERR_INVALID_ID);
     UtAssert_UINT32_EQ(token.lock_mode, OS_LOCK_MODE_NONE);
     UtAssert_UINT32_EQ(token.obj_type, OS_OBJECT_TYPE_UNDEFINED);
     UtAssert_STUB_COUNT(OS_Lock_Global_Impl, 2);
@@ -1049,8 +1049,12 @@ void Test_OS_GetResourceName(void)
     UtAssert_True(actual == expected, "OS_GetResourceName() (%ld) == OS_ERR_NAME_TOO_LONG", (long)actual);
 
     expected = OS_INVALID_POINTER;
-    actual   = OS_GetResourceName(token.obj_id, NULL, OSAL_SIZE_C(0));
+    actual   = OS_GetResourceName(token.obj_id, NULL, sizeof(NameBuffer));
     UtAssert_True(actual == expected, "OS_GetResourceName() (%ld) == OS_INVALID_POINTER", (long)actual);
+
+    expected = OS_ERR_INVALID_SIZE;
+    actual   = OS_GetResourceName(token.obj_id, NameBuffer, OSAL_SIZE_C(0));
+    UtAssert_True(actual == expected, "OS_GetResourceName() (%ld) == OS_ERR_INVALID_SIZE", (long)actual);
 }
 
 void Test_OS_ObjectIdIterator(void)
@@ -1064,8 +1068,7 @@ void Test_OS_ObjectIdIterator(void)
     OS_common_record_t rec;
     uint32             testarg;
 
-    OSAPI_TEST_FUNCTION_RC(OS_ObjectIdIteratorInit(NULL, NULL, OS_OBJECT_TYPE_UNDEFINED, &iter),
-                           OS_ERR_INCORRECT_OBJ_TYPE);
+    OSAPI_TEST_FUNCTION_RC(OS_ObjectIdIteratorInit(NULL, NULL, OS_OBJECT_TYPE_UNDEFINED, &iter), OS_ERR_INVALID_ID);
     OSAPI_TEST_FUNCTION_RC(OS_ObjectIdIterateActive(OS_OBJECT_TYPE_OS_TASK, &iter), OS_SUCCESS);
     UtAssert_STUB_COUNT(OS_Lock_Global_Impl, 1);
 


### PR DESCRIPTION
**Describe the contribution**
Ensures correlation between the test cases and documented return values for the OSAL idmap API.

Fixes #1015

**Testing performed**
Build and run unit tests, re-run cross reference script to confirm

**Expected behavior changes**
All documented return values are tested or noted that they cannot be tested in functional test

**NOTE:** This does update one return code from the the internal function `OS_ObjectIdTransactionInit`, changing it from OS_ERR_INCORRECT_OBJ_TYPE to OS_ERR_INVALID_ID.  There was one case in OS_GetResourceName where this status code gets eventually returned to an application caller, and OS_ERR_INVALID_ID makes it more consistent with other APIs in this regard.  (In other modules the idtype is hard coded so it does not affect these, this error isn't triggered except for coverage tests).

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
