### PR TITLE
Fix #1061, add mutex lock around UtAssert globals

### DIFF
--- a/ut_assert/inc/utbsp.h
+++ b/ut_assert/inc/utbsp.h
@@ -97,4 +97,18 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage);
  */
 void UT_BSP_EndTest(const UtAssert_TestCounter_t *TestCounters);
 
+/**
+ * UT mutex lock for multi-threaded test support
+ *
+ * Lock that should be acquired before modifying any global test state variables
+ */
+void UT_BSP_Lock(void);
+
+/**
+ * UT mutex unlock for multi-threaded test support
+ *
+ * Must be called after UT_BSP_Lock to allow other threads access to the global
+ */
+void UT_BSP_Unlock(void);
+
 #endif /* UTBSP_H */

--- a/ut_assert/src/utbsp.c
+++ b/ut_assert/src/utbsp.c
@@ -50,6 +50,16 @@ typedef struct
 
 BSP_UT_GlobalData_t BSP_UT_Global;
 
+void UT_BSP_Lock(void)
+{
+    OS_BSP_Lock_Impl();
+}
+
+void UT_BSP_Unlock(void)
+{
+    OS_BSP_Unlock_Impl();
+}
+
 void UT_BSP_Setup(void)
 {
     uint8        UserShift;
@@ -114,7 +124,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
 
     if (MsgEnabled & 1)
     {
-        OS_BSP_Lock_Impl();
+        UT_BSP_Lock();
 
         switch (MessageType)
         {
@@ -190,7 +200,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
             OS_BSP_ConsoleOutput_Impl("\n", 1);
         }
 
-        OS_BSP_Unlock_Impl();
+        UT_BSP_Unlock();
     }
 
     /*
@@ -219,9 +229,9 @@ void UT_BSP_EndTest(const UtAssert_TestCounter_t *TestCounters)
     snprintf(Message, sizeof(Message), "COMPLETE: %u tests Segment(s) executed\n\n",
              (unsigned int)TestCounters->TestSegmentCount);
 
-    OS_BSP_Lock_Impl();
+    UT_BSP_Lock();
     OS_BSP_ConsoleOutput_Impl(Message, strlen(Message));
-    OS_BSP_Unlock_Impl();
+    UT_BSP_Unlock();
 
     if ((TestCounters->CaseCount[UTASSERT_CASETYPE_FAILURE] > 0) ||
         (TestCounters->CaseCount[UTASSERT_CASETYPE_TSF] > 0) || (TestCounters->CaseCount[UTASSERT_CASETYPE_TTF] > 0))

--- a/ut_assert/src/uttest.c
+++ b/ut_assert/src/uttest.c
@@ -62,7 +62,9 @@ void UtTest_AddCommon(void (*Test)(void), void (*Setup)(void), void (*Teardown)(
         strncpy(UtTestDataBaseEntry.TestName, TestName, sizeof(UtTestDataBaseEntry.TestName) - 1);
     }
 
+    UT_BSP_Lock();
     UtList_Add(UtAssert_Global.DataBasePtr, &UtTestDataBaseEntry, sizeof(UtTestDataBaseEntry_t), EntryType);
+    UT_BSP_Unlock();
 }
 
 void UtTest_Add(void (*Test)(void), void (*Setup)(void), void (*Teardown)(void), const char *SequenceName)
@@ -86,6 +88,8 @@ void UtTest_Run(void)
     UtListNode_t *         UtListNode;
     UtTestDataBaseEntry_t *UtTestDataBaseEntry;
 
+    UT_BSP_Lock();
+
     /*
      * The overall test sequence goes SETUP->TEST->TEARDOWN
      *
@@ -98,6 +102,8 @@ void UtTest_Run(void)
     UtList_Merge(UtListMain, UtList_GetHead(UtAssert_Global.DataBasePtr, UTASSERT_GROUP_SETUP));
     UtList_Merge(UtListMain, UtList_GetHead(UtAssert_Global.DataBasePtr, UTASSERT_GROUP_TEST));
     UtList_Merge(UtListMain, UtList_GetHead(UtAssert_Global.DataBasePtr, UTASSERT_GROUP_TEARDOWN));
+
+    UT_BSP_Unlock();
 
     /*
      * Run through the merged list in order
@@ -132,7 +138,9 @@ void UtTest_Run(void)
         }
     }
 
+    UT_BSP_Lock();
     UtList_Destroy(UtAssert_Global.DataBasePtr);
+    UT_BSP_Unlock();
 
     UT_BSP_EndTest(UtAssert_GetCounters());
 }


### PR DESCRIPTION
**Describe the contribution**
Adding a mutex around modifications to globals allows UtAssert statements to be done from any test thread.

Fixes #1061

**Testing performed**
Build and run all unit tests, confirm correct operation

**Expected behavior changes**
UtAssert statements can now be used from any test task without risk of interference

**System(s) tested on**
Ubuntu

**Additional context**
Will require an update to CFE if accepted

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
