### PR TITLE
Fix #1052, implement missing parameter/retcode test permutations

### DIFF
--- a/src/os/inc/osapi-filesys.h
+++ b/src/os/inc/osapi-filesys.h
@@ -79,7 +79,7 @@ typedef struct
  *
  *      OS_FileSysAddFixedMap(&fs_id, "/", "/root");
  *
- * @param[out]  filesys_id  A non-zero OSAL ID reflecting the file system
+ * @param[out]  filesys_id  A buffer to store the ID of the file system mapping @nonnull
  * @param[in]   phys_path   The native system directory (an existing mount point) @nonnull
  * @param[in]   virt_path   The virtual mount point of this filesystem @nonnull
  *

--- a/src/os/inc/osapi-network.h
+++ b/src/os/inc/osapi-network.h
@@ -61,8 +61,8 @@ int32 OS_NetworkGetID(void);
  * If configured in the underlying network stack,
  * this function retrieves the local hostname of the system.
  *
- * @param[out]  host_name    Buffer to hold name information
- * @param[in]   name_len     Maximum length of host name buffer
+ * @param[out]  host_name    Buffer to hold name information @nonnull
+ * @param[in]   name_len     Maximum length of host name buffer @nonzero
  *
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS

--- a/src/os/inc/osapi-task.h
+++ b/src/os/inc/osapi-task.h
@@ -91,7 +91,7 @@ typedef osal_task((*osal_task_entry)(void)); /**< @brief For task entry point */
  * In that case, a stack of the requested size will be dynamically allocated from
  * the system heap.
  *
- * @param[out]  task_id will be set to the non-zero ID of the newly-created resource
+ * @param[out]  task_id will be set to the non-zero ID of the newly-created resource @nonnull
  * @param[in]   task_name the name of the new resource to create @nonnull
  * @param[in]   function_pointer the entry point of the new task @nonnull
  * @param[in]   stack_pointer pointer to the stack for the task, or NULL

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -262,6 +262,7 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
     /*
      * Validate inputs
      */
+    OS_CHECK_POINTER(filesys_id);
     OS_CHECK_STRING(phys_path, sizeof(filesys->system_mountpt), OS_FS_ERR_PATH_TOO_LONG);
     OS_CHECK_PATHNAME(virt_path);
 

--- a/src/os/shared/src/osapi-queue.c
+++ b/src/os/shared/src/osapi-queue.c
@@ -166,6 +166,7 @@ int32 OS_QueueGet(osal_id_t queue_id, void *data, size_t size, size_t *size_copi
     /* Check Parameters */
     OS_CHECK_POINTER(data);
     OS_CHECK_POINTER(size_copied);
+    OS_CHECK_SIZE(size);
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, LOCAL_OBJID_TYPE, queue_id, &token);
     if (return_code == OS_SUCCESS)
@@ -205,6 +206,7 @@ int32 OS_QueuePut(osal_id_t queue_id, const void *data, size_t size, uint32 flag
 
     /* Check Parameters */
     OS_CHECK_POINTER(data);
+    OS_CHECK_SIZE(size);
 
     return_code = OS_ObjectIdGetById(OS_LOCK_MODE_NONE, LOCAL_OBJID_TYPE, queue_id, &token);
     if (return_code == OS_SUCCESS)

--- a/src/tests/file-sys-add-fixed-map-api-test/file-sys-add-fixed-map-api-test.c
+++ b/src/tests/file-sys-add-fixed-map-api-test/file-sys-add-fixed-map-api-test.c
@@ -38,8 +38,6 @@
 
 void TestFileSysAddFixedMapApi(void)
 {
-    int32     expected;
-    int32     actual;
     osal_id_t fs_id;
     char      translated_path[OS_MAX_LOCAL_PATH_LEN + 5];
     char      long_path[OS_MAX_PATH_LEN + 5];
@@ -51,42 +49,14 @@ void TestFileSysAddFixedMapApi(void)
      * Just map /test to a dir of the same name, relative to current dir.
      */
 
-    expected = OS_FS_ERR_PATH_INVALID;
-    actual   = OS_TranslatePath("/test/myfile.txt", translated_path);
-    UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_SUCCESS", (long)actual);
-
-    expected = OS_SUCCESS;
-    actual   = OS_FileSysAddFixedMap(&fs_id, "./test", "/test");
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_SUCCESS", (long)actual);
-
-    expected = OS_SUCCESS;
-    actual   = OS_TranslatePath("/test/myfile.txt", translated_path);
-    UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_SUCCESS", (long)actual);
+    UtAssert_INT32_EQ(OS_TranslatePath("/test/myfile.txt", translated_path), OS_FS_ERR_PATH_INVALID);
+    UtAssert_INT32_EQ(OS_FileSysAddFixedMap(&fs_id, "./test", "/test"), OS_SUCCESS);
+    UtAssert_INT32_EQ(OS_TranslatePath("/test/myfile.txt", translated_path), OS_SUCCESS);
 
     /* Test for invalid inputs */
-    expected = OS_ERR_NAME_TAKEN;
-    actual   = OS_FileSysAddFixedMap(NULL, "./test", "/test");
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_FileSysAddFixedMap(&fs_id, NULL, "/test");
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_FileSysAddFixedMap(&fs_id, "./test", NULL);
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_FileSysAddFixedMap(NULL, NULL, NULL);
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_FileSysAddFixedMap(&fs_id, NULL, NULL);
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_FileSysAddFixedMap(NULL, "./test", NULL);
-    UtAssert_True(actual == expected, "OS_FileSysAddFixedMap() (%ld) == OS_INVALID_POINTER", (long)actual);
+    UtAssert_INT32_EQ(OS_FileSysAddFixedMap(NULL, "./test", "/test"), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_FileSysAddFixedMap(&fs_id, NULL, "/test"), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_FileSysAddFixedMap(&fs_id, "./test", NULL), OS_INVALID_POINTER);
 
     /* Test names too long (phys_path and virt_path have different limits) */
     memset(long_path, 'x', sizeof(long_path) - 1);

--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -117,6 +117,7 @@ void TestNetworkApiBadArgs(void)
     /* OS_SocketAddrToString */
     UtAssert_INT32_EQ(OS_SocketAddrToString(addr_string, 0, &addr), OS_ERR_INVALID_SIZE);
     UtAssert_INT32_EQ(OS_SocketAddrToString(NULL, sizeof(addr_string), &addr), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_SocketAddrToString(addr_string, sizeof(addr_string), NULL), OS_INVALID_POINTER);
     UtAssert_INT32_EQ(OS_SocketAddrToString(addr_string, 1, &addr), OS_ERROR);
 }
 
@@ -234,6 +235,7 @@ void TestDatagramNetworkApi(void)
     uint32           Buf3 = 222;
     uint32           Buf4 = 000;
     osal_id_t        objid;
+    osal_id_t        invalid_fd;
     uint16           PortNum;
     OS_socket_prop_t prop;
     OS_SockAddr_t    l_addr;
@@ -250,11 +252,11 @@ void TestDatagramNetworkApi(void)
      */
 
     /* make a bad object ID by flipping the bits of a good object ID */
-    objid = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(p2_socket_id) ^ 0xFFFFFFFF);
+    invalid_fd = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(p2_socket_id) ^ 0xFFFFFFFF);
 
     /* OS_SocketBind */
     UtAssert_INT32_EQ(OS_SocketBind(OS_OBJECT_ID_UNDEFINED, &p2_addr), OS_ERR_INVALID_ID);
-    UtAssert_INT32_EQ(OS_SocketBind(objid, &p2_addr), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_SocketBind(invalid_fd, &p2_addr), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_SocketBind(regular_file_id, &p2_addr), OS_ERR_INCORRECT_OBJ_TYPE);
     UtAssert_INT32_EQ(OS_SocketBind(p2_socket_id, &p2_addr), OS_ERR_INCORRECT_OBJ_STATE);
     UtAssert_INT32_EQ(OS_SocketBind(p2_socket_id, NULL), OS_INVALID_POINTER);
@@ -262,7 +264,7 @@ void TestDatagramNetworkApi(void)
     /* OS_SocketRecvFrom */
     UtAssert_INT32_EQ(OS_SocketRecvFrom(OS_OBJECT_ID_UNDEFINED, &Buf2, sizeof(Buf2), &l_addr, UT_TIMEOUT),
                       OS_ERR_INVALID_ID);
-    UtAssert_INT32_EQ(OS_SocketRecvFrom(objid, &Buf2, sizeof(Buf2), &l_addr, UT_TIMEOUT), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_SocketRecvFrom(invalid_fd, &Buf2, sizeof(Buf2), &l_addr, UT_TIMEOUT), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_SocketRecvFrom(regular_file_id, &Buf2, sizeof(Buf2), &l_addr, UT_TIMEOUT),
                       OS_ERR_INCORRECT_OBJ_TYPE);
     UtAssert_INT32_EQ(OS_SocketRecvFrom(p2_socket_id, NULL, sizeof(Buf2), &l_addr, UT_TIMEOUT), OS_INVALID_POINTER);
@@ -270,7 +272,7 @@ void TestDatagramNetworkApi(void)
 
     /* OS_SocketSendTo */
     UtAssert_INT32_EQ(OS_SocketSendTo(OS_OBJECT_ID_UNDEFINED, &Buf2, sizeof(Buf2), &l_addr), OS_ERR_INVALID_ID);
-    UtAssert_INT32_EQ(OS_SocketSendTo(objid, &Buf2, sizeof(Buf2), &l_addr), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_SocketSendTo(invalid_fd, &Buf2, sizeof(Buf2), &l_addr), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_SocketSendTo(regular_file_id, &Buf2, sizeof(Buf2), &l_addr), OS_ERR_INCORRECT_OBJ_TYPE);
     UtAssert_INT32_EQ(OS_SocketSendTo(p2_socket_id, NULL, sizeof(Buf2), &l_addr), OS_INVALID_POINTER);
     UtAssert_INT32_EQ(OS_SocketSendTo(p2_socket_id, &Buf2, 0, &l_addr), OS_ERR_INVALID_SIZE);
@@ -278,7 +280,7 @@ void TestDatagramNetworkApi(void)
 
     /* OS_SocketGetInfo */
     UtAssert_INT32_EQ(OS_SocketGetInfo(OS_OBJECT_ID_UNDEFINED, &prop), OS_ERR_INVALID_ID);
-    UtAssert_INT32_EQ(OS_SocketGetInfo(objid, &prop), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_SocketGetInfo(invalid_fd, &prop), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_SocketGetInfo(p2_socket_id, NULL), OS_INVALID_POINTER);
 
     /* OS_SocketGetIdByName */
@@ -455,6 +457,7 @@ void TestStreamNetworkApi(void)
     uint32         iter;
     uint32         loopcnt;
     osal_id_t      temp_id;
+    osal_id_t      invalid_fd;
     OS_SockAddr_t  temp_addr;
     OS_task_prop_t taskprop;
     char           Buf_rcv_c[4]           = {0};
@@ -497,8 +500,9 @@ void TestStreamNetworkApi(void)
 
         /* OS_SocketAccept error conditions - check before binding */
         /* create a bad ID by flipping the bits of a good ID */
-        temp_id = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(s_socket_id) ^ 0xFFFFFFFF);
-        UtAssert_INT32_EQ(OS_SocketAccept(temp_id, &temp_id, &temp_addr, 0), OS_ERR_INVALID_ID);
+        invalid_fd = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(s_socket_id) ^ 0xFFFFFFFF);
+        UtAssert_INT32_EQ(OS_SocketAccept(invalid_fd, &temp_id, &temp_addr, 0), OS_ERR_INVALID_ID);
+        UtAssert_INT32_EQ(OS_SocketAccept(OS_OBJECT_ID_UNDEFINED, &temp_id, &temp_addr, 0), OS_ERR_INVALID_ID);
         UtAssert_INT32_EQ(OS_SocketAccept(s_socket_id, NULL, &temp_addr, UT_TIMEOUT), OS_INVALID_POINTER);
         UtAssert_INT32_EQ(OS_SocketAccept(s_socket_id, &temp_id, NULL, UT_TIMEOUT), OS_INVALID_POINTER);
         UtAssert_INT32_EQ(OS_SocketAccept(s_socket_id, &temp_id, &temp_addr, UT_TIMEOUT), OS_ERR_INCORRECT_OBJ_STATE);
@@ -561,10 +565,12 @@ void TestStreamNetworkApi(void)
             if (iter == UT_STREAM_CONNECTION_INITIAL)
             {
                 /* create a bad ID by flipping the bits of a good ID */
-                temp_id = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(c_socket_id) ^ 0xFFFFFFFF);
+                invalid_fd = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(c_socket_id) ^ 0xFFFFFFFF);
 
                 /* OS_SocketShutdown */
-                UtAssert_INT32_EQ(OS_SocketShutdown(temp_id, OS_SocketShutdownMode_SHUT_READ), OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_SocketShutdown(invalid_fd, OS_SocketShutdownMode_SHUT_READ), OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_SocketShutdown(OS_OBJECT_ID_UNDEFINED, OS_SocketShutdownMode_SHUT_READ),
+                                  OS_ERR_INVALID_ID);
                 UtAssert_INT32_EQ(OS_SocketShutdown(regular_file_id, OS_SocketShutdownMode_SHUT_READ),
                                   OS_ERR_INCORRECT_OBJ_TYPE);
                 UtAssert_INT32_EQ(OS_SocketShutdown(c_socket_id, OS_SocketShutdownMode_SHUT_READ),
@@ -582,26 +588,29 @@ void TestStreamNetworkApi(void)
             if (iter == UT_STREAM_CONNECTION_INITIAL)
             {
                 /* create a bad ID by flipping the bits of a good ID */
-                temp_id = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(c_socket_id) ^ 0xFFFFFFFF);
+                invalid_fd = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(c_socket_id) ^ 0xFFFFFFFF);
 
                 /* OS_SocketShutdown */
                 UtAssert_INT32_EQ(OS_SocketShutdown(c_socket_id, OS_SocketShutdownMode_NONE), OS_ERR_INVALID_ARGUMENT);
 
                 /* OS_TimedRead */
-                UtAssert_INT32_EQ(OS_TimedRead(temp_id, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT), OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_TimedRead(invalid_fd, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT),
+                                  OS_ERR_INVALID_ID);
                 UtAssert_INT32_EQ(OS_TimedRead(c_socket_id, NULL, sizeof(Buf_rcv_c), UT_TIMEOUT), OS_INVALID_POINTER);
                 UtAssert_INT32_EQ(OS_TimedRead(c_socket_id, Buf_rcv_c, 0, UT_TIMEOUT), OS_ERR_INVALID_SIZE);
                 UtAssert_INT32_EQ(OS_TimedRead(c_socket_id, Buf_rcv_c, sizeof(Buf_rcv_c), 0), OS_ERROR_TIMEOUT);
 
                 /* OS_TimedWrite */
-                UtAssert_INT32_EQ(OS_TimedWrite(temp_id, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT), OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_TimedWrite(invalid_fd, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT),
+                                  OS_ERR_INVALID_ID);
                 UtAssert_INT32_EQ(OS_TimedWrite(c_socket_id, NULL, sizeof(Buf_rcv_c), UT_TIMEOUT), OS_INVALID_POINTER);
                 UtAssert_INT32_EQ(OS_TimedWrite(c_socket_id, Buf_rcv_c, 0, UT_TIMEOUT), OS_ERR_INVALID_SIZE);
 
                 /* OS_SocketConnect */
-                UtAssert_INT32_EQ(OS_SocketConnect(c_socket_id, NULL, UT_TIMEOUT), OS_INVALID_POINTER);
-                UtAssert_INT32_EQ(OS_SocketConnect(temp_id, &s_addr, UT_TIMEOUT), OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_SocketConnect(invalid_fd, &s_addr, UT_TIMEOUT), OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_SocketConnect(OS_OBJECT_ID_UNDEFINED, &s_addr, UT_TIMEOUT), OS_ERR_INVALID_ID);
                 UtAssert_INT32_EQ(OS_SocketConnect(regular_file_id, &s_addr, UT_TIMEOUT), OS_ERR_INCORRECT_OBJ_TYPE);
+                UtAssert_INT32_EQ(OS_SocketConnect(c_socket_id, NULL, UT_TIMEOUT), OS_INVALID_POINTER);
                 UtAssert_INT32_EQ(OS_SocketConnect(c_socket_id, &s_addr, 0), OS_ERR_INCORRECT_OBJ_STATE);
             }
 

--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -596,12 +596,16 @@ void TestStreamNetworkApi(void)
                 /* OS_TimedRead */
                 UtAssert_INT32_EQ(OS_TimedRead(invalid_fd, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT),
                                   OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_TimedRead(OS_OBJECT_ID_UNDEFINED, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT),
+                                  OS_ERR_INVALID_ID);
                 UtAssert_INT32_EQ(OS_TimedRead(c_socket_id, NULL, sizeof(Buf_rcv_c), UT_TIMEOUT), OS_INVALID_POINTER);
                 UtAssert_INT32_EQ(OS_TimedRead(c_socket_id, Buf_rcv_c, 0, UT_TIMEOUT), OS_ERR_INVALID_SIZE);
                 UtAssert_INT32_EQ(OS_TimedRead(c_socket_id, Buf_rcv_c, sizeof(Buf_rcv_c), 0), OS_ERROR_TIMEOUT);
 
                 /* OS_TimedWrite */
                 UtAssert_INT32_EQ(OS_TimedWrite(invalid_fd, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT),
+                                  OS_ERR_INVALID_ID);
+                UtAssert_INT32_EQ(OS_TimedWrite(OS_OBJECT_ID_UNDEFINED, Buf_rcv_c, sizeof(Buf_rcv_c), UT_TIMEOUT),
                                   OS_ERR_INVALID_ID);
                 UtAssert_INT32_EQ(OS_TimedWrite(c_socket_id, NULL, sizeof(Buf_rcv_c), UT_TIMEOUT), OS_INVALID_POINTER);
                 UtAssert_INT32_EQ(OS_TimedWrite(c_socket_id, Buf_rcv_c, 0, UT_TIMEOUT), OS_ERR_INVALID_SIZE);

--- a/src/tests/timer-add-api-test/timer-add-api-test.c
+++ b/src/tests/timer-add-api-test/timer-add-api-test.c
@@ -65,10 +65,8 @@ void TestTimerAddApi(void)
      * callback_ptr, void *callback_arg)
      */
 
-    int32     actual;
-    int32     expected;
-    int32     tbc_ret_val;
-    int32     tbs_ret_val;
+    uint32    expected;
+    osal_id_t badid;
     osal_id_t timer_id;
     osal_id_t time_base_id;
     int       i = 0;
@@ -80,13 +78,8 @@ void TestTimerAddApi(void)
 
     /* Create and set the TimeBase obj and verify success */
 
-    tbc_ret_val = OS_TimeBaseCreate(&time_base_id, "TimeBase", 0);
-    expected    = OS_SUCCESS;
-    UtAssert_True(tbc_ret_val == expected, "OS_TimeBaseCreate() (%ld) == OS_SUCCESS", (long)tbc_ret_val);
-
-    tbs_ret_val = OS_TimeBaseSet(time_base_id, 10000, 10000); /* ms */
-    expected    = OS_SUCCESS;
-    UtAssert_True(tbs_ret_val == expected, "OS_TimeBaseSet() (%ld) == OS_SUCCESS", (long)tbs_ret_val);
+    UtAssert_INT32_EQ(OS_TimeBaseCreate(&time_base_id, "TimeBase", 0), OS_SUCCESS);
+    UtAssert_INT32_EQ(OS_TimeBaseSet(time_base_id, 10000, 10000), OS_SUCCESS);
 
     memset(temp_name, 'x', sizeof(temp_name) - 1);
     temp_name[sizeof(temp_name) - 1] = 0;
@@ -183,30 +176,18 @@ void TestTimerAddApi(void)
     }
 
     /* Test nominal inputs */
-    expected = OS_SUCCESS;
-    actual   = OS_TimerAdd(&timer_id, "Timer", time_base_id, null_func, NULL);
-    UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_SUCCESS", (long)actual);
+    UtAssert_INT32_EQ(OS_TimerAdd(&timer_id, "Timer", time_base_id, null_func, NULL), OS_SUCCESS);
+
+    /* create a bad ID by flipping the bits of a good ID */
+    badid = OS_ObjectIdFromInteger(OS_ObjectIdToInteger(time_base_id) ^ 0xFFFFFFFF);
 
     /* Test invalid inputs */
-    expected = OS_INVALID_POINTER;
-    actual   = OS_TimerAdd(NULL, "Timer", time_base_id, null_func, NULL);
-    UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_ERR_INVALID_ID;
-    actual   = OS_TimerAdd(&timer_id, "Timer", OS_OBJECT_ID_UNDEFINED, null_func, NULL);
-    UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_ERR_INVALID_ID", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_TimerAdd(&timer_id, "Timer", time_base_id, NULL, NULL);
-    UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_INVALID_POINTER", (long)actual);
-
-    expected = OS_ERR_NAME_TAKEN;
-    actual   = OS_TimerAdd(&timer_id, "Timer", time_base_id, null_func, NULL);
-    UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_ERR_NAME_TAKEN", (long)actual);
-
-    expected = OS_INVALID_POINTER;
-    actual   = OS_TimerAdd(&timer_id, 0, time_base_id, null_func, NULL);
-    UtAssert_True(actual == expected, "OS_TimerAdd() (%ld) == OS_INVALID_POINTER", (long)actual);
+    UtAssert_INT32_EQ(OS_TimerAdd(NULL, "Timer", time_base_id, null_func, NULL), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_TimerAdd(&timer_id, "Timer", OS_OBJECT_ID_UNDEFINED, null_func, NULL), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_TimerAdd(&timer_id, "Timer", badid, null_func, NULL), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_TimerAdd(&timer_id, "Timer", time_base_id, NULL, NULL), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_TimerAdd(&timer_id, "Timer", time_base_id, null_func, NULL), OS_ERR_NAME_TAKEN);
+    UtAssert_INT32_EQ(OS_TimerAdd(&timer_id, 0, time_base_id, null_func, NULL), OS_INVALID_POINTER);
 
 } /* end TestTimerAddApi */
 

--- a/src/unit-test-coverage/shared/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-binsem.c
@@ -61,7 +61,8 @@ void Test_OS_BinSemCreate(void)
     UtAssert_True(actual == expected, "OS_BinSemCreate() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate(NULL, NULL, 0, 0), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate(NULL, "UT", 0, 0), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate(&objid, NULL, 0, 0), OS_INVALID_POINTER);
     UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_BinSemCreate(&objid, "UT", 0, 0), OS_ERR_NAME_TOO_LONG);
 }

--- a/src/unit-test-coverage/shared/src/coveragetest-countsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-countsem.c
@@ -61,7 +61,8 @@ void Test_OS_CountSemCreate(void)
     UtAssert_True(actual == expected, "OS_CountSemCreate() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
-    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate(NULL, NULL, 0, 0), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate(NULL, "UT", 0, 0), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate(&objid, NULL, 0, 0), OS_INVALID_POINTER);
     UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_CountSemCreate(&objid, "UT", 0, 0), OS_ERR_NAME_TOO_LONG);
 }

--- a/src/unit-test-coverage/shared/src/coveragetest-dir.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-dir.c
@@ -70,7 +70,11 @@ void Test_OS_DirectoryOpen(void)
     UtAssert_True(actual == expected, "OS_DirectoryOpen() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
-    OSAPI_TEST_FUNCTION_RC(OS_DirectoryOpen(NULL, NULL), OS_INVALID_POINTER);
+    /*
+     * Note that the second arg (path) is validated by a separate unit (OS_TranslatePath),
+     * so it should not be passed NULL here
+     */
+    OSAPI_TEST_FUNCTION_RC(OS_DirectoryOpen(NULL, "Dir"), OS_INVALID_POINTER);
 }
 
 void Test_OS_DirectoryClose(void)

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -56,7 +56,8 @@ void Test_OS_FileSysAddFixedMap(void)
     osal_id_t id;
 
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_SUCCESS);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, NULL, NULL), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", NULL), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, NULL, "/virt"), OS_INVALID_POINTER);
 
     UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 1, OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_FS_ERR_PATH_TOO_LONG);
@@ -441,9 +442,8 @@ void Test_OS_TranslatePath(void)
                   LocalBuffer);
 
     /* Check various error paths */
-    expected = OS_INVALID_POINTER;
-    actual   = OS_TranslatePath(NULL, NULL);
-    UtAssert_True(actual == expected, "OS_TranslatePath(NULL,NULL) (%ld) == OS_INVALID_POINTER", (long)actual);
+    UtAssert_INT32_EQ(OS_TranslatePath("/cf/test", NULL), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_TranslatePath(NULL, LocalBuffer), OS_INVALID_POINTER);
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     expected = OS_FS_ERR_PATH_TOO_LONG;

--- a/src/unit-test-coverage/shared/src/coveragetest-mutex.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-mutex.c
@@ -60,7 +60,8 @@ void Test_OS_MutSemCreate(void)
     UtAssert_True(actual == expected, "OS_MutSemCreate() (%ld) == OS_SUCCESS", (long)actual);
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
-    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate(NULL, NULL, 0), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate(NULL, "UT", 0), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate(&objid, NULL, 0), OS_INVALID_POINTER);
     UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_MutSemCreate(&objid, "UT", 0), OS_ERR_NAME_TOO_LONG);
 }

--- a/src/unit-test-coverage/shared/src/coveragetest-queue.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-queue.c
@@ -118,6 +118,8 @@ void Test_OS_QueueGet(void)
     expected                   = OS_QUEUE_INVALID_SIZE;
     actual                     = OS_QueueGet(UT_OBJID_1, Buf, sizeof(Buf), &actual_size, 0);
     UtAssert_True(actual == expected, "OS_QueueGet() (%ld) == OS_QUEUE_INVALID_SIZE", (long)actual);
+
+    OSAPI_TEST_FUNCTION_RC(OS_QueueGet(UT_OBJID_1, Buf, 0, &actual_size, 0), OS_ERR_INVALID_SIZE);
 }
 
 void Test_OS_QueuePut(void)
@@ -144,6 +146,8 @@ void Test_OS_QueuePut(void)
     expected = OS_QUEUE_INVALID_SIZE;
     actual   = OS_QueuePut(UT_OBJID_1, Data, 1 + sizeof(Data), 0);
     UtAssert_True(actual == expected, "OS_QueuePut() (%ld) == OS_QUEUE_INVALID_SIZE", (long)actual);
+
+    OSAPI_TEST_FUNCTION_RC(OS_QueuePut(UT_OBJID_1, Data, 0, 0), OS_ERR_INVALID_SIZE);
 }
 
 void Test_OS_QueueGetIdByName(void)

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -116,7 +116,13 @@ void Test_OS_TaskCreate(void)
     OSAPI_TEST_OBJID(objid, !=, OS_OBJECT_ID_UNDEFINED);
 
     OSAPI_TEST_FUNCTION_RC(
-        OS_TaskCreate(NULL, NULL, NULL, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
+        OS_TaskCreate(NULL, "UT", UT_TestHook, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
+        OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(
+        OS_TaskCreate(&objid, NULL, UT_TestHook, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
+        OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(
+        OS_TaskCreate(&objid, "UT", NULL, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
         OS_INVALID_POINTER);
     OSAPI_TEST_FUNCTION_RC(
         OS_TaskCreate(&objid, "UT", UT_TestHook, OSAL_TASK_STACK_ALLOCATE, OSAL_SIZE_C(0), OSAL_PRIORITY_C(0), 0),
@@ -248,7 +254,7 @@ void Test_OS_TaskGetInfo(void)
     OS_task_table[1].stack_size = OSAL_SIZE_C(0);
     OS_task_table[1].priority   = OSAL_PRIORITY_C(0);
 
-    OSAPI_TEST_FUNCTION_RC(OS_TaskGetInfo(OS_OBJECT_ID_UNDEFINED, NULL), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_TaskGetInfo(UT_OBJID_1, NULL), OS_INVALID_POINTER);
 }
 
 void Test_OS_TaskInstallDeleteHandler(void)

--- a/src/unit-tests/oscore-test/ut_oscore_binsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_binsem_test.c
@@ -134,6 +134,7 @@ void UT_os_bin_sem_delete_test()
 
     /*-----------------------------------------------------*/
     UT_RETVAL(OS_BinSemDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_BinSemDelete(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "DeleteTest", 1, 0)))
@@ -157,6 +158,7 @@ void UT_os_bin_sem_flush_test()
 
     /*-----------------------------------------------------*/
     UT_RETVAL(OS_BinSemFlush(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_BinSemFlush(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "FlushTest", 1, 0)))
@@ -181,6 +183,7 @@ void UT_os_bin_sem_give_test()
 
     /*-----------------------------------------------------*/
     UT_RETVAL(OS_BinSemGive(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_BinSemGive(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "GiveTest", 1, 0)))
@@ -206,6 +209,7 @@ void UT_os_bin_sem_take_test()
 
     /*-----------------------------------------------------*/
     UT_RETVAL(OS_BinSemTake(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_BinSemTake(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "TakeTest", 1, 0)))
@@ -230,6 +234,7 @@ void UT_os_bin_sem_timed_wait_test()
 
     /*-----------------------------------------------------*/
     UT_RETVAL(OS_BinSemTimedWait(UT_OBJID_INCORRECT, 1000), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_BinSemTimedWait(OS_OBJECT_ID_UNDEFINED, 1000), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "TimedWait", 1, 0)) && UT_SETUP(OS_BinSemTake(bin_sem_id)))
@@ -299,6 +304,7 @@ void UT_os_bin_sem_get_info_test()
 
     /*-----------------------------------------------------*/
     UT_RETVAL(OS_BinSemGetInfo(UT_OBJID_INCORRECT, &bin_sem_prop), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_BinSemGetInfo(OS_OBJECT_ID_UNDEFINED, &bin_sem_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     if (UT_SETUP(OS_BinSemCreate(&bin_sem_id, "GetInfo", 1, 0)))

--- a/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
@@ -163,6 +163,7 @@ void UT_os_count_sem_delete_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_CountSemDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_CountSemDelete(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -191,6 +192,7 @@ void UT_os_count_sem_give_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_CountSemGive(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_CountSemGive(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -221,6 +223,7 @@ void UT_os_count_sem_take_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_CountSemTake(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_CountSemTake(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -250,6 +253,7 @@ void UT_os_count_sem_timed_wait_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_CountSemTimedWait(UT_OBJID_INCORRECT, 1000), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_CountSemTimedWait(OS_OBJECT_ID_UNDEFINED, 1000), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Sem-take-timed-out */
@@ -341,6 +345,7 @@ void UT_os_count_sem_get_info_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_CountSemGetInfo(UT_OBJID_INCORRECT, &count_sem_prop), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_CountSemGetInfo(OS_OBJECT_ID_UNDEFINED, &count_sem_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-pointer-arg */

--- a/src/unit-tests/oscore-test/ut_oscore_mutex_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_mutex_test.c
@@ -149,6 +149,7 @@ void UT_os_mut_sem_delete_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_MutSemDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_MutSemDelete(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -176,6 +177,7 @@ void UT_os_mut_sem_give_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_MutSemGive(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_MutSemGive(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -208,6 +210,7 @@ void UT_os_mut_sem_take_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_MutSemTake(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_MutSemTake(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -284,6 +287,7 @@ void UT_os_mut_sem_get_info_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_MutSemGetInfo(UT_OBJID_INCORRECT, &mut_sem_prop), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_MutSemGetInfo(OS_OBJECT_ID_UNDEFINED, &mut_sem_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-pointer-arg */

--- a/src/unit-tests/oscore-test/ut_oscore_queue_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_queue_test.c
@@ -161,6 +161,7 @@ void UT_os_queue_delete_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_QueueDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_QueueDelete(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -195,6 +196,8 @@ void UT_os_queue_get_test()
 
     UT_RETVAL(OS_QueueGet(UT_OBJID_INCORRECT, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK),
               OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_QueueGet(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_in, sizeof(uint32), &size_copied, OS_CHECK),
+              OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-pointer-arg-1 */
@@ -205,6 +208,7 @@ void UT_os_queue_get_test()
     {
         UT_RETVAL(OS_QueueGet(queue_id, NULL, sizeof(uint32), &size_copied, OS_CHECK), OS_INVALID_POINTER);
         UT_RETVAL(OS_QueueGet(queue_id, &queue_data_in, sizeof(uint32), NULL, OS_CHECK), OS_INVALID_POINTER);
+        UT_RETVAL(OS_QueueGet(queue_id, &queue_data_in, 0, &size_copied, OS_CHECK), OS_ERR_INVALID_SIZE);
 
         UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
@@ -304,6 +308,7 @@ void UT_os_queue_put_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_QueuePut(UT_OBJID_INCORRECT, (void *)&queue_data_out, sizeof(uint32), 0), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_QueuePut(OS_OBJECT_ID_UNDEFINED, (void *)&queue_data_out, sizeof(uint32), 0), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-pointer-arg */
@@ -313,6 +318,8 @@ void UT_os_queue_put_test()
     {
         UT_RETVAL(OS_QueuePut(queue_id, NULL, sizeof(uint32), 0), OS_INVALID_POINTER);
         UT_RETVAL(OS_QueuePut(queue_id, &queue_data_out, sizeof(uint32) + 1, 0), OS_QUEUE_INVALID_SIZE);
+        UT_RETVAL(OS_QueuePut(queue_id, &queue_data_out, 0, 0), OS_ERR_INVALID_SIZE);
+
         UT_TEARDOWN(OS_QueueDelete(queue_id));
     }
 
@@ -412,6 +419,7 @@ void UT_os_queue_get_info_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_QueueGetInfo(UT_OBJID_INCORRECT, &queue_prop), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_QueueGetInfo(OS_OBJECT_ID_UNDEFINED, &queue_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-pointer-arg */

--- a/src/unit-tests/oscore-test/ut_oscore_select_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_select_test.c
@@ -105,8 +105,11 @@ void UT_os_select_fd_test(void)
     UT_RETVAL(OS_SelectFdIsSet(NULL, selecttest_fd), false);
 
     UT_RETVAL(OS_SelectFdAdd(&FdSet, invalid_fd), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_SelectFdAdd(&FdSet, OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
     UT_RETVAL(OS_SelectFdClear(&FdSet, invalid_fd), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_SelectFdClear(&FdSet, OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
     UT_RETVAL(OS_SelectFdIsSet(&FdSet, invalid_fd), false);
+    UT_RETVAL(OS_SelectFdIsSet(&FdSet, OS_OBJECT_ID_UNDEFINED), false);
 
     UT_NOMINAL(OS_SelectFdZero(&FdSet));
     UT_NOMINAL(OS_SelectFdAdd(&FdSet, selecttest_fd));
@@ -147,6 +150,7 @@ void UT_os_select_single_test(void)
                   (unsigned int)StateFlags);
 
     UT_RETVAL(OS_SelectSingle(invalid_fd, &StateFlags, 0), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_SelectSingle(OS_OBJECT_ID_UNDEFINED, &StateFlags, 0), OS_ERR_INVALID_ID);
 }
 
 /*--------------------------------------------------------------------------------*

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -225,6 +225,7 @@ void UT_os_task_delete_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_TaskDelete(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_TaskDelete(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -431,6 +432,7 @@ void UT_os_task_set_priority_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_TaskSetPriority(UT_OBJID_INCORRECT, OSAL_PRIORITY_C(100)), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_TaskSetPriority(OS_OBJECT_ID_UNDEFINED, OSAL_PRIORITY_C(100)), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #4 Nominal */
@@ -557,6 +559,7 @@ void UT_os_task_get_info_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_TaskGetInfo(UT_OBJID_INCORRECT, &task_prop), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_TaskGetInfo(OS_OBJECT_ID_UNDEFINED, &task_prop), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-pointer-arg */

--- a/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_dirio_test.c
@@ -284,6 +284,7 @@ void UT_os_closedir_test()
     os_dirent_t dirEntry;
 
     UT_RETVAL(OS_DirectoryClose(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_DirectoryClose(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Nominal */
@@ -358,6 +359,7 @@ void UT_os_readdir_test()
     /* Invalid ID */
 
     UT_RETVAL(OS_DirectoryRead(UT_OBJID_INCORRECT, &dirent), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_DirectoryRead(OS_OBJECT_ID_UNDEFINED, &dirent), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -449,6 +451,7 @@ void UT_os_rewinddir_test()
     /* Invalid ID */
 
     UT_RETVAL(OS_DirectoryRewind(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_DirectoryRewind(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Nominal */

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -455,6 +455,7 @@ void UT_os_closefile_test()
     /* #1 Invalid-file-desc-arg */
 
     UT_RETVAL(OS_close(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_close(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */
@@ -549,6 +550,7 @@ void UT_os_readfile_test()
     /*-----------------------------------------------------*/
     /* #2 Invalid-file-desc-arg */
     UT_RETVAL(OS_read(UT_OBJID_INCORRECT, g_readBuff, sizeof(g_readBuff)), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_read(OS_OBJECT_ID_UNDEFINED, g_readBuff, sizeof(g_readBuff)), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #4 Nominal */
@@ -657,6 +659,7 @@ void UT_os_writefile_test()
     /* #2 Invalid-file-desc-arg */
 
     UT_RETVAL(OS_write(UT_OBJID_INCORRECT, g_writeBuff, sizeof(g_writeBuff)), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_write(OS_OBJECT_ID_UNDEFINED, g_writeBuff, sizeof(g_writeBuff)), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #4 Nominal */
@@ -744,6 +747,7 @@ void UT_os_lseekfile_test()
     int32  pos1 = 0, pos2 = 0, pos3 = 0;
 
     UT_RETVAL(OS_lseek(UT_OBJID_INCORRECT, 0, OS_SEEK_SET), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_lseek(OS_OBJECT_ID_UNDEFINED, 0, OS_SEEK_SET), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 Invalid-whence-arg */
@@ -1535,6 +1539,7 @@ void UT_os_getfdinfo_test()
     /* #2 Invalid-file-desc-arg */
 
     UT_RETVAL(OS_FDGetInfo(UT_OBJID_INCORRECT, &fdProps), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_FDGetInfo(OS_OBJECT_ID_UNDEFINED, &fdProps), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #4 Nominal */

--- a/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_fileio_test.c
@@ -1425,6 +1425,7 @@ void UT_os_outputtofile_test()
     /* #2 Invalid-file-desc-arg */
 
     UT_RETVAL(OS_ShellOutputToFile("ls", UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_ShellOutputToFile("ls", OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #4 Nominal */

--- a/src/unit-tests/osloader-test/ut_osloader_module_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_module_test.c
@@ -185,6 +185,7 @@ void UT_os_module_unload_test()
     /* #1 Invalid-ID-arg */
 
     UT_RETVAL(OS_ModuleUnload(UT_OBJID_INCORRECT), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_ModuleUnload(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #2 OS-call-failure */
@@ -224,6 +225,7 @@ void UT_os_module_info_test()
     /* #2 Invalid-ID-arg */
 
     UT_RETVAL(OS_ModuleInfo(UT_OBJID_INCORRECT, &module_info), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_ModuleInfo(OS_OBJECT_ID_UNDEFINED, &module_info), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* #3 Nominal */

--- a/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
@@ -129,22 +129,23 @@ void UT_os_module_symbol_lookup_test()
     }
 
     /*-----------------------------------------------------*/
-    /* #1 Invalid-pointer-arg-1 */
+    /* Invalid object ID */
 
-    UT_RETVAL(OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, 0, "Sym"), OS_INVALID_POINTER);
-
-    /*-----------------------------------------------------*/
-    /* #2 Invalid-pointer-arg-2 */
-
-    UT_RETVAL(OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, 0), OS_INVALID_POINTER);
+    UT_RETVAL(OS_ModuleSymbolLookup(OS_OBJECT_ID_UNDEFINED, &symbol_addr, "Sym"), OS_ERR_INVALID_ID);
+    UT_RETVAL(OS_ModuleSymbolLookup(UT_OBJID_INCORRECT, &symbol_addr, "Sym"), OS_ERR_INVALID_ID);
 
     /*-----------------------------------------------------*/
     /* Setup for remainder of tests */
     if (UT_SETUP(OS_ModuleLoad(&module_id, "Mod1", UT_OS_GENERIC_MODULE_NAME2, OS_MODULE_FLAG_LOCAL_SYMBOLS)))
     {
         /*-----------------------------------------------------*/
-        /* #3 Symbol-not-found */
+        /* #1 Invalid-pointer-arg */
 
+        UT_RETVAL(OS_ModuleSymbolLookup(module_id, NULL, "Sym"), OS_INVALID_POINTER);
+        UT_RETVAL(OS_ModuleSymbolLookup(module_id, &symbol_addr, NULL), OS_INVALID_POINTER);
+
+        /*-----------------------------------------------------*/
+        /* #3 Symbol-not-found */
         UT_RETVAL(OS_ModuleSymbolLookup(module_id, &symbol_addr, "NotFound"), OS_ERROR);
 
         /*-----------------------------------------------------*/

--- a/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
+++ b/src/unit-tests/osnetwork-test/ut_osnetwork_misc_test.c
@@ -150,7 +150,7 @@ void UT_os_networkgethostname_test()
     /*-----------------------------------------------------*/
     /* #1 Null-pointer-arg */
 
-    UT_RETVAL(OS_NetworkGetHostName(NULL, 0), OS_INVALID_POINTER);
+    UT_RETVAL(OS_NetworkGetHostName(NULL, sizeof(buffer)), OS_INVALID_POINTER);
 
     /*-----------------------------------------------------*/
     /* #2 Zero-name-length-arg */


### PR DESCRIPTION
**Describe the contribution**
Another pass through the API to ensure that:
1. every function parameter marked "nonnull" in doxygen has an individual `OS_INVALID_POINTER` retcode test
2. every function parameter marked "nonzero" in doxygen has an individual `OS_ERR_INVALID_SIZE` retcode test
3. every function parameter accepting an `osal_id_t` type has two `OS_ERR_INVALID_ID` retcode tests, and that it is tested with `OS_OBJECT_ID_UNDEFINED` and `UT_OBJID_INCORRECT` (which is not zero, but not valid).

**Testing performed**
Run all unit tests, and run validation script on tests logs to confirm parameters have been exercised and confirmed for each required retcode.

**Expected behavior changes**
Missing tests are implemented

**System(s) tested on**
Ubuntu

**Additional context**
This PR will have each subsystem done as separate commits

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
