### PR TITLE
Fix #1036 Add Workflow to build and verify OSAL API Guide

### DIFF
--- a/.github/workflows/build-osal-apiguide.yml
+++ b/.github/workflows/build-osal-apiguide.yml
@@ -1,0 +1,68 @@
+name: "Build OSAL API Guide"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  #Check for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  build-osal-apiguide:
+    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get install doxygen graphviz -y
+
+      - name: Checkout submodule
+        uses: actions/checkout@v2
+
+      - name: Set up for build
+        run: |
+          cp Makefile.sample Makefile
+          make prep
+
+      - name: Build OSAL API Guide
+        run: |
+          make osal-apiguide > make_osal-apiguide_stdout.txt 2> make_osal-apiguide_stderr.txt
+          mv build/doc/osal-apiguide-warnings.log osal-apiguide-warnings.log
+
+      - name: Archive Osal Guide Build Logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: OSAL Guide Artifacts
+          path: |
+            make_osal-apiguide_stdout.txt
+            make_osal-apiguide_stderr.txt
+            osal-apiguide-warnings.log
+
+      - name: Error Check
+        run: |
+          if [[ -s make_osal-apiguide_stderr.txt ]]; then
+            cat make_osal-apiguide_stderr.txt
+            exit -1
+          fi
+
+      - name: Warning Check
+        run: |
+          if [[ -s osal-apiguide-warnings.log ]]; then
+            cat osal-apiguide-warnings.log
+            exit -1
+          fi


### PR DESCRIPTION
**Describe the contribution**
Fix #1036 Adding a workflow that will build the OSAL API Guide, and check that there are no errors or warnings. 

Currently, the warning-check job always finds warnings. Workflow will complete successfully once documentation warnings are fixed.

Marked as draft since it needs integration-candidate to be merged to main.

**Testing performed**
Steps taken to test the contribution:
1. Pushed workflow file.
2. Verified workflow runs as expected.

**Expected behavior changes**
A new workflow will run on every push and pull request.

**System(s) tested on**
 - Tested on the Github servers where CI actions get to run. (Ubuntu 18.04)

**Contributor Info**
Jose F. Martinez Pedraza/NASA GSFC
