### PR TITLE
Fix #1069, add detail design template

### DIFF
--- a/doc/osal-detaildesign.doxyfile.in
+++ b/doc/osal-detaildesign.doxyfile.in
@@ -1,0 +1,7 @@
+# All of the OSAL FSW code relevant for a detail design document is under
+# src/os and src/bsp, everything else is test and examples/support
+# Note this will include ALL OS/BSP layers, it does not currently filter
+# based on which OS/BSP is actually in use.
+INPUT    += @osal_MISSION_DIR@/src/os
+INPUT    += @osal_MISSION_DIR@/src/bsp
+


### PR DESCRIPTION
**Describe the contribution**
This file indicates which input dirs to use for the cFE detail design document.  It should be controlled with OSAL, as this
knows the detail of the directory tree.

Fixes #1069 

**Testing performed**
Build cFE detail design document, confirm correct/expected content, with no duplicate "mainpage"

**Expected behavior changes**
Detail design document has `src/os` and `src/bsp` content, but NOT the mainpage that is specific for the OSAL API guide.

**System(s) tested on**
Ubuntu

**Additional context**
Related to nasa/cfe#1612

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
