### PR TITLE
HOTFIX:2021-06-15, Add missing OS_Select param doc

### DIFF
--- a/src/os/inc/osapi-select.h
+++ b/src/os/inc/osapi-select.h
@@ -92,6 +92,8 @@ typedef enum
  *
  * @param[in,out] ReadSet  Set of handles to check/wait to become readable
  * @param[in,out] WriteSet Set of handles to check/wait to become writable
+ * @param[in] msecs Indicates the timeout. Positive values will wait up to that many milliseconds. Zero will not wait
+ * (poll). Negative values will wait forever (pend)
  *
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS If any handle in the ReadSet or WriteSet is readable or writable, respectively
@@ -124,6 +126,8 @@ int32 OS_SelectMultiple(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs);
  *
  * @param[in] objid The handle ID to select on
  * @param[in,out] StateFlags State flag(s) (readable or writable) @nonnull
+ * @param[in] msecs Indicates the timeout. Positive values will wait up to that many milliseconds. Zero will not wait
+ * (poll). Negative values will wait forever (pend)
  *
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS If the handle is readable and/or writable, as requested


### PR DESCRIPTION
**Describe the contribution**

Fix usersguide doxygen warning for OS_SelectSingle and OS_SelectMultiple msecs input parameter.

**Testing performed**

**Expected behavior changes**
No doxygen warning

**System(s) tested on**

**Additional context**
See https://github.com/nasa/cFS/pull/265/checks?check_run_id=2798133902

**Third party code**
None