### PR TITLE
Fix #1074, Increase UT object limit for testing

### DIFF
--- a/src/ut-stubs/utstub-helpers.h
+++ b/src/ut-stubs/utstub-helpers.h
@@ -64,7 +64,7 @@
  * (Default value of 16 allows for up to 128 objects to be created in
  * a single test case, far more than anything I've seen yet)
  */
-#define OSAL_MAX_VALID_PER_TYPE 16
+#define OSAL_MAX_VALID_PER_TYPE 32
 
 typedef struct
 {


### PR DESCRIPTION
**Describe the contribution**
Fix #1074 - increases the UT object limit bits from 16 to 32

**Testing performed**
CI

**Expected behavior changes**
None

**System(s) tested on**
CI

**Additional context**
Fix for stakeholder

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC