### PR TITLE
Fix #1080, add range to OS_TaskDelay checks

### DIFF
--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -398,6 +398,12 @@ void UT_os_task_delay_test()
     OS_time_t after_time;
     int64     elapsed;
 
+    /*
+     * Note, if running under a VM/hypervisor, the real time clock may not
+     * be very precise, depending on its implementation.  Therefore the allowed
+     * ranges are slightly extended here.
+     */
+
     /*-----------------------------------------------------*/
     /* Nominal, 100ms delay */
     UT_SETUP(OS_GetLocalTime(&before_time));
@@ -405,7 +411,7 @@ void UT_os_task_delay_test()
     UT_SETUP(OS_GetLocalTime(&after_time));
 
     elapsed = OS_TimeGetTotalMilliseconds(OS_TimeSubtract(after_time, before_time));
-    UtAssert_True(elapsed >= 100, "Elapsed time %ld msec, expected 100", (long)elapsed);
+    UtAssert_True(elapsed >= 95, "Elapsed time %ld msec, expected 100", (long)elapsed);
 
     /*-----------------------------------------------------*/
     /* Nominal, 250ms delay */
@@ -414,7 +420,7 @@ void UT_os_task_delay_test()
     UT_SETUP(OS_GetLocalTime(&after_time));
 
     elapsed = OS_TimeGetTotalMilliseconds(OS_TimeSubtract(after_time, before_time));
-    UtAssert_True(elapsed >= 250, "Elapsed time %ld msec, expected 250", (long)elapsed);
+    UtAssert_True(elapsed >= 245, "Elapsed time %ld msec, expected 250", (long)elapsed);
 }
 
 /*--------------------------------------------------------------------------------*


### PR DESCRIPTION
**Describe the contribution**
To account for potential of imprecise timing/clock sampling when running on a VM, allow for a wider range of time values to pass the test.

Fixes #1080 

**Testing performed**
Build and run tests using QEMU

**Expected behavior changes**
Test now pass even if the time difference is not exactly the expected range.

**System(s) tested on**
RTEMS 4.11.3 under QEMU

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.