### PR TITLE
Fix #1084, root task ID on RTEMS

### DIFF
--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -336,11 +336,20 @@ osal_id_t OS_TaskGetId_Impl(void)
 
     task_self = rtems_task_self();
     /* When the task was created the OSAL ID was used as the "classic name",
-     * which gives us an easy way to map it back again */
+     * which gives us an easy way to map it back again.  However, if this
+     * API is invoked from a non-OSAL task (i.e. the "root" task) then it is
+     * possible that rtems_object_get_classic_name() succeeds but the result
+     * is not actually an OSAL task ID. */
     status = rtems_object_get_classic_name(task_self, &self_name);
     if (status == RTEMS_SUCCESSFUL)
     {
         global_task_id = OS_ObjectIdFromInteger(self_name);
+
+        if (OS_ObjectIdToType_Impl(global_task_id) != OS_OBJECT_TYPE_OS_TASK)
+        {
+            /* not an OSAL task */
+            global_task_id = OS_OBJECT_ID_UNDEFINED;
+        }
     }
     else
     {


### PR DESCRIPTION
**Describe the contribution**
Ensures that OS_GetTaskId_Impl() returns OS_OBJECT_ID_UNDEFINED if called from the root task - as this does not have an OSAL task ID.

Fixes #1084

**Testing performed**
Run unit tests on RTEMS

**Expected behavior changes**
Tests pass

**System(s) tested on**
RTEMS 4.11.3

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
