### PR TITLE
Fix #1082, increase UT symbol dump size limit

### DIFF
--- a/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
+++ b/src/unit-tests/osloader-test/ut_osloader_symtable_test.c
@@ -35,6 +35,14 @@
 ** Macros
 **--------------------------------------------------------------------------------*/
 
+/**
+ * The size limit to pass for OS_SymbolTableDump nominal test
+ *
+ * This must be large enough to actually accomodate all of the symbols
+ * in the target system.
+ */
+#define UT_SYMTABLE_SIZE_LIMIT 1048576
+
 /*--------------------------------------------------------------------------------*
 ** Data types
 **--------------------------------------------------------------------------------*/
@@ -188,9 +196,9 @@ void UT_os_symbol_table_dump_test()
     /*-----------------------------------------------------*/
     /* #3 Nominal */
 
-    if (UT_NOMINAL_OR_NOTIMPL(OS_SymbolTableDump(UT_OS_GENERIC_MODULE_DIR "SymbolFile.dat", 32000)))
+    if (UT_NOMINAL_OR_NOTIMPL(OS_SymbolTableDump(UT_OS_GENERIC_MODULE_DIR "SymbolReal.dat", UT_SYMTABLE_SIZE_LIMIT)))
     {
-        UT_RETVAL(OS_SymbolTableDump(UT_OS_GENERIC_MODULE_DIR "SymbolFile.dat", 0), OS_ERR_OUTPUT_TOO_LARGE);
+        UT_RETVAL(OS_SymbolTableDump(UT_OS_GENERIC_MODULE_DIR "SymbolZero.dat", 0), OS_ERR_OUTPUT_TOO_LARGE);
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
For the MCP750, the symbol table fairly large and requires a considerably larger limit to avoid the OS_ERR_OUTPUT_TOO_LARGE limit.  This also uses a different name, so that the user can actually see the symbol dump file if they want (otherwise the next test overwrites the file).

Fixes #1082

**Testing performed**
Run osal_loader_UT

**Expected behavior changes**
Symbol table dump test now passes

**System(s) tested on**
MCP750 / VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
