### PR TITLE
Fix #1086, increase timeout in network-api-test

### DIFF
--- a/src/tests/network-api-test/network-api-test.c
+++ b/src/tests/network-api-test/network-api-test.c
@@ -42,7 +42,7 @@
  * where the console is on a slow serial port.  Therefore this timeout must
  * not be too short.
  */
-#define UT_TIMEOUT 1000
+#define UT_TIMEOUT 4000
 
 /*
  * Variations of client->server connections to create.


### PR DESCRIPTION
**Describe the contribution**
The number of asserts being printed was still taking longer than 1000ms on a 9600 baud serial link, so increasing the timeout allows tests to pass.

Fixes #1086

**Testing performed**
Run network-api-test

**Expected behavior changes**
Test now passes

**System(s) tested on**
MCP750 / VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
