### PR TITLE
Fix #1088, avoid task delete during UtPrintf

### DIFF
--- a/src/bsp/generic-vxworks/src/bsp_start.c
+++ b/src/bsp/generic-vxworks/src/bsp_start.c
@@ -103,8 +103,8 @@ int OS_BSPMain(void)
     /*
      * Initialize the low level access sem
      */
-    OS_BSP_GenericVxWorksGlobal.AccessMutex =
-        semMInitialize(OS_BSP_GenericVxWorksGlobal.AccessMutexMem, SEM_Q_PRIORITY | SEM_INVERSION_SAFE);
+    OS_BSP_GenericVxWorksGlobal.AccessMutex = semMInitialize(OS_BSP_GenericVxWorksGlobal.AccessMutexMem,
+                                                             SEM_Q_PRIORITY | SEM_INVERSION_SAFE | SEM_DELETE_SAFE);
 
     if (OS_BSP_GenericVxWorksGlobal.AccessMutex == (SEM_ID)0)
     {

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -163,10 +163,10 @@ void UT_os_task_create_test()
         {
             break;
         }
-    }
 
-    /* Delay to let child tasks run */
-    OS_TaskDelay(500);
+        /* Delay to let child task run */
+        OS_TaskDelay(200);
+    }
 
     /* Reset test environment */
     for (i = 0; i < OS_MAX_TASKS; i++)


### PR DESCRIPTION
**Describe the contribution**
In the osal_core_UT test, the test task was being deleted while it was in the midst of a UtPrintf call, which left the BSP mutex in a locked state, causing deadlock.

Using SEM_DELETE_SAFE attribute avoids task deletion for the mutex holder, and adding a small delay to the test case makes all the messages appear as expected (accounts for slow serial console on test platform).

Fixes #1088

**Testing performed**
Run osal_core_UT

**Expected behavior changes**
Test now passes, does not deadlock

**System(s) tested on**
MCP750 / VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
