### PR TITLE
Partial #1108, add typedef for OSAL status codes

### DIFF
--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -119,6 +119,11 @@ extern "C"
     typedef uint32 osal_objtype_t;
 
     /**
+     * The preferred type to represent OSAL status codes defined in osapi-error.h
+     */
+    typedef int32 osal_status_t;
+
+    /**
      * @brief General purpose OSAL callback function
      *
      * This may be used by multiple APIS
@@ -155,5 +160,6 @@ extern "C"
 #define OSAL_BLOCKCOUNT_C(X) ((osal_blockcount_t)(X))
 #define OSAL_INDEX_C(X)      ((osal_index_t)(X))
 #define OSAL_OBJTYPE_C(X)    ((osal_objtype_t)(X))
+#define OSAL_STATUS_C(X)     ((osal_status_t)(X))
 
 #endif /* COMMON_TYPES_H */

--- a/src/os/inc/osapi-error.h
+++ b/src/os/inc/osapi-error.h
@@ -140,6 +140,22 @@ typedef char os_err_name_t[OS_ERROR_NAME_LENGTH];
 
 /*-------------------------------------------------------------------------------------*/
 /**
+ * @brief Convert a status code to a native "long" type
+ *
+ * For printing or logging purposes, this converts the given status code
+ * to a "long" (signed integer) value.  It should be used in conjunction
+ * with the "%ld" conversion specifier in printf-style statements.
+ *
+ * @param[in] Status Execution status, see @ref OSReturnCodes
+ * @return Same status value converted to the "long" data type
+ */
+static inline long OS_StatusToInteger(osal_status_t Status)
+{
+    return (long)Status;
+}
+
+/*-------------------------------------------------------------------------------------*/
+/**
  * @brief Convert an error number to a string
  *
  * @param[in] error_num Error number to convert


### PR DESCRIPTION
**Describe the contribution**
Minimal change to add a typedef for `osal_status_t`, a macro for constants/literals `OSAL_STATUS_C`, and an inline function to convert to "long" for printing/logging.

Partial/related to #1108 (this PR is just for the typedef and conversions, so that CFE/App code can potentially use the type)

**Testing performed**
Build and run CFE, run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
This PR is only intended to avoid a chicken/egg scenario with the `osal_status_t` type.  That is, just to make it exist, so other entities can theoretically start using it, even if OSAL itself does not (yet).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
