### PR TITLE
Fix #1115, Add absolute branch coverage check

### DIFF
--- a/.github/workflows/local_unit_test.yml
+++ b/.github/workflows/local_unit_test.yml
@@ -31,11 +31,25 @@ jobs:
 
       - name: Calculate coverage 
         run: make lcov | tee lcov_out.txt
-
+ 
       - name: Confirm 100% line coverage
         run: |
           if [[ `grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines` != *"100.0%"* ]]; then
             grep -A 3 "Overall coverage rate" lcov_out.txt
             echo "Lacks 100.0% line unit test coverage"
+            exit -1
+          fi
+
+      - name: Confirm absolute line coverage
+        run: |
+          # Current best possible branch coverage is all but 4, with associated issues for each missing case
+          missed_branches=4
+          coverage_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[1-9]+[0-9]*")
+
+          diff=$(echo $coverage_nums | awk '{ print $4 - $3 }')
+          if [ $(($diff > $missed_branches)) == 1 ]
+          then 
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "More than $missed_branches branches missed"
             exit -1
           fi


### PR DESCRIPTION
Check for absolute number of missed branches in GitHub workflow instead of checking a percentage branch coverage.

Ensure that the number of missed branches does not increase from the current 4 missed branches.

**Describe the contribution**
Fixes  #1115. The PR #1114 that is currently in the integration candidate branch has only 4 missed branches in the unit tests. This PR checks that the number of missed branches is <= 4 instead of checking the percentage branch coverage. This puts an absolute limit on the number of missed branches.

**Testing performed**
Steps taken to test the contribution:
1. The local_unit_test workflow will currently fail on any branch that is not the current integration candidate, so I merged this PR into my fork's integration candidate branch to see it pass [here](https://github.com/nmullane/osal/runs/3164099654?check_suite_focus=true). 
2. The error output when the coverage is not high enough can be seen [here](https://github.com/nmullane/osal/runs/3164037705?check_suite_focus=true#step:8:17)

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - This PR will only change the behavior of the local_unit_test GitHub Actions workflow and will fail the test if more than 4 branches are not covered by the unit tests.

**System(s) tested on**
 - GitHub Actions Runner

**Contributor Info - All information REQUIRED for consideration of pull request**
Niall Mullane - GSFC 582 Intern
