### PR TITLE
Fix #1118 Add UtAssert_MIR macro

### DIFF
--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -324,8 +324,7 @@ void TestSelectSingleWrite(void)
 
     if (!FillOutputBuffer(c1_socket_id))
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__, "%s",
-                   "Unable to fill buffer with large looped writes, skipping verification");
+        UtAssert_MIR("%s", "Unable to fill buffer with large looped writes, skipping verification");
     }
     else
     {
@@ -379,8 +378,7 @@ void TestSelectMultipleWrite(void)
 
     if (!FillOutputBuffer(c1_socket_id))
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__, "%s",
-                   "Unable to fill buffer with large looped writes, skipping verification");
+        UtAssert_MIR("Unable to fill buffer with large looped writes, skipping verification");
     }
     else
     {

--- a/src/unit-tests/inc/ut_os_support.h
+++ b/src/unit-tests/inc/ut_os_support.h
@@ -82,7 +82,7 @@ static inline bool UtOsalNotSuccess(int32 Fn, UtAssert_CaseType_t casetype, cons
 
 static inline bool UtManualInspectionWithStatus(int32 Fn, const char *File, uint32 Line, const char *FnTxt)
 {
-    UtAssertEx(false, UTASSERT_CASETYPE_MIR, File, Line, "%s value=%d", FnTxt, (int)Fn);
+    UtAssert_MIR("%s value=%d", FnTxt, (int)Fn);
     return (Fn >= 0);
 }
 
@@ -117,7 +117,7 @@ static inline bool UtOsalImplemented(int32 Fn, const char *File, uint32 Line)
 #define UT_NOT_SUCCESS(Fn) UtOsalNotSuccess(Fn, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #Fn)
 
 #define UT_MIR_STATUS(Fn) UtManualInspectionWithStatus(Fn, __FILE__, __LINE__, #Fn)
-#define UT_MIR_VOID(Fn)   Fn, UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__, "%s", #Fn)
+#define UT_MIR_VOID(Fn)   Fn, UtAssert_MIR("%s", #Fn)
 
 #define UT_SETUP(Fn)    UtOsalCheck(Fn, UTASSERT_CASETYPE_TSF, __FILE__, __LINE__, #Fn)
 #define UT_TEARDOWN(Fn) UtOsalCheck(Fn, UTASSERT_CASETYPE_TTF, __FILE__, __LINE__, #Fn)

--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -111,6 +111,11 @@ typedef struct
 #define UtAssert_NA(...) UtAssertEx(false, UTASSERT_CASETYPE_NA, __FILE__, __LINE__, __VA_ARGS__)
 
 /**
+ * \brief Assert a test MIR (Manual Inspection Required)
+ */
+#define UtAssert_MIR(...) UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__, __VA_ARGS__)
+
+/**
  * \brief Compares two integers and determines if they are equal within a specified absolute tolerance.
  */
 #define UtAssert_IntegerCmpAbs(x, y, Tolerance, ...) \


### PR DESCRIPTION
**Describe the contribution**
Fixes #1118 Added UtAssert_MIR macro to avoid misuse of `UtAssertEx` when using the MIR case type `UTASSERT_CASETYPE_MIR`

**Testing performed**
1. Ran cFS Unit Tests

**Expected behavior changes**
No changes expected. Macro UtAssert_MIR is now available for use.

**System(s) tested on**
Ubuntu 18.04 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / NASA GSFC