### PR TITLE
Fix #1130, add test case types similar to NA

### DIFF
--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -59,11 +59,13 @@ typedef enum
     UTASSERT_CASETYPE_TSF,     /**< Test Setup Failure (TSF) status messages */
     UTASSERT_CASETYPE_TTF,     /**< Test Teardown Failure (TTF) status messages */
     UTASSERT_CASETYPE_MIR,     /**< Manual Inspection Required (MIR) status messages */
+    UTASSERT_CASETYPE_WARN,    /**< Test was unable to run (WARN) status messages (e.g. initial condition wrong) */
     UTASSERT_CASETYPE_NA,      /**< Test Not Applicable (NA) status messages */
     UTASSERT_CASETYPE_BEGIN,   /**< Beginning of test status messages */
     UTASSERT_CASETYPE_END,     /**< End of test status messages */
     UTASSERT_CASETYPE_INFO,    /**< All other informational status messages */
     UTASSERT_CASETYPE_PASS,    /**< Test case passed (normal) status messages */
+    UTASSERT_CASETYPE_FLOW,    /**< Other condition checks/messages that record test flow, but are not assertions */
     UTASSERT_CASETYPE_DEBUG,   /**< Debugging messages */
     UTASSERT_CASETYPE_MAX      /**< Reserved value, No messages should be used with this */
 } UtAssert_CaseType_t;
@@ -152,6 +154,11 @@ typedef struct
  * \brief Assert a test MIR (Manual Inspection Required)
  */
 #define UtAssert_MIR(...) UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__, __VA_ARGS__)
+
+/**
+ * \brief Skip a test due to improper setup (Manual Intervention Required)
+ */
+#define UtAssert_WARN(...) UtAssertEx(false, UTASSERT_CASETYPE_WARN, __FILE__, __LINE__, __VA_ARGS__)
 
 /**
  * \brief Compares two integers and determines if they are equal within a specified absolute tolerance.
@@ -586,6 +593,22 @@ bool UtAssertEx(bool Expression, UtAssert_CaseType_t CaseType, const char *File,
  * \param Message a free form string describing the failure
  */
 void UtAssert_Abort(const char *Message);
+
+/**
+ * \brief Gets the short/abbreviated name for a UtAssert case type
+ *
+ * For tagging lines in the output log file, this returns a short string
+ * representing the human-readable name of the UtAssert case type.
+ *
+ * The returned string is 5 characters or less in length.
+ *
+ * \note This function does not return NULL, such that it can be
+ * used directly inside a printf()-style call.
+ *
+ * \param CaseType Message case type
+ * \returns String representation of case type
+ */
+const char *UtAssert_GetCaseTypeAbbrev(UtAssert_CaseType_t CaseType);
 
 /**
  * \brief Output an informational message to the console/log file

--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -79,14 +79,14 @@ void UtAssert_DoTestSegmentReport(const char *SegmentName, const UtAssert_TestCo
     char ReportBuffer[144];
 
     snprintf(ReportBuffer, sizeof(ReportBuffer),
-             "%02u %-20s TOTAL::%-4u  PASS::%-4u  FAIL::%-4u  MIR::%-4u  TSF::%-4u  TTF::%-4u  N/A::%-4u\n",
+             "%02u %-20s TOTAL::%-4u  PASS::%-4u  FAIL::%-4u  MIR::%-4u  TSF::%-4u  TTF::%-4u  WARN::%-4u\n",
              (unsigned int)TestCounters->TestSegmentCount, SegmentName, (unsigned int)TestCounters->TotalTestCases,
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_PASS],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_FAILURE],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_MIR],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_TSF],
              (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_TTF],
-             (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_NA]);
+             (unsigned int)TestCounters->CaseCount[UTASSERT_CASETYPE_WARN]);
 
     UT_BSP_DoText(UTASSERT_CASETYPE_END, ReportBuffer);
 }
@@ -223,6 +223,60 @@ bool UtAssertEx(bool Expression, UtAssert_CaseType_t CaseType, const char *File,
 void UtAssert_Abort(const char *Message)
 {
     UT_BSP_DoText(UTASSERT_CASETYPE_ABORT, Message);
+}
+
+const char *UtAssert_GetCaseTypeAbbrev(UtAssert_CaseType_t CaseType)
+{
+    const char *AbbrevStr;
+
+    switch (CaseType)
+    {
+        case UTASSERT_CASETYPE_ABORT:
+            AbbrevStr = "ABORT";
+            break;
+        case UTASSERT_CASETYPE_FAILURE:
+            AbbrevStr = "FAIL";
+            break;
+        case UTASSERT_CASETYPE_MIR:
+            AbbrevStr = "MIR";
+            break;
+        case UTASSERT_CASETYPE_TSF:
+            AbbrevStr = "TSF";
+            break;
+        case UTASSERT_CASETYPE_TTF:
+            AbbrevStr = "TTF";
+            break;
+        case UTASSERT_CASETYPE_WARN:
+            AbbrevStr = "WARN";
+            break;
+        case UTASSERT_CASETYPE_NA:
+            AbbrevStr = "N/A";
+            break;
+        case UTASSERT_CASETYPE_BEGIN:
+            AbbrevStr = "BEGIN";
+            break;
+        case UTASSERT_CASETYPE_END:
+            AbbrevStr = "END";
+            break;
+        case UTASSERT_CASETYPE_PASS:
+            AbbrevStr = "PASS";
+            break;
+        case UTASSERT_CASETYPE_INFO:
+            AbbrevStr = "INFO";
+            break;
+        case UTASSERT_CASETYPE_FLOW:
+            AbbrevStr = "FLOW";
+            break;
+        case UTASSERT_CASETYPE_DEBUG:
+            AbbrevStr = "DEBUG";
+            break;
+        default:
+            /* do not return NULL, as the result may be directly passed to C library functions */
+            AbbrevStr = "OTHER";
+            break;
+    }
+
+    return AbbrevStr;
 }
 
 void UtAssert_Message(uint8 MessageType, const char *File, uint32 Line, const char *Spec, ...)

--- a/ut_assert/src/utbsp.c
+++ b/ut_assert/src/utbsp.c
@@ -116,60 +116,37 @@ void UT_BSP_StartTestSegment(uint32 SegmentNumber, const char *SegmentName)
 
 void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
 {
-    const char *Prefix;
-    char        Buffer[16];
-    size_t      MsgLen;
-    uint32      TermModeBits = OS_BSP_CONSOLEMODE_NORMAL;
-    uint32      MsgEnabled   = BSP_UT_Global.CurrVerbosity >> MessageType;
+    char   Buffer[16];
+    size_t MsgLen;
+    uint32 TermModeBits = OS_BSP_CONSOLEMODE_NORMAL;
+    uint32 MsgEnabled   = BSP_UT_Global.CurrVerbosity >> MessageType;
 
     if (MsgEnabled & 1)
     {
         UT_BSP_Lock();
 
+        /* Determine if the message type warrants special treatment (color/highlight/etc). */
         switch (MessageType)
         {
             case UTASSERT_CASETYPE_ABORT:
-                TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_RED;
-                Prefix       = "ABORT";
-                break;
             case UTASSERT_CASETYPE_FAILURE:
                 TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_RED;
-                Prefix       = "FAIL";
                 break;
             case UTASSERT_CASETYPE_MIR:
+            case UTASSERT_CASETYPE_WARN:
                 TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_RED | OS_BSP_CONSOLEMODE_GREEN;
-                Prefix       = "MIR";
                 break;
             case UTASSERT_CASETYPE_TSF:
-                TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_RED | OS_BSP_CONSOLEMODE_BLUE;
-                Prefix       = "TSF";
-                break;
             case UTASSERT_CASETYPE_TTF:
                 TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_RED | OS_BSP_CONSOLEMODE_BLUE;
-                Prefix       = "TTF";
-                break;
-            case UTASSERT_CASETYPE_NA:
-                Prefix = "N/A";
                 break;
             case UTASSERT_CASETYPE_BEGIN:
                 OS_BSP_ConsoleOutput_Impl("\n", 1); /* add a bit of extra whitespace between tests */
-                Prefix = "BEGIN";
-                break;
-            case UTASSERT_CASETYPE_END:
-                Prefix = "END";
                 break;
             case UTASSERT_CASETYPE_PASS:
                 TermModeBits = OS_BSP_CONSOLEMODE_HIGHLIGHT | OS_BSP_CONSOLEMODE_GREEN;
-                Prefix       = "PASS";
-                break;
-            case UTASSERT_CASETYPE_INFO:
-                Prefix = "INFO";
-                break;
-            case UTASSERT_CASETYPE_DEBUG:
-                Prefix = "DEBUG";
                 break;
             default:
-                Prefix = "OTHER";
                 break;
         }
 
@@ -178,7 +155,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
             TermModeBits = OS_BSP_CONSOLEMODE_NORMAL;
         }
 
-        snprintf(Buffer, sizeof(Buffer), "[%5s]", Prefix);
+        snprintf(Buffer, sizeof(Buffer), "[%5s]", UtAssert_GetCaseTypeAbbrev(MessageType));
 
         if (TermModeBits != OS_BSP_CONSOLEMODE_NORMAL)
         {


### PR DESCRIPTION
**Describe the contribution**
Add two more test case variants, similar to NA, where failure of the test case does not translate to failure of the overall
test.

The additional cases have different levels of default visibility, and may be handled differently by the end user.  That is, some
tests may be skipped because they are truly NA (and nothing for the user to do to change that) and some tests may be skipped
because the system was not set up in a way that allowed them to be run (and the user must fix that and re-run).

Fixes #1130

**Testing performed**
Build and run all tests.  Also modify CFE test to use new casetype, confirm working as expected.

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
Intended to differentiate between the nuances of all tests that are currently marked "N/A".  For some cases, its purely informational because the check does not apply, and nothing more needs to be done.  For other cases, a test might be skipped because the user did not start the system in a way where the tests could be run, and the user should correct that.  Lastly, for some cases, the condition was NA simply because there was more than one acceptable result for that test case.

For the first two, they should remain visible in the log by default, because they add some value to indicate what was (and was not) tested.  However the first requires no action of the user, and the second does require the user to correct something, so they should be marked differently.  The third is only relevant to software developers, it doesn't add much value to the log, so it can be hidden by default, but can still be seen by increasing the test verbosity to the debug level.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
