### PR TITLE
Fix #1133, Disable Unit Tests in CodeQL

### DIFF
--- a/.github/workflows/codeql-cfe-build.yml
+++ b/.github/workflows/codeql-cfe-build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   SIMULATION: native
-  ENABLE_UNIT_TESTS: true
+  ENABLE_UNIT_TESTS: false
   OMIT_DEPRECATED: true
   BUILDTYPE: release
 

--- a/.github/workflows/codeql-osal-default.yml
+++ b/.github/workflows/codeql-osal-default.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   SIMULATION: native
-  ENABLE_UNIT_TESTS: true
+  ENABLE_UNIT_TESTS: false
   OMIT_DEPRECATED: true
   BUILDTYPE: release
   PERMISSIVE_MODE: true


### PR DESCRIPTION
**Describe the contribution**
Fix #1133 

**Testing performed**
Tested on forked repo: https://github.com/ArielSAdamsNASA/osal/security/code-scanning?query=branch%3AUnit-test-off

**Expected behavior changes**
Disabled unit tests for both CodeQL workflows. Shows less code scanning alerts with it disabled. Alerts should only be shown for flight code. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal