### PR TITLE
Fix #1135, add bitmask assert macros

### DIFF
--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -81,14 +81,16 @@ typedef enum
  */
 typedef enum
 {
-    UtAssert_Compare_NONE, /**< invalid/not used, always false */
-    UtAssert_Compare_EQ,   /**< actual equals reference value */
-    UtAssert_Compare_NEQ,  /**< actual does not non equal reference value */
-    UtAssert_Compare_LT,   /**< actual less than reference (exclusive) */
-    UtAssert_Compare_GT,   /**< actual greater than reference (exclusive)  */
-    UtAssert_Compare_LTEQ, /**< actual less than or equal to reference (inclusive) */
-    UtAssert_Compare_GTEQ, /**< actual greater than reference (inclusive) */
-    UtAssert_Compare_MAX   /**< placeholder, not used */
+    UtAssert_Compare_NONE,          /**< invalid/not used, always false */
+    UtAssert_Compare_EQ,            /**< actual equals reference value */
+    UtAssert_Compare_NEQ,           /**< actual does not non equal reference value */
+    UtAssert_Compare_LT,            /**< actual less than reference (exclusive) */
+    UtAssert_Compare_GT,            /**< actual greater than reference (exclusive)  */
+    UtAssert_Compare_LTEQ,          /**< actual less than or equal to reference (inclusive) */
+    UtAssert_Compare_GTEQ,          /**< actual greater than reference (inclusive) */
+    UtAssert_Compare_BITMASK_SET,   /**< actual equals reference value */
+    UtAssert_Compare_BITMASK_UNSET, /**< actual equals reference value */
+    UtAssert_Compare_MAX            /**< placeholder, not used */
 } UtAssert_Compare_t;
 
 /**
@@ -403,6 +405,24 @@ typedef struct
 #define UtAssert_UINT32_GT(expr, ref)                                                                           \
     UtAssert_GenericUnsignedCompare((uint32)(expr), UtAssert_Compare_GT, (uint32)(ref), UtAssert_Radix_DECIMAL, \
                                     __FILE__, __LINE__, "", #expr, #ref)
+
+/**
+ * \brief Macro for checking that bits in a bit field are set
+ *
+ * Test Passes if all the bits specified in "mask" are set in "rawval"
+ */
+#define UtAssert_BITMASK_SET(rawval, mask)                                                          \
+    UtAssert_GenericUnsignedCompare((uint32)(rawval), UtAssert_Compare_BITMASK_SET, (uint32)(mask), \
+                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "", #rawval, #mask)
+
+/**
+ * \brief Macro for checking that bits in a bit field are unset
+ *
+ * Test Passes if none of the bits specified in "mask" are set in "rawval"
+ */
+#define UtAssert_BITMASK_UNSET(rawval, mask)                                                          \
+    UtAssert_GenericUnsignedCompare((uint32)(rawval), UtAssert_Compare_BITMASK_UNSET, (uint32)(mask), \
+                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "", #rawval, #mask)
 
 /**
  * \brief Macro for logging calls to a "void" function

--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -336,6 +336,12 @@ const char *UtAssert_GetOpText(UtAssert_Compare_t CompareType)
         case UtAssert_Compare_GTEQ: /* actual greater than reference (inclusive) */
             OpText = ">=";
             break;
+        case UtAssert_Compare_BITMASK_SET: /* bit(s) in reference are set in actual */
+            OpText = "&";
+            break;
+        case UtAssert_Compare_BITMASK_UNSET: /* bit(s) in reference are not set in actual */
+            OpText = "&~";
+            break;
         default: /* should never happen */
             OpText = "??";
             break;
@@ -370,6 +376,12 @@ bool UtAssert_GenericUnsignedCompare(unsigned long ActualValue, UtAssert_Compare
             break;
         case UtAssert_Compare_GTEQ: /* actual greater than reference (inclusive) */
             Result = (ActualValue >= ReferenceValue);
+            break;
+        case UtAssert_Compare_BITMASK_SET: /* bit(s) in reference are set in actual */
+            Result = (ActualValue & ReferenceValue) == ReferenceValue;
+            break;
+        case UtAssert_Compare_BITMASK_UNSET: /* bit(s) in reference are not set in actual */
+            Result = (ActualValue & ReferenceValue) == 0;
             break;
         default: /* should never happen */
             Result = false;


### PR DESCRIPTION
**Describe the contribution**
Add a pair of macros that can confirm a value has bits set or does not have bits set.  By using bitmask-aware macros, the logged
information can include both the raw/actual value as well as the specific bits being tested.

Fixes #1135

**Testing performed**
Build and run all tests

**Expected behavior changes**
None here, just adds new macros

**System(s) tested on**
Ubuntu

**Additional context**
Tested by updating the new time clock state checks to use this macro.  Looks a little something like this in the log:

```
[BEGIN] 94 Test Clock
[ INFO] time_current_test.c:126:Testing: CFE_TIME_GetClockState, CFE_TIME_GetClockInfo
[ PASS] 94.001 time_current_test.c:145 - CFE_TIME_GetClockInfo() (0x33e0) &~ CFE_TIME_FLAG_CLKSET (0x8000)
[ PASS] 94.002 time_current_test.c:148 - CFE_TIME_GetClockInfo() (0x33e0) & CFE_TIME_FLAG_SRCINT (0x2000)
[ PASS] 94.003 time_current_test.c:149 - CFE_TIME_GetClockInfo() (0x33e0) & CFE_TIME_FLAG_SIGPRI (0x1000)
[ PASS] 94.004 time_current_test.c:150 - CFE_TIME_GetClockInfo() (0x33e0) &~ CFE_TIME_FLAG_REFERR (0x10)
[ PASS] 94.005 time_current_test.c:151 - CFE_TIME_GetClockInfo() (0x33e0) &~ CFE_TIME_FLAG_UNUSED (0xf)
[  END] 94 Test Clock           TOTAL::5     PASS::5     FAIL::0     MIR::0     TSF::0     TTF::0     WARN::0
```

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
