### PR TITLE
Fix #1141, add typecast to memchr call

### DIFF
--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -149,7 +149,7 @@ void OS_ApplicationShutdown_Impl(void);
  ------------------------------------------------------------------*/
 static inline size_t OS_strnlen(const char *s, size_t maxlen)
 {
-    const char *end = memchr(s, 0, maxlen);
+    const char *end = (const char *)memchr(s, 0, maxlen);
     if (end != NULL)
     {
         /* actual length of string is difference */


### PR DESCRIPTION
**Describe the contribution**
This function is documented as returning `void*`, and on some compilers this requires an explicit cast to `const char*` to avoid a warning.

Fixes #1141

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
Isolated from draft contribution from @thesamprice in #1140

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
