### PR TITLE
Fix #1143, Regex update in coverage enforcement to match .0

### DIFF
--- a/.github/workflows/local_unit_test.yml
+++ b/.github/workflows/local_unit_test.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           # Current best possible branch coverage is all but 4, with associated issues for each missing case
           missed_branches=4
-          coverage_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[1-9]+[0-9]*")
+          coverage_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
 
           diff=$(echo $coverage_nums | awk '{ print $4 - $3 }')
-          if [ $(($diff > $missed_branches)) == 1 ]
+          if [ $diff -gt $missed_branches ]
           then 
             grep -A 3 "Overall coverage rate" lcov_out.txt
             echo "More than $missed_branches branches missed"


### PR DESCRIPTION
**Describe the contribution**
- Fix #1143 

Updates the regex to always get 4 matches (was ignoring .0%) so coverage enforcement will work as expected.  Also simplified the comparison.

**Testing performed**
Ran regex offline with various inputs including .0% case.

**Expected behavior changes**
CI will work more consistently

**System(s) tested on**
 - Hardware: Intel i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC