### PR TITLE
Fix #1154, add bsp-specific configuration flag registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ set(BSP_SRCLIST
     src/bsp/shared/src/bsp_default_app_run.c
     src/bsp/shared/src/bsp_default_app_startup.c
     src/bsp/shared/src/bsp_default_symtab.c
+    src/bsp/shared/src/bsp_default_resourcecfg.c
 )
 
 # Define the external "osal_bsp" static library target

--- a/src/bsp/shared/inc/bsp-impl.h
+++ b/src/bsp/shared/inc/bsp-impl.h
@@ -47,6 +47,7 @@
 #include "osapi-common.h"
 #include "osapi-bsp.h"
 #include "osapi-error.h"
+#include "osapi-idmap.h"
 
 /*
  * A set of simplified console control options
@@ -97,6 +98,14 @@ typedef struct
     char **           ArgV;          /* strings for boot/startup parameters */
     int32             AppStatus;     /* value which can be returned to the OS (0=nominal) */
     osal_blockcount_t MaxQueueDepth; /* Queue depth limit supported by BSP (0=no limit) */
+
+    /*
+     * Configuration registry - abstract integer flags to select platform-specific options
+     * for each resource type.  Flags are all platform-defined, and not every platform uses this
+     * feature.
+     */
+    uint32 ResoureConfig[OS_OBJECT_TYPE_USER];
+
 } OS_BSP_GlobalData_t;
 
 /*

--- a/src/bsp/shared/src/bsp_default_resourcecfg.c
+++ b/src/bsp/shared/src/bsp_default_resourcecfg.c
@@ -1,0 +1,65 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * File:  bsp_default_resourcecfg.c
+ *
+ * Purpose:
+ *   Simple integer key/value table lookup to allow BSP-specific flags/options
+ *   to be set for various resource types.  Meanings are all platform-defined.
+ *
+ */
+
+#include "osapi-idmap.h"
+#include "bsp-impl.h"
+
+/* ---------------------------------------------------------
+    OS_BSP_SetResourceTypeConfig()
+
+    Helper function to register BSP-specific options.
+   --------------------------------------------------------- */
+void OS_BSP_SetResourceTypeConfig(uint32 ResourceType, uint32 ConfigOptionValue)
+{
+    if (ResourceType < OS_OBJECT_TYPE_USER)
+    {
+        OS_BSP_Global.ResoureConfig[ResourceType] = ConfigOptionValue;
+    }
+}
+
+/* ---------------------------------------------------------
+    OS_BSP_GetResourceTypeConfig()
+
+    Helper function to register BSP-specific options.
+   --------------------------------------------------------- */
+uint32 OS_BSP_GetResourceTypeConfig(uint32 ResourceType)
+{
+    uint32 ConfigOptionValue;
+
+    if (ResourceType < OS_OBJECT_TYPE_USER)
+    {
+        ConfigOptionValue = OS_BSP_Global.ResoureConfig[ResourceType];
+    }
+    else
+    {
+        ConfigOptionValue = 0;
+    }
+
+    return ConfigOptionValue;
+}

--- a/src/os/inc/osapi-bsp.h
+++ b/src/os/inc/osapi-bsp.h
@@ -45,6 +45,22 @@
  */
 
 /*----------------------------------------------------------------
+   Function: OS_BSP_SetResourceTypeConfig
+
+    Purpose: Sets BSP/platform-specific flags for the given resource type
+             Flags and bit meanings are all platform defined.
+ ------------------------------------------------------------------*/
+void OS_BSP_SetResourceTypeConfig(uint32 ResourceType, uint32 ConfigOptionValue);
+
+/*----------------------------------------------------------------
+   Function: OS_BSP_SetResourceTypeConfig
+
+    Purpose: Gets BSP/platform-specific flags for the given resource type
+             Flags and bit meanings are all platform defined.
+ ------------------------------------------------------------------*/
+uint32 OS_BSP_GetResourceTypeConfig(uint32 ResourceType);
+
+/*----------------------------------------------------------------
    Function: OS_BSP_GetArgC
 
     Purpose: Obtain the number of boot arguments passed from the bootloader

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -34,6 +34,7 @@
 #include "os-shared-task.h"
 #include "os-shared-idmap.h"
 #include "os-shared-timebase.h"
+#include "osapi-bsp.h"
 
 #include <errnoLib.h>
 #include <taskLib.h>
@@ -132,7 +133,7 @@ int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
     /* see if the user wants floating point enabled. If
      * so, then se the correct option.
      */
-    vxflags = 0;
+    vxflags = OS_BSP_GetResourceTypeConfig(OS_OBJECT_TYPE_OS_TASK);
     if (flags & OS_FP_ENABLED)
     {
         vxflags |= VX_FP_TASK;

--- a/src/ut-stubs/osapi-bsp-stubs.c
+++ b/src/ut-stubs/osapi-bsp-stubs.c
@@ -57,6 +57,22 @@ char *const *OS_BSP_GetArgV(void)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for OS_BSP_GetResourceTypeConfig()
+ * ----------------------------------------------------
+ */
+uint32 OS_BSP_GetResourceTypeConfig(uint32 ResourceType)
+{
+    UT_GenStub_SetupReturnBuffer(OS_BSP_GetResourceTypeConfig, uint32);
+
+    UT_GenStub_AddParam(OS_BSP_GetResourceTypeConfig, uint32, ResourceType);
+
+    UT_GenStub_Execute(OS_BSP_GetResourceTypeConfig, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(OS_BSP_GetResourceTypeConfig, uint32);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for OS_BSP_SetExitCode()
  * ----------------------------------------------------
  */
@@ -65,4 +81,17 @@ void OS_BSP_SetExitCode(int32 code)
     UT_GenStub_AddParam(OS_BSP_SetExitCode, int32, code);
 
     UT_GenStub_Execute(OS_BSP_SetExitCode, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_BSP_SetResourceTypeConfig()
+ * ----------------------------------------------------
+ */
+void OS_BSP_SetResourceTypeConfig(uint32 ResourceType, uint32 ConfigOptionValue)
+{
+    UT_GenStub_AddParam(OS_BSP_SetResourceTypeConfig, uint32, ResourceType);
+    UT_GenStub_AddParam(OS_BSP_SetResourceTypeConfig, uint32, ConfigOptionValue);
+
+    UT_GenStub_Execute(OS_BSP_SetResourceTypeConfig, Basic, NULL);
 }


### PR DESCRIPTION
**Describe the contribution**
Adds a simple BSP API to get/set integer flags for each resource type.  All bits are platform-defined, so this can be used to store any arbitrary platform flag.

Initial use case is for setting task flags on vxWorks platforms which require a certain task flag to be set.

Fixes #1154

**Testing performed**
Build and sanity check CFE, run all tests.

**Expected behavior changes**
None on the framework build.  However this feature can be used internally to get around an issue where some vxWorks task flags need to be set only on one specific platform.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
