### PR TITLE
Fix #1153, add os-specifc socket flag function

### DIFF
--- a/src/os/shared/inc/os-shared-sockets.h
+++ b/src/os/shared/inc/os-shared-sockets.h
@@ -188,5 +188,6 @@ int32 OS_SocketAddrSetPort_Impl(OS_SockAddr_t *Addr, uint16 PortNum);
  * Not normally called outside the local unit, except during unit test
  */
 void OS_CreateSocketName(const OS_object_token_t *token, const OS_SockAddr_t *Addr, const char *parent_name);
+void OS_SetSocketDefaultFlags_Impl(const OS_object_token_t *token);
 
 #endif /* OS_SHARED_SOCKETS_H */

--- a/src/os/vxworks/CMakeLists.txt
+++ b/src/os/vxworks/CMakeLists.txt
@@ -65,6 +65,7 @@ if (OSAL_CONFIG_INCLUDE_NETWORK)
     list(APPEND VXWORKS_IMPL_SRCLIST
 	src/os-impl-network.c
         ../portable/os-impl-bsd-sockets.c   # Use BSD socket layer implementation
+        src/os-impl-sockets.c               # Additional vxworks-specific code to handle socket flags
     )
 else()
     list(APPEND VXWORKS_IMPL_SRCLIST

--- a/src/os/vxworks/inc/os-impl-sockets.h
+++ b/src/os/vxworks/inc/os-impl-sockets.h
@@ -29,6 +29,7 @@
 #define OS_IMPL_SOCKETS_H
 
 #include "os-impl-io.h"
+#include "os-shared-globaldefs.h"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -37,25 +38,19 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <hostLib.h>
+#include <ioLib.h>
 
 /*
- * Socket descriptors should be usable with the select() API
+ * Override the socket flag set routine on this platform.
+ * This is required because some versions of VxWorks do not support
+ * the standard POSIX fcntl() opcodes, and must use ioctl() instead.
  */
-#define OS_IMPL_SOCKET_SELECTABLE true
-
-/*
- * Use the O_NONBLOCK flag on sockets
- *
- * NOTE: the fcntl() F_GETFL/F_SETFL opcodes that set descriptor flags may not
- * work correctly on some version of VxWorks.
- *
- * This flag is not strictly required, things still mostly work without it,
- * but lack of this mode does introduce some potential race conditions if more
- * than one task attempts to use the same descriptor handle at the same time.
- */
-#define OS_IMPL_SOCKET_FLAGS O_NONBLOCK
+#define OS_IMPL_SET_SOCKET_FLAGS(impl) OS_VxWorks_SetSocketFlags_Impl(impl)
 
 /* The "in.h" header file supplied in VxWorks 6.9 is missing the "in_port_t" typedef */
 typedef u_short in_port_t;
+
+/* VxWorks-specific helper function to configure the socket flags on a connection */
+void OS_VxWorks_SetSocketFlags_Impl(const OS_object_token_t *token);
 
 #endif /* OS_IMPL_SOCKETS_H */

--- a/src/os/vxworks/src/os-impl-sockets.c
+++ b/src/os/vxworks/src/os-impl-sockets.c
@@ -1,0 +1,64 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-sockets.c
+ * \ingroup  vxworks
+ * \author   joseph.p.hickey@nasa.gov
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-vxworks.h"
+#include "os-shared-idmap.h"
+#include "os-impl-io.h"
+#include "os-impl-sockets.h"
+
+/****************************************************************************************
+                                INITIALIZATION FUNCTION
+ ***************************************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_VxWorks_ModuleAPI_Impl_Init
+ *
+ *  Purpose: Local helper routine, not part of OSAL API.
+ *
+ *-----------------------------------------------------------------*/
+void OS_VxWorks_SetSocketFlags_Impl(const OS_object_token_t *token)
+{
+    OS_impl_file_internal_record_t *impl;
+    int                             os_flags;
+
+    impl = OS_OBJECT_TABLE_GET(OS_impl_filehandle_table, *token);
+
+    /* Use ioctl/FIONBIO on this platform, rather than standard fcntl() */
+    os_flags = 1;
+    if (ioctl(impl->fd, FIONBIO, &os_flags) == -1)
+    {
+        /* No recourse if ioctl fails - just report the error and move on. */
+        OS_DEBUG("ioctl(FIONBIO): %s\n", strerror(errno));
+    }
+
+    impl->selectable = true;
+}

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_ioLib.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_ioLib.h
@@ -37,6 +37,7 @@
 
 #define OCS_FIOCHKDSK  0x1E01
 #define OCS_FIOUNMOUNT 0x1E02
+#define OCS_FIONBIO    0x1E03
 
 /* ----------------------------------------- */
 /* types normally defined in ioLib.h */

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-sockets-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-sockets-impl-stubs.c
@@ -29,6 +29,18 @@
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for OS_SetSocketDefaultFlags_Impl()
+ * ----------------------------------------------------
+ */
+void OS_SetSocketDefaultFlags_Impl(const OS_object_token_t *token)
+{
+    UT_GenStub_AddParam(OS_SetSocketDefaultFlags_Impl, const OS_object_token_t *, token);
+
+    UT_GenStub_Execute(OS_SetSocketDefaultFlags_Impl, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for OS_SocketAccept_Impl()
  * ----------------------------------------------------
  */

--- a/src/unit-test-coverage/vxworks/CMakeLists.txt
+++ b/src/unit-test-coverage/vxworks/CMakeLists.txt
@@ -15,6 +15,7 @@ set(VXWORKS_MODULE_LIST
     network
     queues
     shell
+    sockets
     symtab
     tasks
     timebase

--- a/src/unit-test-coverage/vxworks/adaptors/CMakeLists.txt
+++ b/src/unit-test-coverage/vxworks/adaptors/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(ut-adaptor-${SETNAME} STATIC
     src/ut-adaptor-mutex.c
     src/ut-adaptor-queues.c
     src/ut-adaptor-filetable-stub.c
+    src/ut-adaptor-sockets.c
     src/ut-adaptor-symtab.c
     src/ut-adaptor-tasks.c
     src/ut-adaptor-timebase.c

--- a/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-sockets.h
+++ b/src/unit-test-coverage/vxworks/adaptors/inc/ut-adaptor-sockets.h
@@ -20,24 +20,16 @@
 
 /**
  * \file
- * \ingroup ut-stubs
+ * \ingroup adaptors
  *
- * OSAL coverage stub replacement for ioLib.h
+ * Declarations and prototypes for ut-adaptor-symtab
  */
 
-#ifndef OVERRIDE_IOLIB_H
-#define OVERRIDE_IOLIB_H
+#ifndef UT_ADAPTOR_SOCKETS_H
+#define UT_ADAPTOR_SOCKETS_H
 
-#include "OCS_ioLib.h"
-#include <vxWorks.h>
+#include "common_types.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in ioLib.h */
-/* ----------------------------------------- */
+void UT_SocketTest_CallVxWorksSetFlags_Impl(uint32 index);
 
-#define FIOCHKDSK  OCS_FIOCHKDSK
-#define FIOUNMOUNT OCS_FIOUNMOUNT
-#define FIONBIO    OCS_FIONBIO
-#define ioctl      OCS_ioctl
-
-#endif /* OVERRIDE_IOLIB_H */
+#endif /* UT_ADAPTOR_SOCKETS_H */

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-sockets.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-sockets.c
@@ -19,25 +19,26 @@
  */
 
 /**
- * \file
- * \ingroup ut-stubs
+ * \file     ut-adaptor-sockets.c
+ * \ingroup  adaptors
+ * \author   joseph.p.hickey@nasa.gov
  *
- * OSAL coverage stub replacement for ioLib.h
  */
 
-#ifndef OVERRIDE_IOLIB_H
-#define OVERRIDE_IOLIB_H
+/* pull in the OSAL configuration */
+#include "osconfig.h"
+#include "ut-adaptor-sockets.h"
 
-#include "OCS_ioLib.h"
-#include <vxWorks.h>
+#include "os-vxworks.h"
+#include "os-shared-idmap.h"
+#include "os-impl-sockets.h"
 
-/* ----------------------------------------- */
-/* mappings for declarations in ioLib.h */
-/* ----------------------------------------- */
+/*
+ * A UT-specific wrapper function to invoke the VxWorks "SetFlag" helper
+ */
+void UT_SocketTest_CallVxWorksSetFlags_Impl(uint32 index)
+{
+    OS_object_token_t token = {.obj_idx = index};
 
-#define FIOCHKDSK  OCS_FIOCHKDSK
-#define FIOUNMOUNT OCS_FIOUNMOUNT
-#define FIONBIO    OCS_FIONBIO
-#define ioctl      OCS_ioctl
-
-#endif /* OVERRIDE_IOLIB_H */
+    OS_VxWorks_SetSocketFlags_Impl(&token);
+}

--- a/src/unit-test-coverage/vxworks/src/coveragetest-sockets.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-sockets.c
@@ -1,0 +1,68 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     coveragetest-no-module.c
+ * \ingroup  vxworks
+ * \author   joseph.p.hickey@nasa.gov
+ *
+ */
+#include "os-vxworks-coveragetest.h"
+#include "ut-adaptor-sockets.h"
+
+#include "OCS_ioLib.h"
+
+void Test_OS_VxWorks_SetSocketFlags_Impl(void)
+{
+    UtAssert_VOIDCALL(UT_SocketTest_CallVxWorksSetFlags_Impl(0));
+
+    UT_SetDefaultReturnValue(UT_KEY(OCS_ioctl), OCS_ERROR);
+    UtAssert_VOIDCALL(UT_SocketTest_CallVxWorksSetFlags_Impl(0));
+}
+
+/* ------------------- End of test cases --------------------------------------*/
+
+/* Osapi_Test_Setup
+ *
+ * Purpose:
+ *   Called by the unit test tool to set up the app prior to each test
+ */
+void Osapi_Test_Setup(void)
+{
+    UT_ResetState(0);
+}
+
+/*
+ * Osapi_Test_Teardown
+ *
+ * Purpose:
+ *   Called by the unit test tool to tear down the app after each test
+ */
+void Osapi_Test_Teardown(void) {}
+
+/* UtTest_Setup
+ *
+ * Purpose:
+ *   Registers the test cases to execute with the unit test tool
+ */
+void UtTest_Setup(void)
+{
+    ADD_TEST(OS_VxWorks_SetSocketFlags_Impl);
+}

--- a/src/unit-test-coverage/vxworks/ut-stubs/CMakeLists.txt
+++ b/src/unit-test-coverage/vxworks/ut-stubs/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(ut_vxworks_impl_stubs
     src/vxworks-os-impl-module-stubs.c
     src/vxworks-os-impl-mutex-stubs.c
     src/vxworks-os-impl-queue-stubs.c
+    src/vxworks-os-impl-sockets-stubs.c
     src/vxworks-os-impl-task-stubs.c
     src/vxworks-os-impl-timer-stubs.c
 )

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-sockets-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-sockets-stubs.c
@@ -19,25 +19,15 @@
  */
 
 /**
- * \file
- * \ingroup ut-stubs
+ * \file     vxworks-os-impl-socket-stubs.c
+ * \ingroup  ut-stubs
+ * \author   joseph.p.hickey@nasa.gov
  *
- * OSAL coverage stub replacement for ioLib.h
  */
+#include <string.h>
+#include <stdlib.h>
+#include "utstubs.h"
 
-#ifndef OVERRIDE_IOLIB_H
-#define OVERRIDE_IOLIB_H
+#include "os-shared-idmap.h"
 
-#include "OCS_ioLib.h"
-#include <vxWorks.h>
-
-/* ----------------------------------------- */
-/* mappings for declarations in ioLib.h */
-/* ----------------------------------------- */
-
-#define FIOCHKDSK  OCS_FIOCHKDSK
-#define FIOUNMOUNT OCS_FIOUNMOUNT
-#define FIONBIO    OCS_FIONBIO
-#define ioctl      OCS_ioctl
-
-#endif /* OVERRIDE_IOLIB_H */
+void OS_VxWorks_SetSocketFlags_Impl(const OS_object_token_t *token) {}


### PR DESCRIPTION
**Describe the contribution**
Adds the capability for the bsd sockets implementation to use a function provided by the OS layer to set the socket flags.

This allows VxWorks to have an alternative implementation that uses ioctl rather than fcntl to set the flags.

Fixes #1153

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
VxWorks will use `ioctl()` rather than `fcntl()` to set the socket flags

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
