### PR TITLE
Fix #1167, vxWorks intLib stub aliasing issue

### DIFF
--- a/src/unit-test-coverage/ut-stubs/src/vxworks-intLib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/vxworks-intLib-stubs.c
@@ -54,10 +54,12 @@ OCS_VOIDFUNCPTR *OCS_INUM_TO_IVEC(unsigned int ui)
     OCS_VOIDFUNCPTR *      VecTbl;
     static OCS_VOIDFUNCPTR DummyVec;
     size_t                 VecTblSize;
+    void *                 GenericPtr;
 
     if (Status == 0)
     {
-        UT_GetDataBuffer(UT_KEY(OCS_INUM_TO_IVEC), (void **)&VecTbl, &VecTblSize, NULL);
+        UT_GetDataBuffer(UT_KEY(OCS_INUM_TO_IVEC), &GenericPtr, &VecTblSize, NULL);
+        VecTbl = GenericPtr;
         if (VecTbl != NULL && ui < (VecTblSize / sizeof(OCS_VOIDFUNCPTR)))
         {
             VecTbl += ui;


### PR DESCRIPTION
**Describe the contribution**
Use a separate local variable rather than casting to (void **).

Fixes #1167 

**Testing performed**
Build with strict aliasing, confirm no warnings

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
