### PR TITLE
Fix #1166, recognize ifdef __cplusplus

### DIFF
--- a/ut_assert/scripts/generate_stubs.pl
+++ b/ut_assert/scripts/generate_stubs.pl
@@ -110,6 +110,7 @@ foreach my $hdr (@hdrlist)
     my $file = "";
     my $file_boilerplate;
     my $file_variadic;
+    my @ifdef_level = (1);
 
     # All header files start with some legal boilerplate comments
     # Take the first one and save it, so it can be put into the output.
@@ -125,7 +126,31 @@ foreach my $hdr (@hdrlist)
             # so it will be in a single "line" in the result.
             chomp if (s/\\$//);
         }
-        push(@lines, $_);
+
+        # detect "#ifdef" lines - some may need to be recognized.
+        # at the very least, any C++-specific bits need to be skipped.
+        # for now this just specifically looks for __cplusplus
+        if (/^\#(if\w+)\s+(.*)$/) {
+            my $check = $1;
+            my $cond = $2;
+            my $result = $ifdef_level[0];
+
+            if ($cond eq "__cplusplus" && $check eq "ifdef") {
+                $result = 0;
+            }
+
+            unshift(@ifdef_level, $result);
+        }
+        elsif (/^\#else/) {
+            # invert the last preprocessor condition
+            $ifdef_level[0] = $ifdef_level[0] ^ $ifdef_level[1];
+        }
+        elsif (/^\#endif/) {
+            shift(@ifdef_level);
+        }
+        elsif ($ifdef_level[0]) {
+            push(@lines, $_) ;
+        }
     }
     close(HDR);
 
@@ -163,7 +188,6 @@ foreach my $hdr (@hdrlist)
     foreach (@lines) {
         next if (/\btypedef\b/);        # ignore typedefs
         next if (/\bstatic inline\b/);  # ignore
-
 
         # discard "extern" qualifier
         # (but other qualifiers like "const" are OK and should be preserved, as
@@ -408,4 +432,3 @@ foreach my $basename (sort keys %{$publicapi}) {
 
     print "Generated $stubfile\n";
 }
-


### PR DESCRIPTION
**Describe the contribution**
Add feature to generate_stubs.pl input phase to recognize and skip over `#ifdef __cplusplus` blocks.  This makes it so it
can be used on C headers which are C++-enabled too.

The logic should be fairly easy to extend to other `#if` conditionals as needed.

Fixes #1166

**Testing performed**
Generate stubs for a C header that has C++-aware extern wrappers in it.

**Expected behavior changes**
Stubs for prototypes inside C++ extern "C" block are generated successfully.

**System(s) tested on**
Ubuntu

**Additional context**
Tempting to attempt to use gcc proprocessor here (-E) to get full evaluation of all preprocessor logic, but this would depend on the target headers and may introduce more problems than it solves.  So in the interim this just adds a local check that specifically looks for `#ifdef __cplusplus` and filters out everything inside this block.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
