### PR TITLE
Fix #1139, Remove extern in stub prototypes

### DIFF
--- a/ut_assert/scripts/generate_stubs.pl
+++ b/ut_assert/scripts/generate_stubs.pl
@@ -327,7 +327,7 @@ foreach my $basename (sort keys %{$publicapi}) {
             if ($fileapi->{$funcname}->{variadic}) {
                 $args .= ", va_list";
             }
-            print OUT "extern void ".$handler_func->{$funcname}."($args);\n";
+            print OUT "void ".$handler_func->{$funcname}."($args);\n";
         }
     }
 


### PR DESCRIPTION
Removed 'extern' from function prototypes in stub generator script #1139.
