### PR TITLE
Fix #1184, Static Analysis Add Duplicate and Remove Main Push

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,13 +3,26 @@ name: Static Analysis
 # Run this workflow every time a new commit pushed to your repository
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
-
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          
   static-analysis:
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     name: Run cppcheck
     runs-on: ubuntu-18.04
     timeout-minutes: 15


### PR DESCRIPTION
**Describe the contribution**
Fixes #1184 

**Testing performed**
Forked repo, https://github.com/ArielSAdamsNASA/osal/actions/runs/1372520583.

**Expected behavior changes**
Static analysis workflow should run on all branches for both pull requests and push. The duplicate job prevents two instances of the static analysis to run at the same time. Pull requests are prioritized. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal