### PR TITLE
Fix #1183, Add Duplicate Check to Local Unit Test

### DIFF
--- a/.github/workflows/local_unit_test.yml
+++ b/.github/workflows/local_unit_test.yml
@@ -5,8 +5,23 @@ on:
   pull_request:
 
 jobs:
+  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
+  check-for-duplicates:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   Local-Unit-Test:
+    needs: check-for-duplicates
+    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-18.04
     timeout-minutes: 15
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #1183 

**Testing performed**
https://github.com/ArielSAdamsNASA/osal/actions/runs/1372766073

**Expected behavior changes**
Skip workflows on push for local unit tests if there is a duplicate workflow. 


**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal