### PR TITLE
Fix #1188, Reuse CodeQL, Static Analysis, Format Check

### DIFF
--- a/.github/workflows/codeql-cfe-build.yml
+++ b/.github/workflows/codeql-cfe-build.yml
@@ -4,107 +4,11 @@ on:
   push:
   pull_request:
 
-env:
-  SIMULATION: native
-  ENABLE_UNIT_TESTS: true
-  OMIT_DEPRECATED: true
-  BUILDTYPE: release
-
 jobs:
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
-  check-for-duplicates:
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          concurrent_skipping: 'same_content'
-          skip_after_successful_duplicate: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-
-  CodeQL-Security-Build:
-    needs: check-for-duplicates
-    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout bundle
-        uses: actions/checkout@v2
-        with:
-          repository: nasa/cFS
-          submodules: true
-
-      - name: Checkout submodule
-        uses: actions/checkout@v2
-        with:
-          path: osal
-
-      - name: Check versions
-        run: git submodule
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-         languages: c
-         config-file: nasa/cFS/.github/codeql/codeql-security.yml@main
-
-      - name: Set up for build
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-          make prep
-
-      - name: Build
-        run: make -j native/default_cpu1/osal/
-
-      - name: Run tests
-        run: (cd build/native/default_cpu1/osal && make test)
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
-
-  CodeQL-Coding-Standard-Build:
-    needs: check-for-duplicates
-    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout bundle
-        uses: actions/checkout@v2
-        with:
-          repository: nasa/cFS
-          submodules: true
-
-      - name: Checkout submodule
-        uses: actions/checkout@v2
-        with:
-          path: osal
-
-      - name: Check versions
-        run: git submodule
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-         languages: c
-         config-file: nasa/cFS/.github/codeql/codeql-coding-standard.yml@main
-
-      - name: Set up for build
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-          make prep
-
-      - name: Build
-        run: make -j native/default_cpu1/osal/
-
-      - name: Run tests
-        run: (cd build/native/default_cpu1/osal && make test)
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+  codeql:
+    name: CodeQl Analysis
+    uses: nasa/cFS/.github/workflows/codeql-build.yml@main
+    with: 
+      make-prep: 'make prep'
+      make: 'make -j native/default_cpu1/osal/'
+      tests: '(cd build/native/default_cpu1/osal && make test)'

--- a/.github/workflows/codeql-osal-default.yml
+++ b/.github/workflows/codeql-osal-default.yml
@@ -4,81 +4,11 @@ on:
   push:
   pull_request:
 
-env:
-  SIMULATION: native
-  ENABLE_UNIT_TESTS: true
-  OMIT_DEPRECATED: true
-  BUILDTYPE: release
-  PERMISSIVE_MODE: true
-
 jobs:
-
-  #Checks for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action. 
-  check-for-duplicates:
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          concurrent_skipping: 'same_content'
-          skip_after_successful_duplicate: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-          
-  CodeQL-Security-Build:
-    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
-    needs: check-for-duplicates
-    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout submodule
-        uses: actions/checkout@v2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-         languages: c
-         config-file: nasa/cFS/.github/codeql/codeql-security.yml@main
-
-      - name: Set up for build
-        run: |
-          cp Makefile.sample Makefile
-          make prep
-          
-      - name: Build
-        run: make -j 
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
-
-  CodeQL-Coding-Standard-Build:
-    #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
-    needs: check-for-duplicates
-    if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout submodule
-        uses: actions/checkout@v2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-         languages: c
-         config-file: nasa/cFS/.github/codeql/codeql-coding-standard.yml@main
-
-      - name: Set up for build
-        run: |
-          cp Makefile.sample Makefile
-          make prep
-          
-      - name: Build
-        run: make -j 
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+  codeql:
+    name: CodeQl Analysis
+    uses: nasa/cFS/.github/workflows/codeql-build.yml@main
+    with: 
+      setup: 'cd osal && cp Makefile.sample Makefile'
+      make-prep: 'cd osal && make prep'
+      make: 'cd osal && make -j'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,6 +1,6 @@
 name: Format Check
 
-# Run on main push and pull requests
+# Run on all push and pull requests
 on:
   push:
     branches:
@@ -8,46 +8,6 @@ on:
   pull_request:
 
 jobs:
-
-  static-analysis:
+  format-check:
     name: Run format check
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-
-      - name: Install format checker
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-10 main'
-          sudo apt-get update && sudo apt-get install clang-format-10
-
-      - name: Checkout bundle
-        uses: actions/checkout@v2
-        with:
-          repository: nasa/cFS
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: repo
-
-      - name: Generate format differences
-        run: |
-          cd repo
-          find . -name "*.[ch]" -exec clang-format-10 -i -style=file {} +
-          git diff > $GITHUB_WORKSPACE/style_differences.txt
-
-      - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: style_differences
-          path: style_differences.txt
-
-      - name: Error on differences
-        run: |
-          if [[ -s style_differences.txt ]];
-          then
-            cat style_differences.txt
-            exit -1
-          fi
+    uses: nasa/cFS/.github/workflows/format-check.yml@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,55 +1,13 @@
 name: Static Analysis
 
-# Run this workflow every time a new commit pushed to your repository
+# Run on all push and pull requests
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
-
   static-analysis:
     name: Run cppcheck
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    strategy:
-      fail-fast: false
-      matrix:
-        cppcheck: [all, osal]
-
-    steps:
-
-      - name: Install cppcheck
-        run: sudo apt-get install cppcheck -y
-
-        # Checks out a copy of the cfs bundle
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Run bundle cppcheck
-        if: ${{matrix.cppcheck =='all'}}
-        run: cppcheck --force --inline-suppr . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
-
-        # Run strict static analysis for embedded portions of osal
-      - name: osal strict cppcheck
-        if: ${{matrix.cppcheck =='osal'}}
-        run: |
-          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./src/bsp ./src/os 2> ./${{matrix.cppcheck}}_cppcheck_err.txt
-
-      - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{matrix.cppcheck}}-cppcheck-err
-          path: ./*cppcheck_err.txt
-
-      - name: Check for errors
-        run: |
-          if [[ -s ${{matrix.cppcheck}}_cppcheck_err.txt ]];
-          then
-            cat ${{matrix.cppcheck}}_cppcheck_err.txt
-            exit -1
-          fi
+    uses: nasa/cFS/.github/workflows/static-analysis.yml@main
+    with: 
+      strict-dir-list: './src/bsp ./src/os'


### PR DESCRIPTION
**Describe the contribution**
Fixes #1188 

**Testing performed**
Tested on forked repos.
OSAL Static Analysis Reuse: https://github.com/ArielSAdamsNASA/osal/actions/runs/1391621678
cFS Static Analysis Reuse: https://github.com/ArielSAdamsNASA/cFS-JSF-Rules/actions/runs/1391690020
OSAL CodeQL Reuse cFE Build: https://github.com/ArielSAdamsNASA/osal/runs/4023159610?check_suite_focus=true
OSAL CodeQL Reuse OSAL Default: https://github.com/ArielSAdamsNASA/osal/actions/runs/1390702434
cFS CodeQL Reuse: https://github.com/ArielSAdamsNASA/cFS-JSF-Rules/actions/runs/1390777421
OSAL Format Check Reuse: https://github.com/ArielSAdamsNASA/osal/actions/runs/1390702433
cFS Format Check: https://github.com/ArielSAdamsNASA/cFS-JSF-Rules/actions/runs/1390865379

**Expected behavior changes**
cFS will hold the workflows for CodeQL, Static Analysis, and Format Check. These workflows will be called by all OSAL to reuse. These workflows will not work until https://github.com/nasa/cFS/pull/386 is merged. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal
