### PR TITLE
Fix #1199, correct warnings on gcc11

### DIFF
--- a/src/unit-test-coverage/portable/src/coveragetest-bsd-sockets.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-bsd-sockets.c
@@ -316,10 +316,10 @@ void Test_OS_SocketRecvFrom_Impl(void)
 
 void Test_OS_SocketSendTo_Impl(void)
 {
-    OS_object_token_t    token = {0};
-    uint8                buffer[UT_BUFFER_SIZE];
-    OS_SockAddr_t        addr = {0};
-    struct OCS_sockaddr *sa   = (struct OCS_sockaddr *)&addr.AddrData;
+    OS_object_token_t    token                  = {0};
+    const uint8          buffer[UT_BUFFER_SIZE] = {0};
+    OS_SockAddr_t        addr                   = {0};
+    struct OCS_sockaddr *sa                     = (struct OCS_sockaddr *)&addr.AddrData;
 
     /* Set up token */
     token.obj_idx = UT_INDEX_0;
@@ -393,9 +393,9 @@ void Test_OS_SocketAddrToString_Impl(void)
 
 void Test_OS_SocketAddrFromString_Impl(void)
 {
-    char                 buffer[UT_BUFFER_SIZE];
-    OS_SockAddr_t        addr = {0};
-    struct OCS_sockaddr *sa   = (struct OCS_sockaddr *)&addr.AddrData;
+    const char           buffer[UT_BUFFER_SIZE] = "UT";
+    OS_SockAddr_t        addr                   = {0};
+    struct OCS_sockaddr *sa                     = (struct OCS_sockaddr *)&addr.AddrData;
 
     /* Bad family */
     sa->sa_family = -1;

--- a/src/unit-test-coverage/shared/src/coveragetest-clock.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-clock.c
@@ -50,9 +50,9 @@ void Test_OS_SetLocalTime(void)
      * Test Case For:
      * int32 OS_SetLocalTime(OS_time_t *time_struct)
      */
-    OS_time_t time_struct;
-    int32     expected = OS_SUCCESS;
-    int32     actual   = OS_SetLocalTime(&time_struct);
+    OS_time_t time_struct = OS_TimeAssembleFromMicroseconds(5, 12345);
+    int32     expected    = OS_SUCCESS;
+    int32     actual      = OS_SetLocalTime(&time_struct);
 
     UtAssert_True(actual == expected, "OS_SetLocalTime() (%ld) == OS_SUCCESS", (long)actual);
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -145,7 +145,7 @@ void Test_OS_TaskDetach_Impl(void)
      * Test Case For:
      * int32 OS_TaskDetach_Impl(const OS_object_token_t *token)
      */
-    OS_object_token_t token;
+    OS_object_token_t token = UT_TOKEN_0;
 
     /* no-op on VxWorks - always returns success */
     OSAPI_TEST_FUNCTION_RC(OS_TaskDetach_Impl(&token), OS_SUCCESS);

--- a/src/unit-tests/oscore-test/ut_oscore_task_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_task_test.c
@@ -605,7 +605,7 @@ void UT_os_task_get_info_test()
 **--------------------------------------------------------------------------------*/
 void UT_os_task_getid_by_sysdata_test()
 {
-    uint8     sysdata;
+    uint8     sysdata = 0;
     osal_id_t task_id;
 
     /*


### PR DESCRIPTION
**Describe the contribution**
- Fix #1199
These new warnings are detected by the new compiler. They are all places in unit test where an uninitialized value is passed via "const" pointer into a unit under test.  By definition a "const" pointer is always an input.

While the warning is pedantically true - should not pass an uninitialized struct as an input - these were all unit tests where the object value is a don't-care value, so it does not matter.  But to fix the warning, simply need to initialize a value before making the call.

Fixes #1199

**Testing performed**
Build and run all tests on GCC 11.2 (Ubuntu 21.10)

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
