### PR TITLE
Fix #1208, typesafe definition of osal_id_t

### DIFF
--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -91,10 +91,24 @@ extern "C"
     typedef size_t    cpusize;
     typedef ptrdiff_t cpudiff;
 
+#ifdef OSAL_OMIT_DEPRECATED
     /**
      * A type to be used for OSAL resource identifiers.
+     * This is a type-safe ID, and cannot be implicitly converted to an integer.
+     * Use the provided inline functions in osapi-idmap.h to interpret ID values.
      */
-    typedef uint32_t osal_id_t;
+    typedef struct
+    {
+        uint32_t v;
+    } osal_id_t;
+#else
+
+/**
+ * A type to be used for OSAL resource identifiers.
+ * This typedef is backward compatible with the IDs from older versions of OSAL
+ */
+typedef uint32 osal_id_t;
+#endif
 
     /**
      * A type used to represent a number of blocks or buffers

--- a/src/os/inc/osapi-idmap.h
+++ b/src/os/inc/osapi-idmap.h
@@ -80,7 +80,11 @@
  */
 static inline unsigned long OS_ObjectIdToInteger(osal_id_t object_id)
 {
+#ifdef OSAL_OMIT_DEPRECATED
+    return object_id.v;
+#else
     return object_id;
+#endif
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -98,7 +102,11 @@ static inline unsigned long OS_ObjectIdToInteger(osal_id_t object_id)
  */
 static inline osal_id_t OS_ObjectIdFromInteger(unsigned long value)
 {
+#ifdef OSAL_OMIT_DEPRECATED
+    return (osal_id_t) {value};
+#else
     return (osal_id_t)value;
+#endif
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -119,7 +127,7 @@ static inline osal_id_t OS_ObjectIdFromInteger(unsigned long value)
  */
 static inline bool OS_ObjectIdEqual(osal_id_t object_id1, osal_id_t object_id2)
 {
-    return (object_id1 == object_id2);
+    return (OS_ObjectIdToInteger(object_id1) == OS_ObjectIdToInteger(object_id2));
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -140,7 +148,7 @@ static inline bool OS_ObjectIdEqual(osal_id_t object_id1, osal_id_t object_id2)
  */
 static inline bool OS_ObjectIdDefined(osal_id_t object_id)
 {
-    return (object_id != 0);
+    return (OS_ObjectIdToInteger(object_id) != 0);
 }
 
 /*-------------------------------------------------------------------------------------*/


### PR DESCRIPTION
**Describe the contribution**
Modifies the osal_id_t typedef to be a non-integer value.  The intent is to catch cases where it inappropriately being used as an integer value.

This is transparent so long as the osal_id_t typedef and provided check and conversion routines are used.

Fixes #1208 

**Testing performed**
Build and sanity check CFE and OSAL with and without OSAL_OMIT_DEPRECATED flag

**Expected behavior changes**
When OSAL_OMIT_DEPRECATED is enabled (opt-in) this will catch misuse of OSAL IDs as integers, or failure to use correct `osal_id_t` typedef to hold the value.

**System(s) tested on**
Ubuntu 21.10

**Additional context**
OSAL and CFE should all be compliant, but CFS apps probably are not yet compliant with this.  Hence why it is "opt-in" via OSAL_OMIT_DEPRECATED flag, like other similar changes done in the past.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
