### PR TITLE
Fix #1210, Set output in OS_stat handler

### DIFF
--- a/src/ut-stubs/osapi-file-handlers.c
+++ b/src/ut-stubs/osapi-file-handlers.c
@@ -192,13 +192,20 @@ void UT_DefaultHandler_OS_TimedWrite(void *UserObj, UT_EntryKey_t FuncKey, const
 void UT_DefaultHandler_OS_stat(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     os_fstat_t *filestats = UT_Hook_GetArgValueByName(Context, "filestats", os_fstat_t *);
+    size_t      CopySize;
     int32       Status;
 
     UT_Stub_GetInt32StatusCode(Context, &Status);
 
     if (Status == OS_SUCCESS)
     {
-        UT_Stub_CopyToLocal(UT_KEY(OS_stat), filestats, sizeof(*filestats));
+        CopySize = UT_Stub_CopyToLocal(UT_KEY(OS_stat), filestats, sizeof(*filestats));
+
+        /* Ensure memory is set if not provided by test */
+        if (CopySize < sizeof(*filestats))
+        {
+            memset(filestats, 0, sizeof(*filestats));
+        }
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
- Fix #1210 
- Provides consistent default OS_stat handler behavior

**Testing performed**
Tested with FM that relies on default behavior, CI

**Expected behavior changes**
Avoids uninitialized variable risk in unit tests

**System(s) tested on**
 - Hardware: i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC