### PR TITLE
Fix #1214, Resolve UT uninitialized variable warnings

### DIFF
--- a/src/unit-test-coverage/ut-stubs/CMakeLists.txt
+++ b/src/unit-test-coverage/ut-stubs/CMakeLists.txt
@@ -172,6 +172,7 @@ add_library(ut_osapi_impl_stubs STATIC EXCLUDE_FROM_ALL
     src/os-shared-queue-impl-stubs.c
     src/os-shared-select-impl-stubs.c
     src/os-shared-shell-impl-stubs.c
+    src/os-shared-sockets-impl-handlers.c
     src/os-shared-sockets-impl-stubs.c
     src/os-shared-task-impl-stubs.c
     src/os-shared-timebase-impl-stubs.c

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-sockets-impl-handlers.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-sockets-impl-handlers.c
@@ -1,0 +1,53 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file
+ *
+ * Stub implementations for the functions defined in the OSAL API
+ *
+ * The stub implementation can be used for unit testing applications built
+ * on top of OSAL.  The stubs do not do any real function, but allow
+ * the return code to be crafted such that error paths in the application
+ * can be executed.
+ */
+
+#include "osapi-sockets.h" /* OSAL public API for this subsystem */
+#include "os-shared-sockets.h"
+#include "utstubs.h"
+
+/*
+ * -----------------------------------------------------------------
+ * Default handler implementation
+ * -----------------------------------------------------------------
+ */
+void UT_DefaultHandler_OS_SocketAddrGetPort_Impl(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    uint16 *PortNum = UT_Hook_GetArgValueByName(Context, "PortNum", uint16 *);
+    int32   status;
+
+    UT_Stub_GetInt32StatusCode(Context, &status);
+
+    if (status == OS_SUCCESS &&
+        UT_Stub_CopyToLocal(UT_KEY(OS_SocketAddrGetPort_Impl), PortNum, sizeof(*PortNum)) < sizeof(*PortNum))
+    {
+        *PortNum = 0;
+    }
+}

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-sockets-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-sockets-impl-stubs.c
@@ -27,6 +27,8 @@
 #include "os-shared-sockets.h"
 #include "utgenstub.h"
 
+void UT_DefaultHandler_OS_SocketAddrGetPort_Impl(void *, UT_EntryKey_t, const UT_StubContext_t *);
+
 /*
  * ----------------------------------------------------
  * Generated stub function for OS_SetSocketDefaultFlags_Impl()
@@ -88,7 +90,7 @@ int32 OS_SocketAddrGetPort_Impl(uint16 *PortNum, const OS_SockAddr_t *Addr)
     UT_GenStub_AddParam(OS_SocketAddrGetPort_Impl, uint16 *, PortNum);
     UT_GenStub_AddParam(OS_SocketAddrGetPort_Impl, const OS_SockAddr_t *, Addr);
 
-    UT_GenStub_Execute(OS_SocketAddrGetPort_Impl, Basic, NULL);
+    UT_GenStub_Execute(OS_SocketAddrGetPort_Impl, Basic, UT_DefaultHandler_OS_SocketAddrGetPort_Impl);
 
     return UT_GenStub_GetReturnValue(OS_SocketAddrGetPort_Impl, int32);
 }


### PR DESCRIPTION
**Describe the contribution**
- Fix #1214 

**Testing performed**
Built 32-bit and ran unit tests in valgrind, warnings squashed

**Expected behavior changes**
No more uninit variable warnings

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC