### PR TITLE
Fix #1216, Remove explicit filename doxygen comments

### DIFF
--- a/src/bsp/shared/src/osapi-bsp.c
+++ b/src/bsp/shared/src/osapi-bsp.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-bsp.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file  contains some of the OS APIs abstraction layer code

--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-bsd-select.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * Purpose: This file contains wrappers around the select() system call

--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-bsd-sockets.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * Purpose: This file contains the network functionality for

--- a/src/os/portable/os-impl-console-bsp.c
+++ b/src/os/portable/os-impl-console-bsp.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-console-bsp.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * Purpose:

--- a/src/os/portable/os-impl-no-loader.c
+++ b/src/os/portable/os-impl-no-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-loader.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file contains a module loader implementation for systems

--- a/src/os/portable/os-impl-no-network.c
+++ b/src/os/portable/os-impl-no-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-network.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file contains the network implementation for

--- a/src/os/portable/os-impl-no-shell.c
+++ b/src/os/portable/os-impl-no-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-shell.c
+ * \file
  *
  * No shell implementation, returns OS_ERR_NOT_IMPLEMENTED for calls
  */

--- a/src/os/portable/os-impl-no-sockets.c
+++ b/src/os/portable/os-impl-no-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-no-sockets.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * Purpose: All functions return OS_ERR_NOT_IMPLEMENTED.

--- a/src/os/portable/os-impl-no-symtab.c
+++ b/src/os/portable/os-impl-no-symtab.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-symtab.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file contains a symbol table implementation for systems

--- a/src/os/portable/os-impl-posix-dirs.c
+++ b/src/os/portable/os-impl-posix-dirs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-posix-dirs.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file Contains all of the api calls for manipulating files

--- a/src/os/portable/os-impl-posix-dl-loader.c
+++ b/src/os/portable/os-impl-posix-dl-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-posix-dl-loader.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file contains a module loader implementation for systems

--- a/src/os/portable/os-impl-posix-dl-symtab.c
+++ b/src/os/portable/os-impl-posix-dl-symtab.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-posix-dl-symtab.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * This file contains a module loader implementation for systems

--- a/src/os/portable/os-impl-posix-files.c
+++ b/src/os/portable/os-impl-posix-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-posix-files.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * This file Contains all of the api calls for manipulating files

--- a/src/os/portable/os-impl-posix-gettime.c
+++ b/src/os/portable/os-impl-posix-gettime.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-posix-gettime.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * This file contains implementation for OS_GetLocalTime() and OS_SetLocalTime()

--- a/src/os/portable/os-impl-posix-io.c
+++ b/src/os/portable/os-impl-posix-io.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file   os-impl-posix-io.c
+ * \file
  * \author joseph.p.hickey@nasa.gov
  *
  * This file contains generic calls for manipulating filehandles

--- a/src/os/portable/os-impl-posix-network.c
+++ b/src/os/portable/os-impl-posix-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-posix-network.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * This file contains the network functionality for

--- a/src/os/posix/src/os-impl-binsem.c
+++ b/src/os/posix/src/os-impl-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-binsem.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-common.c
+++ b/src/os/posix/src/os-impl-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-common.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-console.c
+++ b/src/os/posix/src/os-impl-console.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-console.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-countsem.c
+++ b/src/os/posix/src/os-impl-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-countsem.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-dirs.c
+++ b/src/os/posix/src/os-impl-dirs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-dirs.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-errors.c
+++ b/src/os/posix/src/os-impl-errors.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-errors.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-files.c
+++ b/src/os/posix/src/os-impl-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-files.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-filesys.c
+++ b/src/os/posix/src/os-impl-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-filesys.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-heap.c
+++ b/src/os/posix/src/os-impl-heap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-heap.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-idmap.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-loader.c
+++ b/src/os/posix/src/os-impl-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-loader.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-mutex.c
+++ b/src/os/posix/src/os-impl-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-mutex.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-no-module.c
+++ b/src/os/posix/src/os-impl-no-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-module.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-queues.c
+++ b/src/os/posix/src/os-impl-queues.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-queues.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-shell.c
+++ b/src/os/posix/src/os-impl-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-shell.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-tasks.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-timebase.c
+ * \file
  * \ingroup  posix
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-binsem.c
+++ b/src/os/rtems/src/os-impl-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-binsem.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-common.c
+++ b/src/os/rtems/src/os-impl-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-common.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-console.c
+++ b/src/os/rtems/src/os-impl-console.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-console.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-countsem.c
+++ b/src/os/rtems/src/os-impl-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-countsem.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-dirs.c
+++ b/src/os/rtems/src/os-impl-dirs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-dirs.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-errors.c
+++ b/src/os/rtems/src/os-impl-errors.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-errors.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-files.c
+++ b/src/os/rtems/src/os-impl-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-files.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-filesys.c
+++ b/src/os/rtems/src/os-impl-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-filesys.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-heap.c
+++ b/src/os/rtems/src/os-impl-heap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-heap.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-idmap.c
+++ b/src/os/rtems/src/os-impl-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-idmap.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-loader.c
+++ b/src/os/rtems/src/os-impl-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-loader.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-mutex.c
+++ b/src/os/rtems/src/os-impl-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-mutex.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-network.c
+++ b/src/os/rtems/src/os-impl-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-network.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-no-module.c
+++ b/src/os/rtems/src/os-impl-no-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-module.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-queues.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-tasks.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-timebase.c
+ * \file
  * \ingroup  rtems
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-binsem.c
+++ b/src/os/shared/src/osapi-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-binsem.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-clock.c
+++ b/src/os/shared/src/osapi-clock.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-clock.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-common.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-countsem.c
+++ b/src/os/shared/src/osapi-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-countsem.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-debug.c
+++ b/src/os/shared/src/osapi-debug.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-debug.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-dir.c
+++ b/src/os/shared/src/osapi-dir.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-dir.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-errors.c
+++ b/src/os/shared/src/osapi-errors.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-errors.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-file.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-filesys.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-heap.c
+++ b/src/os/shared/src/osapi-heap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-heap.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-idmap.c
+++ b/src/os/shared/src/osapi-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-idmap.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-module.c
+++ b/src/os/shared/src/osapi-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-module.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-mutex.c
+++ b/src/os/shared/src/osapi-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-mutex.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-network.c
+++ b/src/os/shared/src/osapi-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-network.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-printf.c
+++ b/src/os/shared/src/osapi-printf.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-printf.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-queue.c
+++ b/src/os/shared/src/osapi-queue.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-queue.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-select.c
+++ b/src/os/shared/src/osapi-select.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-select.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-shell.c
+++ b/src/os/shared/src/osapi-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shell.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-sockets.c
+++ b/src/os/shared/src/osapi-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-sockets.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-task.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-time.c
+++ b/src/os/shared/src/osapi-time.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-time.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-timebase.c
+++ b/src/os/shared/src/osapi-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-timebase.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/shared/src/osapi-version.c
+++ b/src/os/shared/src/osapi-version.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-version.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-binsem.c
+++ b/src/os/vxworks/src/os-impl-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-binsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-common.c
+++ b/src/os/vxworks/src/os-impl-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-common.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-console.c
+++ b/src/os/vxworks/src/os-impl-console.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-console.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-countsem.c
+++ b/src/os/vxworks/src/os-impl-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-countsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-dirs-globals.c
+++ b/src/os/vxworks/src/os-impl-dirs-globals.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-dirs.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-errors.c
+++ b/src/os/vxworks/src/os-impl-errors.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-errors.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-files.c
+++ b/src/os/vxworks/src/os-impl-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-files.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-filesys.c
+++ b/src/os/vxworks/src/os-impl-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-filesys.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-heap.c
+++ b/src/os/vxworks/src/os-impl-heap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-heap.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-idmap.c
+++ b/src/os/vxworks/src/os-impl-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-idmap.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-loader.c
+++ b/src/os/vxworks/src/os-impl-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-loader.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-mutex.c
+++ b/src/os/vxworks/src/os-impl-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-mutex.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-network.c
+++ b/src/os/vxworks/src/os-impl-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-network.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-no-module.c
+++ b/src/os/vxworks/src/os-impl-no-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-no-module.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-queues.c
+++ b/src/os/vxworks/src/os-impl-queues.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-queues.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-shell.c
+++ b/src/os/vxworks/src/os-impl-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-shell.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-sockets.c
+++ b/src/os/vxworks/src/os-impl-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-sockets.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-symtab.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-tasks.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/os/vxworks/src/os-impl-timebase.c
+++ b/src/os/vxworks/src/os-impl-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-impl-timebase.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-files.c
+++ b/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-portable-posix-files.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
+++ b/src/unit-test-coverage/portable/adaptors/src/ut-adaptor-portable-posix-io.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-portable-posix-io.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-bsd-select.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-bsd-select.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  */

--- a/src/unit-test-coverage/portable/src/coveragetest-console-bsp.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-console-bsp.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-console-bsp.c
+ * \file
  * \ingroup  portable
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/portable/src/coveragetest-no-loader.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-no-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-no-loader.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  */

--- a/src/unit-test-coverage/portable/src/coveragetest-no-shell.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-no-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-no-shell.c
+ * \file
  * \ingroup  portable
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-dirs.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-dirs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-posix-dirs.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  */

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-posix-files.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  */

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-gettime.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-gettime.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-posix-gettime.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  */

--- a/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-posix-io.c
+ * \file
  * \ingroup  portable
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/adaptors/src/ut-adaptor-module.c
+++ b/src/unit-test-coverage/shared/adaptors/src/ut-adaptor-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-module.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-binsem.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-clock.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-clock.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-clock.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-common.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-common.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-countsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-countsem.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-dir.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-dir.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-dir.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-errors.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-errors.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-errors.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-file.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-file.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-file.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-filesys.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-heap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-heap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-heap.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-idmap.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-module.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-module.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-mutex.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-mutex.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-network.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-network.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-printf.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-printf.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-printf.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-queue.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-queue.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-queue.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-select.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-select.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-select.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-shell.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-shell.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-sockets.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-sockets.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-task.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-task.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-task.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-time.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-time.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-time.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-timebase.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/coveragetest-version.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-version.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-version.c
+ * \file
  * \ingroup  shared
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/shared/src/os-shared-coverage-support.c
+++ b/src/unit-test-coverage/shared/src/os-shared-coverage-support.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     os-shared-coverage-support.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/bsp-console-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/bsp-console-impl-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     bsp-console-impl-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-file-impl-handlers.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-file-impl-handlers.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-utstub-idmap.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * Stub implementations for the functions defined in the OSAL API

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-filesys-impl-handlers.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-filesys-impl-handlers.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-utstub-idmap.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * Stub implementations for the functions defined in the OSAL API

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-idmap-handlers.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-idmap-handlers.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-utstub-idmap.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * Stub implementations for the functions defined in the OSAL API

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-network-impl-handlers.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-network-impl-handlers.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-utstub-idmap.c
+ * \file
  * \author   joseph.p.hickey@nasa.gov
  *
  * Stub implementations for the functions defined in the OSAL API

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-binsem-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-binsem-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-binsem-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-common-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-common-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-common-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-console-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-console-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-console-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-countsem-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-countsem-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-countsem-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-dir-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-dir-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-dir-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-error-impl-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-error-impl-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-error-impl-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-filesys-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-filesys-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-filesys-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-idmap-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-idmap-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-idmap-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-module-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-module-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-module-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-mutex-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-mutex-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-mutex-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-queue-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-queue-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-queue-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-stream-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-stream-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-stream-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-task-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-task-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-task-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-timebase-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-timebase-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-timebase-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/osapi-shared-timecb-table-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/osapi-shared-timecb-table-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     osapi-shared-timecb-table-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/sys-select-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/sys-select-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     bsd-select-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/vxworks-hostLib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/vxworks-hostLib-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-hostLib-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/ut-stubs/src/vxworks-symLib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/vxworks-symLib-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-symLib-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-binsem.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-binsem.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-common.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-common.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-console.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-console.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-console.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-countsem.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-countsem.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-dirs.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-dirs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-dirs.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-dirtable-stub.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-dirtable-stub.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-filetable-stub.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-files.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-files.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filesys.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-filesys.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filetable-stub.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-filetable-stub.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-filetable-stub.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-idmap.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-idmap.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-loader.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-loader.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-mutex.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-mutex.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-queues.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-queues.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-queues.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-sockets.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-sockets.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-symtab.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-symtab.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-symtab.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-tasks.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-tasks.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-tasks.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-timebase.c
+++ b/src/unit-test-coverage/vxworks/adaptors/src/ut-adaptor-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     ut-adaptor-timebase.c
+ * \file
  * \ingroup  adaptors
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-binsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-binsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-common.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-common.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-common.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-console.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-console.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-console.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-countsem.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-countsem.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-countsem.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-dirs-globals.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-dirs-globals.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-dirs-globals.c
+ * \file
  * \ingroup  vxworks
  * \author   steven.seeger@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-files.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-files.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-files.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-filesys.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-heap.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-heap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-heap.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-idmap.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-loader.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-loader.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-mutex.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-mutex.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-mutex.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-network.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-network.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-network.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-no-module.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-no-module.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-no-module.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-queues.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-queues.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-queues.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-shell.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-sockets.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-sockets.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-no-module.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-symtab.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-tasks.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-timebase.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     coveragetest-timebase.c
+ * \file
  * \ingroup  vxworks
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-binsem-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-binsem-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-binsem-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-common-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-common-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-common-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-countsem-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-countsem-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-countsem-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-dir-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-dir-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-dir-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-file-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-file-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-file-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-idmap-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-idmap-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-idmap-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-module-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-module-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-module-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-mutex-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-mutex-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-mutex-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-queue-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-queue-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-queue-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-sockets-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-sockets-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-socket-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-task-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-task-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-task-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-timer-stubs.c
+++ b/src/unit-test-coverage/vxworks/ut-stubs/src/vxworks-os-impl-timer-stubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file     vxworks-os-impl-timer-stubs.c
+ * \file
  * \ingroup  ut-stubs
  * \author   joseph.p.hickey@nasa.gov
  *

--- a/src/ut-stubs/utstub-helpers.h
+++ b/src/ut-stubs/utstub-helpers.h
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file utstub-helpers.h
+ * \file
  *
  * Internal header file for OSAL UT stub functions
  *

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -19,7 +19,7 @@
  */
 
 /**
- * \file utstubs.c
+ * \file
  *
  *  Created on: Feb 25, 2015
  *      Author: joseph.p.hickey@nasa.gov


### PR DESCRIPTION
**Describe the contribution**
- Fix #1216

**Testing performed**
Make doc, observe no filename warnings

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC