### PR TITLE
Fix #1218, Add ut_assert to doxygen and fix warnings

### DIFF
--- a/docs/osal-detaildesign.doxyfile.in
+++ b/docs/osal-detaildesign.doxyfile.in
@@ -5,3 +5,5 @@
 INPUT    += @osal_MISSION_DIR@/src/os
 INPUT    += @osal_MISSION_DIR@/src/bsp
 
+# Include ut_assert documentation in detail design document
+INPUT    += @osal_MISSION_DIR@/ut_assert

--- a/src/os/portable/os-impl-bsd-select.c
+++ b/src/os/portable/os-impl-bsd-select.c
@@ -126,9 +126,10 @@ static int32 OS_FdSet_ConvertIn_Impl(int *os_maxfd, fd_set *os_set, const OS_FdS
  *
  * This un-sets bits in OSAL_set that are set in the OS_set
  *
- * \param[in]      OS_set   The fd_set from select
- * \param[in, out] OSAL_set The OS_FdSet updated by this helper
- *-----------------------------------------------------------------*/
+ * \param[in]     OS_set   The fd_set from select
+ * \param[in,out] OSAL_set The OS_FdSet updated by this helper
+ */
+/*-----------------------------------------------------------------*/
 static void OS_FdSet_ConvertOut_Impl(fd_set *OS_set, OS_FdSet *OSAL_set)
 {
     size_t       offset;

--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -818,7 +818,7 @@ void UtAssert_Message(uint8 MessageType, const char *File, uint32 Line, const ch
  * \param SubsysName   The subsystem under test (abbreviated name)
  * \param ShortDesc    Short description of the test case
  * \param SegmentNum   Sequence among the overall/global test Segments
- * \param TestDescr    Sequence within the current test Segment
+ * \param SegmentSeq   Sequence within the current test Segment
  */
 void UtAssert_DoReport(const char *File, uint32 LineNum, uint32 SegmentNum, uint32 SegmentSeq, uint8 MessageType,
                        const char *SubsysName, const char *ShortDesc);
@@ -831,7 +831,7 @@ void UtAssert_DoReport(const char *File, uint32 LineNum, uint32 SegmentNum, uint
  * Like the UtAssert_DoReport() function, this is typically done as a message on the console/log however
  * it might be different for embedded targets.
  *
- * \param Appname       The application under test
+ * \param SegmentName   The segment under test
  * \param TestCounters  Counter object for the completed test
  */
 void UtAssert_DoTestSegmentReport(const char *SegmentName, const UtAssert_TestCounter_t *TestCounters);

--- a/ut_assert/inc/utbsp.h
+++ b/ut_assert/inc/utbsp.h
@@ -67,7 +67,8 @@ void UT_BSP_Setup(void);
  *
  * This is just a hook for the BSP to be informed of the start-of-test event and may be a no-op.
  *
- * \param Appname Name of current test segment
+ * \param[in] SegmentNumber Number of current test segment
+ * \param[in] SegmentName   Name of current test segment
  */
 void UT_BSP_StartTestSegment(uint32 SegmentNumber, const char *SegmentName);
 

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -212,7 +212,7 @@ void UT_SetDataBuffer(UT_EntryKey_t FuncKey, void *DataBuffer, size_t BufferSize
  *
  * \param FuncKey The stub function to reference.
  * \param DataBuffer Set to Pointer to data buffer that is associated with the stub function (output)
- * \param BufferSize Set to Maximum Size of data buffer (output)
+ * \param MaxSize Set to Maximum Size of data buffer (output)
  * \param Position Set to current position in data buffer (output)
  */
 void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, size_t *MaxSize, size_t *Position);
@@ -557,9 +557,10 @@ void UT_Stub_RegisterContextWithMetaData(UT_EntryKey_t FuncKey, const char *Name
  *
  * This does not return NULL, such that the returned value can always be dereferenced.
  *
- * \param ContextPtr   The context structure containing arguments
- * \param Name         Argument name to find
- * \param ExpectedSize The size of the expected object type
+ * \param ContextPtr       The context structure containing arguments
+ * \param Name             Argument name to find
+ * \param ExpectedTypeSize The size of the expected object type
+ *
  * \returns Pointer to buffer containing the value.
  */
 const void *UT_Hook_GetArgPtr(const UT_StubContext_t *ContextPtr, const char *Name, size_t ExpectedTypeSize);
@@ -588,8 +589,10 @@ const void *UT_Hook_GetArgPtr(const UT_StubContext_t *ContextPtr, const char *Na
  * \param FunctionName  The printable name of the actual function called, for the debug message.  If
  *    NULL then no debug message will be generated.
  * \param FuncKey       The Key to look up in the table
+ * \param DefaultRc     Default return code
+ * \param ArgList       Argument list
  */
-int32 UT_DefaultStubImplWithArgs(const char *FunctionName, UT_EntryKey_t FuncKey, int32 DefaultRc, va_list va);
+int32 UT_DefaultStubImplWithArgs(const char *FunctionName, UT_EntryKey_t FuncKey, int32 DefaultRc, va_list ArgList);
 
 /**
  * Handles a stub call for a variadic function
@@ -605,8 +608,10 @@ int32 UT_DefaultStubImplWithArgs(const char *FunctionName, UT_EntryKey_t FuncKey
  *
  * \sa UT_DefaultStubImplWithArgs()
  *
- * \param FuncKey       The key of the stub being executed
- * \param FunctionName  The printable name of the actual function called, for the debug message.
+ * \param FuncKey        The key of the stub being executed
+ * \param FunctionName   The printable name of the actual function called, for the debug message.
+ * \param DefaultHandler The default handler
+ * \param VaList         Argument list
  */
 void UT_ExecuteVaHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_VaHandlerFunc_t DefaultHandler,
                          va_list VaList);
@@ -637,8 +642,9 @@ int32 UT_DefaultStubImpl(const char *FunctionName, UT_EntryKey_t FuncKey, int32 
  *
  * \sa UT_DefaultStubImplWithArgs()
  *
- * \param FuncKey       The key of the stub being executed
- * \param FunctionName  The printable name of the actual function called, for the debug message.
+ * \param FuncKey        The key of the stub being executed
+ * \param FunctionName   The printable name of the actual function called, for the debug message.
+ * \param DefaultHandler The default handler
  */
 void UT_ExecuteBasicHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_HandlerFunc_t DefaultHandler);
 

--- a/ut_assert/inc/uttest.h
+++ b/ut_assert/inc/uttest.h
@@ -61,8 +61,8 @@ void UtTest_Add(void (*Test)(void), void (*Setup)(void), void (*Teardown)(void),
  * This group of functions are invoked BEFORE normal test routines added with UtTest_Add.
  * Within the group, functions are executed in the order registered.
  *
- * \param Setup    Setup function, called before the test function
- * \param TestName Name of function for logging purposes
+ * \param Setup        Setup function, called before the test function
+ * \param SequenceName Name of sequence for logging purposes
  */
 void UtTest_AddSetup(void (*Setup)(void), const char *SequenceName);
 
@@ -72,8 +72,8 @@ void UtTest_AddSetup(void (*Setup)(void), const char *SequenceName);
  * This group of functions is invoked AFTER normal test routines added with UtTest_Add.
  * Within the group, functions are executed in the order registered.
  *
- * \param Teardown Teardown function, called before the test function
- * \param TestName Name of function for logging purposes
+ * \param Teardown     Teardown function, called before the test function
+ * \param SequenceName Name of sequence for logging purposes
  */
 void UtTest_AddTeardown(void (*Teardown)(void), const char *SequenceName);
 

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -1037,24 +1037,24 @@ int32 UT_DefaultStubImpl(const char *FunctionName, UT_EntryKey_t FuncKey, int32 
     return Retcode;
 }
 
-void UT_ExecuteBasicHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_HandlerFunc_t DefaultHook)
+void UT_ExecuteBasicHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_HandlerFunc_t DefaultHandler)
 {
     /* Check if the test case registered a hook, and use the default if not */
-    if (UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_FINAL_HANDLER) == NULL && DefaultHook != NULL)
+    if (UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_FINAL_HANDLER) == NULL && DefaultHandler != NULL)
     {
-        UT_SetHandlerFunction(FuncKey, DefaultHook, NULL);
+        UT_SetHandlerFunction(FuncKey, DefaultHandler, NULL);
     }
 
     UT_DefaultStubImpl(FunctionName, FuncKey, 0, NULL);
 }
 
-void UT_ExecuteVaHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_VaHandlerFunc_t DefaultHook,
+void UT_ExecuteVaHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_VaHandlerFunc_t DefaultHandler,
                          va_list VaList)
 {
     /* Check if the test case registered a hook, and use the default if not */
-    if (UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_FINAL_HANDLER) == NULL && DefaultHook != NULL)
+    if (UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_FINAL_HANDLER) == NULL && DefaultHandler != NULL)
     {
-        UT_SetVaHandlerFunction(FuncKey, DefaultHook, NULL);
+        UT_SetVaHandlerFunction(FuncKey, DefaultHandler, NULL);
     }
 
     UT_DefaultStubImplWithArgs(FunctionName, FuncKey, 0, VaList);


### PR DESCRIPTION
**Describe the contribution**
- Fix #1218 

**Testing performed**
Build detailed design, observe osal warnings go away.  Also built unit tests to confirm parameter name change worked.

**Expected behavior changes**
Squash doxygen warnings

**System(s) tested on**
 - Hardware: i5/wsl2
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC