### PR TITLE
Fix #1220 Implement OS_ModuleGetInfo_Impl for RTEMS

### DIFF
--- a/src/os/rtems/src/os-impl-loader.c
+++ b/src/os/rtems/src/os-impl-loader.c
@@ -35,6 +35,7 @@
 #include "os-impl-loader.h"
 #include "os-shared-module.h"
 #include "os-shared-idmap.h"
+#include <rtems/rtl/rtl.h>
 
 /****************************************************************************************
                                    GLOBAL DATA
@@ -216,10 +217,44 @@ int32 OS_ModuleUnload_Impl(const OS_object_token_t *token)
  *-----------------------------------------------------------------*/
 int32 OS_ModuleGetInfo_Impl(const OS_object_token_t *token, OS_module_prop_t *module_prop)
 {
-    /*
-    ** RTEMS does not specify a way to get these values
-    ** Everything left at zero
-    */
-    return (OS_SUCCESS);
+    rtems_rtl_obj                       *obj; 
+    OS_impl_module_internal_record_t    *impl;
+    int32                               status = OS_ERROR;
+
+    impl = OS_OBJECT_TABLE_GET(OS_impl_module_table, *token);
+ 
+    /* Lock RTEMS runtime loader */ 
+    if(rtems_rtl_lock() != NULL){
+
+        /* Get RTL object from handle */ 
+        obj = rtems_rtl_check_handle(impl->dl_handle);
+
+        if (obj == NULL)
+        {
+            OS_DEBUG("Error getting object information from handle\n");
+            module_prop->addr.valid = false;
+        }
+        else
+        {
+            module_prop->addr.valid        = true;
+            module_prop->addr.code_address = obj->text_base;
+            module_prop->addr.code_size    = rtems_rtl_obj_text_size(obj); 
+            module_prop->addr.data_address = obj->data_base; 
+            module_prop->addr.data_size    = rtems_rtl_obj_data_size(obj); 
+            module_prop->addr.bss_address  = obj->bss_base; 
+            module_prop->addr.bss_size     = rtems_rtl_obj_bss_size(obj); 
+
+            status = OS_SUCCESS; 
+        }
+
+        /* Unlock RTEMS runtime loader */ 
+        rtems_rtl_unlock(); 
+    }
+    else{
+        OS_DEBUG("Error locking RTEMS runtime loader\n");
+        module_prop->addr.valid = false;
+    }
+
+    return status;
 
 } /* end OS_ModuleGetInfo_Impl */


### PR DESCRIPTION
**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes #1220 

**Testing performed**
The ES "query application" command yields a telemetry packet that contains section information supplied by OS_ModuleGetInfo_Impl. Compared object section sizes (.text, .data, .bss) in the telemetry given by the query app command to section sizes reported by the "size" tool in the platform toolchain. Checked the disassembly of application objects built in FSW to find symbols in each section (.text, .data, .bss) and used the MM application to report the addresses for each. Verified that symbol addresses reported were contained in the interval [addr, addr + size) for each section. 

Tested with cFS bundle:
https://github.com/ezpollack/cFS/actions/workflows/build-cfs-rtems4.11.yml
https://github.com/ezpollack/cFS/actions/workflows/build-cfs-rtems5.yml

**Expected behavior changes**
 - Behavior Change: OS_ModuleGetInfo will report section information for apps in RTEMS 4.11+. ES application info packet will contain valid section information for apps in RTEMS 4.11+. 

**System(s) tested on**
 - Hardware: Wildcat Processor Card (QEMU emulation) (GR740)
 - OS: RTEMS 5.1 via Gaisler's RTEMS LEON/ERC32 GNU cross-compiler system (RCC) 1.3.0
 - Versions: cFS Caelum RC4 + this commit + customizations for runtime environment (PSP + build system)

**Additional context**
This will only work for RTEMS 4.11+. Version 4.11 was the first version to support dynamic loading of objects via the RTEMS Runtime Loader (RTL). 

**Contributor Info - All information REQUIRED for consideration of pull request**
Eric Pollack - NASA/GSFC
