### PR TITLE
Fix #1222, protect if OS_FDGetInfo called on socket

### DIFF
--- a/src/os/shared/src/osapi-file.c
+++ b/src/os/shared/src/osapi-file.c
@@ -532,7 +532,10 @@ int32 OS_FDGetInfo(osal_id_t filedes, OS_file_prop_t *fd_prop)
     {
         record = OS_OBJECT_TABLE_GET(OS_global_stream_table, token);
 
-        strncpy(fd_prop->Path, record->name_entry, sizeof(fd_prop->Path) - 1);
+        if (record->name_entry != NULL)
+        {
+            strncpy(fd_prop->Path, record->name_entry, sizeof(fd_prop->Path) - 1);
+        }
         fd_prop->User    = record->creator;
         fd_prop->IsValid = true;
 

--- a/src/unit-test-coverage/shared/src/coveragetest-file.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-file.c
@@ -310,6 +310,10 @@ void Test_OS_FDGetInfo(void)
     OSAPI_TEST_FUNCTION_RC(OS_FDGetInfo(UT_OBJID_1, &file_prop), OS_SUCCESS);
     UtAssert_True(strcmp(file_prop.Path, "ABC") == 0, "file_prop.Path (%s) == ABC", file_prop.Path);
 
+    OS_UT_SetupBasicInfoTest(OS_OBJECT_TYPE_OS_STREAM, UT_INDEX_1, NULL, UT_OBJID_OTHER);
+    OSAPI_TEST_FUNCTION_RC(OS_FDGetInfo(UT_OBJID_1, &file_prop), OS_SUCCESS);
+    UtAssert_STRINGBUF_EQ(file_prop.Path, 1, "", 1);
+
     OSAPI_TEST_FUNCTION_RC(OS_FDGetInfo(UT_OBJID_1, NULL), OS_INVALID_POINTER);
 
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetById), OS_ERR_INVALID_ID);

--- a/src/unit-test-coverage/shared/src/os-shared-coverage-support.c
+++ b/src/unit-test-coverage/shared/src/os-shared-coverage-support.c
@@ -108,7 +108,7 @@ void OS_UT_SetupBasicInfoTest(osal_objtype_t obj_type, osal_index_t test_idx, co
     rptr += test_idx;
     memset(rptr, 0, sizeof(*rptr));
     rptr->creator    = UT_OBJID_OTHER;
-    rptr->name_entry = "ABC";
+    rptr->name_entry = name;
 
     OS_UT_SetupTestTargetIndex(obj_type, test_idx);
 }


### PR DESCRIPTION
**Describe the contribution**
Datagram sockets do not have a name_entry, it is set NULL.  If the user calls OS_FDGetInfo() on this type of ID, it will
pass the first test, so this needs to be checked for non-NULL.

Fixes #1222

**Testing performed**
Build and sanity check OSAL
Run all tests
Confirm coverage test is exercising the new check

**Expected behavior changes**
Calling OS_FDGetInfo on a datagram socket returns an empty string in the Path field, it does not segfault.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
