### PR TITLE
Fix #1231, Doxygen strip path and expose common config

### DIFF
--- a/docs/osal-detaildesign.doxyfile.in
+++ b/docs/osal-detaildesign.doxyfile.in
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------
 
 # Common files
-@INCLUDE  = @MISSION_BINARY_DIR@/docs/osalguide/osal-common.doxyfile
+@INCLUDE  = @MISSION_BINARY_DIR@/docs/osal-common.doxyfile
 
 # All of the OSAL FSW code relevant for a detail design document is under
 # src/os and src/bsp, everything else is test and examples/support

--- a/docs/src/CMakeLists.txt
+++ b/docs/src/CMakeLists.txt
@@ -5,7 +5,7 @@
 ########################################################
 
 #
-# This CMake script currently defines a top-level target "apiguide"
+# This CMake script currently defines a top-level target "osal-apiguide"
 # to build the OSAL API documentation.  This may be invoked either
 # from the main OSAL CMakeLists.txt as a subdirectory (useful in the
 # case of a self-contained/standalone build) or by a separate script
@@ -61,14 +61,19 @@ foreach(DIR ${OSAL_API_INCLUDE_DIRECTORIES})
 endforeach()
 
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/osal-apiguide-warnings.log OSAL_NATIVE_LOGFILE)
-file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/osal-common.doxyfile OSAL_NATIVE_COMMON_CFGFILE)
+file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/docs/osal-common.doxyfile OSAL_NATIVE_COMMON_CFGFILE)
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/osal-apiguide.doxyfile OSAL_NATIVE_APIGUIDE_CFGFILE)
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/default-settings.doxyfile OSAL_NATIVE_DEFAULT_SETTINGS)
+
+# Add a top level source directory if not defined
+if (NOT DEFINED MISSION_SOURCE_DIR)
+    set(MISSION_SOURCE_DIR ${CMAKE_SOURCE_DIR})
+endif()
 
 # generate the configuration files
 configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/osal-common.doxyfile.in
-        ${CMAKE_CURRENT_BINARY_DIR}/osal-common.doxyfile
+        ${CMAKE_BINARY_DIR}/docs/osal-common.doxyfile
         @ONLY
 )
 
@@ -78,14 +83,14 @@ configure_file(
         @ONLY
 )
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/apiguide/html/index.html"
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/html/index.html"
     COMMAND doxygen ${OSAL_NATIVE_APIGUIDE_CFGFILE}
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/osal-apiguide.doxyfile ${CMAKE_CURRENT_BINARY_DIR}/osal-common.doxyfile
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/osal-apiguide.doxyfile ${CMAKE_BINARY_DIR}/docs/osal-common.doxyfile
             ${OSAL_DOCFILE_LIST} ${OSAL_DOC_DEPENDENCY_LIST}
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
 add_custom_target(osal-apiguide
-    COMMAND echo "OSAL API Guide: file://${CMAKE_CURRENT_BINARY_DIR}/apiguide/html/index.html"
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/apiguide/html/index.html"
+    COMMAND echo "OSAL API Guide: file://${CMAKE_CURRENT_BINARY_DIR}/html/index.html"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/html/index.html"
 )

--- a/docs/src/osal-apiguide.doxyfile.in
+++ b/docs/src/osal-apiguide.doxyfile.in
@@ -2,10 +2,8 @@
 # Doxygen Configuration options to generate the "OSAL API Guide"
 #---------------------------------------------------------------------------
 
-# Common definitions, some of which are extended or overridden here.
+# Common definitions, can be overridden here
 @INCLUDE               = @OSAL_NATIVE_COMMON_CFGFILE@
-PROJECT_NAME           = "OSAL User's Guide"
-OUTPUT_DIRECTORY       = apiguide
 
-# output the warnings to a separate file
+PROJECT_NAME           = "OSAL User's Guide"
 WARN_LOGFILE           = @OSAL_NATIVE_LOGFILE@

--- a/docs/src/osal-common.doxyfile.in
+++ b/docs/src/osal-common.doxyfile.in
@@ -5,7 +5,7 @@
 # Allow overrides
 @INCLUDE_PATH          = @MISSION_SOURCE_DIR@
 
-# Default settings from cFE
+# Default settings
 @INCLUDE               = @OSAL_NATIVE_DEFAULT_SETTINGS@
 
 # Include any passed in predefines
@@ -13,3 +13,6 @@ PREDEFINED            += @OSALDOC_PREDEFINED@
 
 # Minimum set of source files (includes *.dox, followed by public headers)
 INPUT                 += @OSAL_NATIVE_APIGUIDE_SOURCEFILES@
+
+# Strip source dir from path
+STRIP_FROM_PATH       += @MISSION_SOURCE_DIR@


### PR DESCRIPTION
**Describe the contribution**
- Fix #1231

**Testing performed**
Built OSAL users guide locally and from bundle, no warnings.  Inspected generated documents

**Expected behavior changes**
None, but osal-common.doxyfile can now be used by other documents to resolve OSAL references

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC