### PR TITLE
FIX #1248, add os-impl-no-select.c for RTEMS

### DIFF
--- a/src/os/portable/os-impl-no-select.c
+++ b/src/os/portable/os-impl-no-select.c
@@ -1,0 +1,78 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file   os-impl-no-select.c
+ * \author joseph.p.hickey@nasa.gov
+ *
+ * Purpose: All functions return OS_ERR_NOT_IMPLEMENTED.
+ * This is used when network functionality is disabled by config.
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include <osapi.h>
+#include "os-shared-select.h"
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/***************************************************************************************
+                                 FUNCTION PROTOTYPES
+ **************************************************************************************/
+
+/****************************************************************************************
+                                   GLOBAL DATA
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                LOCAL FUNCTIONS
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                SELECT API
+ ***************************************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_SelectSingle_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_SelectSingle_Impl(const OS_object_token_t *token, uint32 *SelectFlags, int32 msecs)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_SelectSingle_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_SelectMultiple_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_SelectMultiple_Impl(OS_FdSet *ReadSet, OS_FdSet *WriteSet, int32 msecs)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_SelectMultiple_Impl */

--- a/src/os/rtems/CMakeLists.txt
+++ b/src/os/rtems/CMakeLists.txt
@@ -30,7 +30,6 @@ set(RTEMS_BASE_SRCLIST
 set(RTEMS_IMPL_SRCLIST
     ../portable/os-impl-posix-gettime.c
     ../portable/os-impl-console-bsp.c
-    ../portable/os-impl-bsd-select.c
     ../portable/os-impl-posix-io.c
     ../portable/os-impl-posix-files.c
     ../portable/os-impl-posix-dirs.c
@@ -61,11 +60,13 @@ if (OSAL_CONFIG_INCLUDE_NETWORK)
     list(APPEND RTEMS_IMPL_SRCLIST
         src/os-impl-network.c
         ../portable/os-impl-bsd-sockets.c
+        ../portable/os-impl-bsd-select.c
     )
 else()
     list(APPEND RTEMS_IMPL_SRCLIST
         ../portable/os-impl-no-network.c
         ../portable/os-impl-no-sockets.c
+        ../portable/os-impl-no-select.c
     )
 endif ()
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

- Fix #1248 

Implements os-impl-no-select.c for RTEMS or any other OS that has a configuration without select.
Currently only used for RTEMS when the network stack is disabled in the OSAL. On RTEMS the select call only works with network file descriptors.
In current RTEMS 4.11 and 5 builds, when the OSAL_CONFIG_INCLUDE_NETWORK option is false, the select call will still be included even though it cannot be used. The does not fail because the select call is still available in the RTEMS libraries.

If you build RTEMS 4.11 or 5 without the default network stack, the select call will not be included in the RTEMS libraries, causing the OSAL build to fail. In addition, RTEMS 6 removes the legacy network stack, so a default OS build will cause the OSAL build to fail.

By selecting os-impl-no-select.c when the OSAL_CONFIG_INCLUDE_NETWORK option is false, the select call will be omitted, and it will build for RTEMS with and without the network stack.

**Testing performed**
Steps taken to test the contribution:
This was tested with RTEMS 4.11 and RTEMS 5 using the pc-rtems CI platform.
I ran all tests on 4.11 and 5 with OSAL_CONFIG_INCLUDE_NETWORK set to true and false. All tests pass, but I did notice that the OSAL module unload test did not pass on RTEMS 4.11 - I don't think this test is related.
This is also being used on LEON3/RTEMS 5.1 for GTOSat.

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
When building the cFS with the OSAL_CONFIG_INCLUDE_NETWORK to false for RTEMS only (currently), the OS_Select* calls will return OS_ERR_NOT_IMPLEMENTED. This is probably safer, since the underlying select call should only be used with network sockets/file descriptors anyway.

**System(s) tested on**
 - Build system: Docker containers for RTEMS 4.11 and 5 cFS CI tests
 - Target OS/cFS Platform: RTEMS 4.11/x86 with cFS pc-rtems platform, and RTEMS 5/x86 with cFS pc-rtems platform
 - This patch has also been in use for GTOSat on a LEON3/RTEMS 5.1 platform for a year.

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Cudmore, NASA GSFC/582.0