### PR TITLE
Fix #1258, Add OS_StatusToString API

### DIFF
--- a/src/os/inc/osapi-error.h
+++ b/src/os/inc/osapi-error.h
@@ -46,6 +46,20 @@
  */
 typedef char os_err_name_t[OS_ERROR_NAME_LENGTH];
 
+/**
+ * @brief Status converted to string length limit
+ *
+ * Used for sizing os_status_string_t intended for use in printing osal_status_t values
+ * Sized to fit LONG_MIN including NULL termination
+ */
+#define OS_STATUS_STRING_LENGTH 12
+
+/**
+ * @brief For the @ref OS_StatusToString() function, to ensure
+ * everyone is making an array of the same length.
+ */
+typedef char os_status_string_t[OS_STATUS_STRING_LENGTH];
+
 /** @defgroup OSReturnCodes OSAL Return Code Defines
  *
  * The specific status/return code definitions listed in this section may be extended or refined
@@ -165,6 +179,17 @@ static inline long OS_StatusToInteger(osal_status_t Status)
  * @retval #OS_ERROR if error could not be converted
  */
 int32 OS_GetErrorName(int32 error_num, os_err_name_t *err_name);
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Convert status to a string
+ *
+ * @param[in] status Status value to convert
+ * @param[out] status_string Buffer to store status converted to string
+ *
+ * @return Passed in string pointer
+ */
+os_status_string_t *OS_StatusToString(osal_status_t status, os_status_string_t *status_string);
 /**@}*/
 
 #endif /* OSAPI_ERROR_H */

--- a/src/os/shared/src/osapi-errors.c
+++ b/src/os/shared/src/osapi-errors.c
@@ -100,6 +100,23 @@ static const OS_ErrorTable_Entry_t OS_GLOBAL_ERROR_NAME_TABLE[] = {
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_StatusToString
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+os_status_string_t *OS_StatusToString(osal_status_t status, os_status_string_t *status_string)
+{
+    if (status_string != NULL)
+    {
+        snprintf(*status_string, sizeof(*status_string), "%ld", OS_StatusToInteger(status));
+    }
+    return status_string;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_GetErrorName
  *
  *  Purpose: Implemented per public OSAL API

--- a/src/unit-test-coverage/shared/src/coveragetest-errors.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-errors.c
@@ -45,6 +45,37 @@ void Test_OS_GetErrorName(void)
     OSAPI_TEST_FUNCTION_RC(OS_GetErrorName(-555555, NULL), OS_INVALID_POINTER);
 }
 
+/*--------------------------------------------------------------------------------*
+** OS_StatusToString test helper function to avoid repeating logic
+**--------------------------------------------------------------------------------*/
+void Test_OS_StatusToString_Helper(osal_status_t status)
+{
+    os_status_string_t  status_string;
+    os_status_string_t *rtn_addr;
+    char                expected[OS_STATUS_STRING_LENGTH + 1];
+
+    /* Used oversized string to test for truncation */
+    snprintf(expected, sizeof(expected), "%ld", OS_StatusToInteger(status));
+    rtn_addr = OS_StatusToString(status, &status_string);
+    UtAssert_ADDRESS_EQ(rtn_addr, &status_string);
+    UtAssert_STRINGBUF_EQ(status_string, sizeof(status_string), expected, sizeof(expected));
+}
+
+/*--------------------------------------------------------------------------------*
+** Functional OS_StatusToString test
+**--------------------------------------------------------------------------------*/
+void Test_OS_StatusToString(void)
+{
+    /* NULL test */
+    UtAssert_ADDRESS_EQ(OS_StatusToString(OS_SUCCESS, NULL), NULL);
+
+    /* Status value tests */
+    Test_OS_StatusToString_Helper(OS_SUCCESS);
+    Test_OS_StatusToString_Helper(OS_ERROR);
+    Test_OS_StatusToString_Helper(OSAL_STATUS_C(INT32_MAX));
+    Test_OS_StatusToString_Helper(OSAL_STATUS_C(INT32_MIN));
+}
+
 /* Osapi_Test_Setup
  *
  * Purpose:
@@ -69,4 +100,5 @@ void Osapi_Test_Teardown(void) {}
 void UtTest_Setup(void)
 {
     ADD_TEST(OS_GetErrorName);
+    ADD_TEST(OS_StatusToString);
 }

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.c
@@ -410,6 +410,37 @@ void UT_os_geterrorname_test(void)
 }
 
 /*--------------------------------------------------------------------------------*
+** OS_StatusToString test helper function to avoid repeating logic
+**--------------------------------------------------------------------------------*/
+void UT_os_statustostring_test_helper(osal_status_t status)
+{
+    os_status_string_t  status_string;
+    os_status_string_t *rtn_addr;
+    char                expected[OS_STATUS_STRING_LENGTH + 1];
+
+    /* Used oversized string to test for truncation */
+    snprintf(expected, sizeof(expected) - 1, "%ld", OS_StatusToInteger(status));
+    rtn_addr = OS_StatusToString(status, &status_string);
+    UtAssert_ADDRESS_EQ(rtn_addr, &status_string);
+    UtAssert_STRINGBUF_EQ(status_string, sizeof(status_string), expected, sizeof(expected));
+}
+
+/*--------------------------------------------------------------------------------*
+** Functional OS_StatusToString test
+**--------------------------------------------------------------------------------*/
+void UT_os_statustostring_test(void)
+{
+    /* NULL test */
+    UtAssert_ADDRESS_EQ(OS_StatusToString(OS_SUCCESS, NULL), NULL);
+
+    /* Status value tests */
+    UT_os_statustostring_test_helper(OS_SUCCESS);
+    UT_os_statustostring_test_helper(OS_ERROR);
+    UT_os_statustostring_test_helper(OSAL_STATUS_C(INT32_MAX));
+    UT_os_statustostring_test_helper(OSAL_STATUS_C(INT32_MIN));
+}
+
+/*--------------------------------------------------------------------------------*
 ** Syntax: int32 OS_HeapGetInfo(OS_heap_prop_t *heap_prop)
 ** Purpose: Returns current info on the heap
 ** Parameters: prop - out pointer to heap data

--- a/src/unit-tests/oscore-test/ut_oscore_misc_test.h
+++ b/src/unit-tests/oscore-test/ut_oscore_misc_test.h
@@ -63,6 +63,7 @@ void UT_os_getlocaltime_test(void);
 void UT_os_setlocaltime_test(void);
 
 void UT_os_geterrorname_test(void);
+void UT_os_statustostring_test(void);
 
 void UT_os_heapgetinfo_test(void);
 

--- a/src/unit-tests/oscore-test/ut_oscore_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_test.c
@@ -245,6 +245,7 @@ void UtTest_Setup(void)
     UtTest_Add(UT_os_task_getid_by_sysdata_test, UT_os_task_getid_by_sysdata_test, NULL, "OS_TaskFindIdBySystemData");
 
     UtTest_Add(UT_os_geterrorname_test, NULL, NULL, "OS_GetErrorName");
+    UtTest_Add(UT_os_statustostring_test, NULL, NULL, "OS_StatusToString");
 
     UtTest_Add(UT_os_getlocaltime_test, NULL, NULL, "OS_GetLocalTime");
     UtTest_Add(UT_os_setlocaltime_test, NULL, NULL, "OS_SetLocalTime");

--- a/src/ut-stubs/osapi-error-stubs.c
+++ b/src/ut-stubs/osapi-error-stubs.c
@@ -43,3 +43,20 @@ int32 OS_GetErrorName(int32 error_num, os_err_name_t *err_name)
 
     return UT_GenStub_GetReturnValue(OS_GetErrorName, int32);
 }
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_StatusToString()
+ * ----------------------------------------------------
+ */
+os_status_string_t *OS_StatusToString(osal_status_t status, os_status_string_t *status_string)
+{
+    UT_GenStub_SetupReturnBuffer(OS_StatusToString, os_status_string_t *);
+
+    UT_GenStub_AddParam(OS_StatusToString, osal_status_t, status);
+    UT_GenStub_AddParam(OS_StatusToString, os_status_string_t *, status_string);
+
+    UT_GenStub_Execute(OS_StatusToString, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(OS_StatusToString, os_status_string_t *);
+}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1258 

Related to:
- nasa/cFE#2110
- nasa/cFE#2010
- #1112

**Testing performed**
Added unit and functional tests, confirmed expected output

**Expected behavior changes**
None, just adds macro for future cleanup that will be Draco compliant

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
See links above.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC