### PR TITLE
Fix #1263, update cmake_minimum_required

### DIFF
--- a/src/unit-test-coverage/CMakeLists.txt
+++ b/src/unit-test-coverage/CMakeLists.txt
@@ -15,7 +15,6 @@
 #  NO ARTEFACTS FROM THIS BUILD SHOULD EVER INTERMINGLE WITH THE REAL TARGET BUILD
 #
 
-cmake_minimum_required(VERSION 2.6.4)
 project(OSALCOVERAGE C)
 
 # Ask to generate a "make test" target


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Remove the extra/unneded cmake_minimum_required that was triggering a deprecation warning.  This will just inherit the minimum version of the parent.

Fixes #1263

**Testing performed**
Build using cmake 3.20

**Expected behavior changes**
No deprecation warning

**System(s) tested on**
RHEL 8

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.