### PR TITLE
Fix #1150, Set OSAL Loader unit test number of modules to OSAL_CONFIG_MAX_MODULES.

### DIFF
--- a/src/unit-tests/osloader-test/CMakeLists.txt
+++ b/src/unit-tests/osloader-test/CMakeLists.txt
@@ -9,8 +9,9 @@ add_osal_ut_exe(osal_loader_UT ${TEST_MODULE_FILES})
 
 # build many copies of the test module
 # we need to have unique modules to load up to OS_MAX_MODULES
-# This will cover up to 32 -- extras are ignored.  If needed this can be increased.
-set(MOD 32)
+# This will cover up to $OSAL_CONFIG_MAX_MODULES + 1.  If needed
+# this can be increased by increasing $OSAL_CONFIG_MAX_MODULES.
+math(EXPR MOD "${OSAL_CONFIG_MAX_MODULES} + 1")
 while(MOD GREATER 0)
   math(EXPR MOD "${MOD} - 1")
   add_library(MODULE${MOD} SHARED ut_module.c)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1150

**Testing performed**
Printed value of MOD variable in CMakeLists.txt to ensure that it gets set to one more than the OSAL_CONFIG_MAX_MODULES value

Ran OSAL unit tests

**Expected behavior changes**
OSAL Loader unit tests will now support up to OSAL_CONFIG_MAX_MODULES modules.

**System(s) tested on**
 - OS: RHEL 8.6