### PR TITLE
Fix #1244, Add RTEMS timebase callback wrapper

### DIFF
--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -408,9 +408,9 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
         else
         {
             /* will place the task in 'ready for scheduling' state */
-            rtems_sc = rtems_task_start(local->handler_task,                               /*rtems task id*/
-                                        (rtems_task_entry)OS_TimeBase_CallbackThreadEntry, /* task entry point */
-                                        (rtems_task_argument)r_name);                      /* passed argument  */
+            rtems_sc = rtems_task_start(local->handler_task,             /* rtems task id */
+                                        OS_TimeBase_CallbackThreadEntry, /* task entry point */
+                                        (rtems_task_argument)r_name);    /* passed argument  */
 
             if (rtems_sc != RTEMS_SUCCESSFUL)
             {

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -288,6 +288,24 @@ void OS_UsecsToTicks(uint32 usecs, rtems_interval *ticks)
 
 /*----------------------------------------------------------------
  *
+ * Function: OS_TimeBase_CallbackThreadEntry
+ *
+ *  Purpose: Local helper routine, not part of OSAL API.
+ *           Wrapper function used by OS_TimeBaseCreate_Impl to
+ *           convert the rtems_task_argument on newly created
+ *           timebase task into an osal_id_t used by the
+ *           OS_TimeBase_CallbackThread.
+ *
+ *-----------------------------------------------------------------*/
+static void OS_TimeBase_CallbackThreadEntry(rtems_task_argument arg)
+{
+    osal_id_t id;
+    id = OS_ObjectIdFromInteger(arg);
+    OS_TimeBase_CallbackThread(id);
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: OS_TimeBaseCreate_Impl
  *
  *  Purpose: Implemented per internal OSAL API
@@ -390,9 +408,9 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
         else
         {
             /* will place the task in 'ready for scheduling' state */
-            rtems_sc = rtems_task_start(local->handler_task,                          /*rtems task id*/
-                                        (rtems_task_entry)OS_TimeBase_CallbackThread, /* task entry point */
-                                        (rtems_task_argument)r_name);                 /* passed argument  */
+            rtems_sc = rtems_task_start(local->handler_task,                               /*rtems task id*/
+                                        (rtems_task_entry)OS_TimeBase_CallbackThreadEntry, /* task entry point */
+                                        (rtems_task_argument)r_name);                      /* passed argument  */
 
             if (rtems_sc != RTEMS_SUCCESSFUL)
             {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1244 by creating a wrapper function to convert timebase callback task argument from rtems_task_argument into osal_id_t

**Testing performed**
Steps taken to test the contribution:
1. Built with `OMIT_DEPRECATED = true` and `MISSION_RESOURCEID_MODE = "STRICT"` for RTEMS/GR740
2. Run and verify successful cFS init

**System(s) tested on**
 - Hardware: GR740
 - OS: RTEMS 5
 - Versions: Draco-rc2 +

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F Martinez Pedraza / NASA GSFC code 582
