### PR TITLE
Fix #1279, rtems allow variable length queue msgs.

### DIFF
--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -223,8 +223,7 @@ int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, size_t size, 
     }
 
     /*
-    ** Check the size of the message.  If a valid message was
-    ** obtained, indicate success.
+    ** If a valid message was obtained fill in queue size, otherwise fill in zero on error
     */
     if (status == RTEMS_SUCCESSFUL)
     {

--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -229,11 +229,6 @@ int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, size_t size, 
     if (status == RTEMS_SUCCESSFUL)
     {
         *size_copied = rtems_size;
-        if (rtems_size != size)
-        {
-            /* Success, but the size was wrong */
-            return_code = OS_QUEUE_INVALID_SIZE;
-        }
     }
     else
     {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.
NA as Gov employee? NA as removing code not adding?

**Describe the contribution**
A clear and concise description of what the contribution is.
Drops check on size != rtems_size to allow variable length queue messages.
Matches the posix queue implementation.

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
Built and ran a non cfs system using posix.
built and ran the same cfs system using rtems, this fix allowed system to run.

1. Execution steps '...'
Ran on RTEMS on microblaze.

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: RTEMS queues changed to match posix queues for variable length messages 

**System(s) tested on**
RTEMS / Microblaze

**Additional context**
Add any other context about the contribution here.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
NASA GSFC

