### PR TITLE
Fix #1281, Rtems On task creation register name.

### DIFF
--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -130,6 +130,13 @@ int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
         return OS_ERROR;
     }
 
+    status = rtems_object_set_name(impl->id, task->task_name);
+    if (status != RTEMS_SUCCESSFUL)
+    {
+        /* Provide some feedback */
+        OS_printf("Unable to set task name: %s\n", rtems_status_text(status));
+    }
+
     /* will place the task in 'ready for scheduling' state */
     status = rtems_task_start(impl->id,                        /*rtems task id*/
                               (rtems_task_entry)OS_RtemsEntry, /* task entry point */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Registers task name with rtems on creation
 Fixes #1281 

**Testing performed**
Steps taken to test the contribution:
Ran on microblaze, typed cpuuse in rtems task, saw names.

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: microblaze kcu105
 - OS:RTEMS


**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Nasa/ GSFC

