### PR TITLE
Fix #1279, rtems queue multi-size, mimic posix logic

### DIFF
--- a/src/os/rtems/src/os-impl-queues.c
+++ b/src/os/rtems/src/os-impl-queues.c
@@ -206,7 +206,7 @@ int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, size_t size, 
 
     if (status != RTEMS_SUCCESSFUL)
     {
-        *size_copied = 0;
+        *size_copied = OSAL_SIZE_C(0);
 
         /* Map the rtems error to the most appropriate OSAL return code */
         if ((timeout == OS_PEND) && (status != RTEMS_TIMEOUT))
@@ -234,7 +234,7 @@ int32 OS_QueueGet_Impl(const OS_object_token_t *token, void *data, size_t size, 
     }
     else
     {
-        *size_copied = impl_size;
+        *size_copied = OSAL_SIZE_C(impl_size);
         return_code  = OS_SUCCESS;
     }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Refactor rtems queue to not do size check, and to mimic posix logic.

Fixes #1279 

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
