### PR TITLE
Fix #1293, Remove 'return;' from last line of void functions.

### DIFF
--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -114,15 +114,12 @@ void task_generic_no_exit(void)
     {
         OS_TaskDelay(100);
     }
-
-    return;
 } /* end task_0 */
 
 /* **************** A TASK THAT EXITS ITSELF **************************** */
 
 void task_generic_with_exit(void)
 {
-    return;
 } /* end task_0 */
 
 typedef struct
@@ -524,7 +521,6 @@ void InitializeTaskIds(void)
     task_1_id = OS_OBJECT_ID_UNDEFINED;
     task_2_id = OS_OBJECT_ID_UNDEFINED;
     task_3_id = OS_OBJECT_ID_UNDEFINED;
-    return;
 } /* end InitializeTaskIds */
 
 /* **************************************************************************** */
@@ -534,7 +530,6 @@ void InitializeQIds(void)
     msgq_1 = OS_OBJECT_ID_UNDEFINED;
     msgq_2 = OS_OBJECT_ID_UNDEFINED;
     msgq_3 = OS_OBJECT_ID_UNDEFINED;
-    return;
 } /* end InitializeQIds */
 
 /* ***************************************************************************** */
@@ -544,7 +539,6 @@ void InitializeBinIds(void)
     bin_1 = OS_OBJECT_ID_UNDEFINED;
     bin_2 = OS_OBJECT_ID_UNDEFINED;
     bin_3 = OS_OBJECT_ID_UNDEFINED;
-    return;
 } /* end InitializeBinIds */
 
 /* ***************************************************************************** */
@@ -554,7 +548,6 @@ void InitializeMutIds(void)
     mut_1 = OS_OBJECT_ID_UNDEFINED;
     mut_2 = OS_OBJECT_ID_UNDEFINED;
     mut_3 = OS_OBJECT_ID_UNDEFINED;
-    return;
 } /* end InitializeMutIds */
 
 /* ***************************************************************************** */

--- a/src/unit-tests/osloader-test/ut_module.c
+++ b/src/unit-tests/osloader-test/ut_module.c
@@ -22,5 +22,4 @@ void MODULE_NAME(void)
     i = 1;
     i = i + 1; /* squelch set-but-not-used compiler warning */
     (void)i;
-    return;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1293
Removes all cases of redundant "return;" statements on the last line of void functions.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 