### PR TITLE
Fix #1296, Adding commit-msg hook, copy to .git/hooks to enable.

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Purpose: Enforce proper commit message to avoid message rework.
+# See https://github.com/nasa/cFS/blob/main/.github/workflows/format-check.yml for true format
+
+# Check for issue tag in commit message
+issue_tag_regex="^((Fix|HotFix|Part)\s\#[0-9]+,\s[a-zA-Z0-9]+|Merge\spull\srequest\s\#[0-9]+\s[a-zA-Z0-9]+|IC:\s[a-zA-Z0-9]+)"
+
+if ! grep -qE "$issue_tag_regex" "$1"; then
+    cat << EOF
+ERROR - Commit message format wrong. 
+You need at least one "Fix|HotFix|Part #<issue number>, <short description>" line in the commit message.
+Or delete / update .git/hooks/commit-msg
+EOF
+
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a githook that matches the regex that the server side checks for.
- Include explicitly what issue it addresses [e.g. Fixes #1296 ]

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
