### PR TITLE
Fix #1300, do not set file permissions on UT assert outputs

### DIFF
--- a/ut_assert/src/uttools.c
+++ b/ut_assert/src/uttools.c
@@ -31,7 +31,6 @@
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>
-#include <sys/stat.h>
 
 #include "common_types.h"
 #include "utassert.h"
@@ -54,18 +53,10 @@ typedef struct
 
 bool UtMem2BinFile(const void *Memory, const char *Filename, uint32 Length)
 {
-    FILE *      fp;
-    int         fd;
-    struct stat dststat;
+    FILE *fp;
 
     if ((fp = fopen(Filename, "w")))
     {
-        fd = fileno(fp);
-        if (fstat(fd, &dststat) == 0)
-        {
-            fchmod(fd, dststat.st_mode & ~(S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH));
-        }
-
         fwrite(Memory, Length, 1, fp);
         fclose(fp);
         return true;
@@ -102,20 +93,12 @@ bool UtBinFile2Mem(void *Memory, const char *Filename, uint32 Length)
 
 bool UtMem2HexFile(const void *Memory, const char *Filename, uint32 Length)
 {
-    FILE *      fp;
-    uint32      i;
-    uint32      j;
-    int         fd;
-    struct stat dststat;
+    FILE * fp;
+    uint32 i;
+    uint32 j;
 
     if ((fp = fopen(Filename, "w")))
     {
-        fd = fileno(fp);
-        if (fstat(fd, &dststat) == 0)
-        {
-            fchmod(fd, dststat.st_mode & ~(S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH));
-        }
-
         for (i = 0; i < Length; i += 16)
         {
             fprintf(fp, "   %06lX: ", (unsigned long)i);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
File permissions in general are a POSIX concept, but this tool should be pure C99.  It should not rely on any POSIX headers or POSIX-specific API calls.

Fixes #1300

**Testing performed**
Build and run tests

**Expected behavior changes**
No more build failures

**System(s) tested on**
Ubuntu 22.04

**Additional context**
Setting permissions explicitly is not really necessary.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
