### PR TITLE
Fix #1307, Add time conversion reciprocal functions

### DIFF
--- a/src/os/inc/osapi-clock.h
+++ b/src/os/inc/osapi-clock.h
@@ -123,6 +123,7 @@ int32 OS_SetLocalTime(const OS_time_t *time_struct);
  * structure was defined with separate seconds/microseconds fields.
  *
  * @sa OS_TimeGetMicrosecondsPart()
+ * @sa OS_TimeFromTotalSeconds()
  *
  * @param[in] tm    Time interval value
  * @returns   Whole number of seconds in time interval
@@ -134,9 +135,28 @@ static inline int64 OS_TimeGetTotalSeconds(OS_time_t tm)
 
 /*-------------------------------------------------------------------------------------*/
 /**
+ * @brief Get an OS_time_t interval object from an integer number of seconds
+ *
+ * This is the inverse operation of OS_TimeGetTotalSeconds(), converting the
+ * total number of seconds into an OS_time_t value.
+ *
+ * @sa OS_TimeGetTotalSeconds()
+ *
+ * @param[in] tm    Time interval value, in seconds
+ * @returns   OS_time_t value representing the interval
+ */
+static inline OS_time_t OS_TimeFromTotalSeconds(int64 tm)
+{
+    return (OS_time_t) {.ticks = (tm * OS_TIME_TICKS_PER_SECOND)};
+}
+
+/*-------------------------------------------------------------------------------------*/
+/**
  * @brief Get interval from an OS_time_t object normalized to millisecond units
  *
  * Note this refers to the complete interval, not just the fractional part.
+ *
+ * @sa OS_TimeFromTotalMilliseconds()
  *
  * @param[in] tm    Time interval value
  * @returns   Whole number of milliseconds in time interval
@@ -148,9 +168,28 @@ static inline int64 OS_TimeGetTotalMilliseconds(OS_time_t tm)
 
 /*-------------------------------------------------------------------------------------*/
 /**
+ * @brief Get an OS_time_t interval object from a integer number of milliseconds
+ *
+ * This is the inverse operation of OS_TimeGetTotalMilliseconds(), converting the
+ * total number of milliseconds into an OS_time_t value.
+ *
+ * @sa OS_TimeGetTotalMilliseconds()
+ *
+ * @param[in] tm    Time interval value, in milliseconds
+ * @returns   OS_time_t value representing the interval
+ */
+static inline OS_time_t OS_TimeFromTotalMilliseconds(int64 tm)
+{
+    return (OS_time_t) {.ticks = (tm * OS_TIME_TICKS_PER_MSEC)};
+}
+
+/*-------------------------------------------------------------------------------------*/
+/**
  * @brief Get interval from an OS_time_t object normalized to microsecond units
  *
  * Note this refers to the complete interval, not just the fractional part.
+ *
+ * @sa OS_TimeFromTotalMicroseconds()
  *
  * @param[in] tm    Time interval value
  * @returns   Whole number of microseconds in time interval
@@ -158,6 +197,23 @@ static inline int64 OS_TimeGetTotalMilliseconds(OS_time_t tm)
 static inline int64 OS_TimeGetTotalMicroseconds(OS_time_t tm)
 {
     return (tm.ticks / OS_TIME_TICKS_PER_USEC);
+}
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Get an OS_time_t interval object from a integer number of microseconds
+ *
+ * This is the inverse operation of OS_TimeGetTotalMicroseconds(), converting the
+ * total number of microseconds into an OS_time_t value.
+ *
+ * @sa OS_TimeGetTotalMicroseconds()
+ *
+ * @param[in] tm    Time interval value, in microseconds
+ * @returns   OS_time_t value representing the interval
+ */
+static inline OS_time_t OS_TimeFromTotalMicroseconds(int64 tm)
+{
+    return (OS_time_t) {.ticks = (tm * OS_TIME_TICKS_PER_USEC)};
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -170,12 +226,31 @@ static inline int64 OS_TimeGetTotalMicroseconds(OS_time_t tm)
  * Applications must use caution to ensure that the interval does not exceed the
  * representable range of a signed 64 bit integer - approximately 140 years.
  *
+ * @sa OS_TimeFromTotalNanoseconds
+ *
  * @param[in] tm    Time interval value
  * @returns   Whole number of microseconds in time interval
  */
 static inline int64 OS_TimeGetTotalNanoseconds(OS_time_t tm)
 {
     return (tm.ticks * OS_TIME_TICK_RESOLUTION_NS);
+}
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Get an OS_time_t interval object from a integer number of nanoseconds
+ *
+ * This is the inverse operation of OS_TimeGetTotalNanoseconds(), converting the
+ * total number of nanoseconds into an OS_time_t value.
+ *
+ * @sa OS_TimeGetTotalNanoseconds()
+ *
+ * @param[in] tm    Time interval value, in nanoseconds
+ * @returns   OS_time_t value representing the interval
+ */
+static inline OS_time_t OS_TimeFromTotalNanoseconds(int64 tm)
+{
+    return (OS_time_t) {.ticks = (tm / OS_TIME_TICK_RESOLUTION_NS)};
 }
 
 /*-------------------------------------------------------------------------------------*/

--- a/src/unit-test-coverage/shared/src/coveragetest-clock.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-clock.c
@@ -156,6 +156,19 @@ void Test_OS_TimeAccessConversions(void)
     UtAssert_UINT32_EQ(OS_TimeGetTotalMilliseconds(t3), 8666);
     t4 = OS_TimeSubtract(t3, t2);
     UtAssert_UINT32_EQ(OS_TimeGetTotalMilliseconds(t4), 3777);
+
+    /*
+     * Confirm reciprocity of the Get/From unit conversions.
+     * Note there is no (easy) way to directly compare a OS_time_t here,
+     * so this uses both conversions an just confirms the result, subject
+     * to rounding from the conversion.  In the default configuration the
+     * tick units are 100ns and so the numbers here are chosen such that
+     * the result will not lose precision, and also not overflow a uint32.
+     */
+    UtAssert_UINT32_EQ(OS_TimeGetTotalSeconds(OS_TimeFromTotalSeconds(123)), 123);
+    UtAssert_UINT32_EQ(OS_TimeGetTotalMilliseconds(OS_TimeFromTotalMilliseconds(12659687)), 12659687);
+    UtAssert_UINT32_EQ(OS_TimeGetTotalMicroseconds(OS_TimeFromTotalMicroseconds(3329165800)), 3329165800);
+    UtAssert_UINT32_EQ(OS_TimeGetTotalNanoseconds(OS_TimeFromTotalNanoseconds(347230000)), 347230000);
 }
 
 /* Osapi_Test_Setup


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds the following APIs which are direct reciprocals of the existing time conversion functions:

```
OS_time_t OS_TimeFromTotalSeconds(int64 tm)
OS_time_t OS_TimeFromTotalMilliseconds(int64 tm)
OS_time_t OS_TimeFromTotalMicroseconds(int64 tm)
OS_time_t OS_TimeFromTotalNanoseconds(int64 tm)
```

Fixes #1307

**Testing performed**
Added test cases to cover the new APIs
Build and run all tests to confirm that the new functions are working as intended

**Expected behavior changes**
Adds reciprocal operations for existing time conversions

**System(s) tested on**
Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
