### PR TITLE
Fix #1304, locks for condvar objects on rtems/vxworks

### DIFF
--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -89,10 +89,13 @@ void OS_Lock_Global_Impl(osal_objtype_t idtype)
 
     impl = OS_impl_objtype_lock_table[idtype];
 
-    ret = pthread_mutex_lock(&impl->mutex);
-    if (ret != 0)
+    if (impl != NULL)
     {
-        OS_DEBUG("pthread_mutex_lock(&impl->mutex): %s", strerror(ret));
+        ret = pthread_mutex_lock(&impl->mutex);
+        if (ret != 0)
+        {
+            OS_DEBUG("pthread_mutex_lock(&impl->mutex): %s", strerror(ret));
+        }
     }
 
 } /* end OS_Lock_Global_Impl */
@@ -112,18 +115,21 @@ void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 
     impl = OS_impl_objtype_lock_table[idtype];
 
-    /* Notify any waiting threads that the state _may_ have changed */
-    ret = pthread_cond_broadcast(&impl->cond);
-    if (ret != 0)
+    if (impl != NULL)
     {
-        OS_DEBUG("pthread_cond_broadcast(&impl->cond): %s", strerror(ret));
-        /* unexpected but keep going (not critical) */
-    }
+        /* Notify any waiting threads that the state _may_ have changed */
+        ret = pthread_cond_broadcast(&impl->cond);
+        if (ret != 0)
+        {
+            OS_DEBUG("pthread_cond_broadcast(&impl->cond): %s", strerror(ret));
+            /* unexpected but keep going (not critical) */
+        }
 
-    ret = pthread_mutex_unlock(&impl->mutex);
-    if (ret != 0)
-    {
-        OS_DEBUG("pthread_mutex_unlock(&impl->mutex): %s", strerror(ret));
+        ret = pthread_mutex_unlock(&impl->mutex);
+        if (ret != 0)
+        {
+            OS_DEBUG("pthread_mutex_unlock(&impl->mutex): %s", strerror(ret));
+        }
     }
 
 } /* end OS_Unlock_Global_Impl */

--- a/src/os/rtems/src/os-impl-idmap.c
+++ b/src/os/rtems/src/os-impl-idmap.c
@@ -55,6 +55,7 @@ static OS_impl_objtype_lock_t OS_timecb_table_lock;
 static OS_impl_objtype_lock_t OS_module_table_lock;
 static OS_impl_objtype_lock_t OS_filesys_table_lock;
 static OS_impl_objtype_lock_t OS_console_lock;
+static OS_impl_objtype_lock_t OS_condvar_lock;
 
 OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] = {
     [OS_OBJECT_TYPE_UNDEFINED]   = NULL,
@@ -70,6 +71,7 @@ OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] = 
     [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_lock,
     [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_lock,
     [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_lock,
+    [OS_OBJECT_TYPE_OS_CONDVAR]  = &OS_condvar_lock,
 };
 
 /*----------------------------------------------------------------
@@ -87,10 +89,13 @@ void OS_Lock_Global_Impl(osal_objtype_t idtype)
 
     impl = OS_impl_objtype_lock_table[idtype];
 
-    rtems_sc = rtems_semaphore_obtain(impl->id, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
-    if (rtems_sc != RTEMS_SUCCESSFUL)
+    if (impl != NULL)
     {
-        OS_DEBUG("OS_Lock_Global_Impl: rtems_semaphore_obtain failed: %s\n", rtems_status_text(rtems_sc));
+        rtems_sc = rtems_semaphore_obtain(impl->id, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
+        if (rtems_sc != RTEMS_SUCCESSFUL)
+        {
+            OS_DEBUG("OS_Lock_Global_Impl: rtems_semaphore_obtain failed: %s\n", rtems_status_text(rtems_sc));
+        }
     }
 
 } /* end OS_Lock_Global_Impl */
@@ -110,10 +115,13 @@ void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 
     impl = OS_impl_objtype_lock_table[idtype];
 
-    rtems_sc = rtems_semaphore_release(impl->id);
-    if (rtems_sc != RTEMS_SUCCESSFUL)
+    if (impl != NULL)
     {
-        OS_DEBUG("OS_Unlock_Global_Impl: rtems_semaphore_release failed: %s\n", rtems_status_text(rtems_sc));
+        rtems_sc = rtems_semaphore_release(impl->id);
+        if (rtems_sc != RTEMS_SUCCESSFUL)
+        {
+            OS_DEBUG("OS_Unlock_Global_Impl: rtems_semaphore_release failed: %s\n", rtems_status_text(rtems_sc));
+        }
     }
 
 } /* end OS_Unlock_Global_Impl */

--- a/src/os/vxworks/src/os-impl-idmap.c
+++ b/src/os/vxworks/src/os-impl-idmap.c
@@ -57,6 +57,7 @@ VX_MUTEX_SEMAPHORE(OS_timecb_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_module_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_filesys_table_mut_mem);
 VX_MUTEX_SEMAPHORE(OS_console_table_mut_mem);
+VX_MUTEX_SEMAPHORE(OS_condvar_table_mut_mem);
 
 static OS_impl_objtype_lock_t OS_task_table_lock      = {.mem = OS_task_table_mut_mem};
 static OS_impl_objtype_lock_t OS_queue_table_lock     = {.mem = OS_queue_table_mut_mem};
@@ -70,6 +71,7 @@ static OS_impl_objtype_lock_t OS_timecb_table_lock    = {.mem = OS_timecb_table_
 static OS_impl_objtype_lock_t OS_module_table_lock    = {.mem = OS_module_table_mut_mem};
 static OS_impl_objtype_lock_t OS_filesys_table_lock   = {.mem = OS_filesys_table_mut_mem};
 static OS_impl_objtype_lock_t OS_console_table_lock   = {.mem = OS_console_table_mut_mem};
+static OS_impl_objtype_lock_t OS_condvar_table_lock   = {.mem = OS_condvar_table_mut_mem};
 
 OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] = {
     [OS_OBJECT_TYPE_UNDEFINED]   = NULL,
@@ -84,7 +86,8 @@ OS_impl_objtype_lock_t *const OS_impl_objtype_lock_table[OS_OBJECT_TYPE_USER] = 
     [OS_OBJECT_TYPE_OS_TIMECB]   = &OS_timecb_table_lock,
     [OS_OBJECT_TYPE_OS_MODULE]   = &OS_module_table_lock,
     [OS_OBJECT_TYPE_OS_FILESYS]  = &OS_filesys_table_lock,
-    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_table_lock};
+    [OS_OBJECT_TYPE_OS_CONSOLE]  = &OS_console_table_lock,
+    [OS_OBJECT_TYPE_OS_CONDVAR]  = &OS_condvar_table_lock};
 
 /*----------------------------------------------------------------
  *
@@ -100,9 +103,12 @@ void OS_Lock_Global_Impl(osal_objtype_t idtype)
 
     impl = OS_impl_objtype_lock_table[idtype];
 
-    if (semTake(impl->vxid, WAIT_FOREVER) != OK)
+    if (impl != NULL)
     {
-        OS_DEBUG("semTake() - vxWorks errno %d\n", errno);
+        if (semTake(impl->vxid, WAIT_FOREVER) != OK)
+        {
+            OS_DEBUG("semTake() - vxWorks errno %d\n", errno);
+        }
     }
 
 } /* end OS_Lock_Global_Impl */
@@ -121,9 +127,12 @@ void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 
     impl = OS_impl_objtype_lock_table[idtype];
 
-    if (semGive(impl->vxid) != OK)
+    if (impl != NULL)
     {
-        OS_DEBUG("semGive() - vxWorks errno %d\n", errno);
+        if (semGive(impl->vxid) != OK)
+        {
+            OS_DEBUG("semGive() - vxWorks errno %d\n", errno);
+        }
     }
 
 } /* end OS_Unlock_Global_Impl */

--- a/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-idmap.c
@@ -42,7 +42,11 @@ void Test_OS_Lock_Global_Impl(void)
 
     UT_IdMapTest_SetImplTableMutex(OS_OBJECT_TYPE_OS_TASK, &TestGlobalSem);
     OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_semTake)) == 1, "semTake() called");
+    UtAssert_STUB_COUNT(OCS_semTake, 1);
+
+    /* The "undefined" type should not have a lock instantiated */
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_UNDEFINED);
+    UtAssert_STUB_COUNT(OCS_semTake, 1);
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_semTake), -1);
     OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK); /* for coverage of error path */
@@ -57,7 +61,11 @@ void Test_OS_Unlock_Global_Impl(void)
 
     UT_IdMapTest_SetImplTableMutex(OS_OBJECT_TYPE_OS_TASK, &TestGlobalSem);
     OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_semGive)) == 1, "semTake() called");
+    UtAssert_STUB_COUNT(OCS_semGive, 1);
+
+    /* The "undefined" type should not have a lock instantiated */
+    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_UNDEFINED);
+    UtAssert_STUB_COUNT(OCS_semGive, 1);
 
     UT_SetDefaultReturnValue(UT_KEY(OCS_semGive), -1);
     OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK); /* for coverage of error path */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Instantiate the condvar lock on rtems and vxworks even though the feature is not currently implemented.  This is because OS_MAX_CONDVARS must still be nonzero and if the "Create" function is called, it still goes through the motions of allocating an ID.

This also adds a NULL check in the lock implementation, and thus if a lock is not instantiated in the future this will not dereference a NULL pointer.

Fixes #1304

**Testing performed**
Build and run all tests

**Expected behavior changes**
Missing lock is instantiated
Add null check - Avoids possible null dereference in the event of a missing lock in the future

**System(s) tested on**
Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
