### PR TITLE
Fix #1284, add export targets and package script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,15 @@
 #                  Normally this setting is not needed to be configured as it is
 #                  inferred from the BSP type.
 #
+# OSAL_INSTALL_LIBRARIES : Boolean, enables "install" of targets listed above such 
+#                  that libraries and public API header files are copied into the system
+#                  location specified by CMAKE_INSTALL_PREFIX.  This set of headers
+#                  and link libraries can then be used to compile other applications
+#                  separately from OSAL.  Default is "ON" when OSAL is being compiled
+#                  standalone (i.e. cmake called directly on the OSAL source dir).
+#                  Default is "OFF" when OSAL is included via 'add_subdirectory' in 
+#                  a parent application project such as CFE/CFS.
+#
 # ENABLE_UNIT_TESTS : Boolean, enables build of the unit tests (coverage and functional)
 #
 # OSAL_OMIT_DEPRECATED : Boolean, Compile without deprecated or obsolete features for
@@ -99,7 +108,23 @@ define_property(TARGET PROPERTY OSAL_EXPECTED_OSTYPE
         "This property is used to indicate the OS implementation layer that is intended to be paired with the BSP implementation"
 )
 
+# If this build is being performed as a subdirectory within a larger project,
+# then the static libraries and header files will _not_ be installed by default,
+# as in those cases one would typically just use the "osal" target directly.
+# This behavior can be explicitly controlled via the OSAL_INSTALL_LIBRARIES option.
+get_directory_property(HAS_PARENT PARENT_DIRECTORY)
+if (HAS_PARENT)
+    set(OSAL_DEFAULT_INSTALL_LIBRARIES OFF)
+else()
+    set(OSAL_DEFAULT_INSTALL_LIBRARIES ON)
+endif()
+
+option(OSAL_INSTALL_LIBRARIES "Whether or not to install static libraries and headers" ${OSAL_DEFAULT_INSTALL_LIBRARIES})
 option(OSAL_OMIT_DEPRECATED   "Compile without deprecated or obsolete features for backward compatibility testing" OFF)
+
+if (OSAL_INSTALL_LIBRARIES)
+    include(CMakePackageConfigHelpers)
+endif()
 
 # The "OSAL_EXT_SOURCE_DIR" cache variable may be set to a path
 # on the host containing extra OS/BSP implementations which are not
@@ -406,7 +431,6 @@ endif (ENABLE_UNIT_TESTS)
 # If this build is being performed as a subdirectory within a larger project,
 # then export the important data regarding compile flags/dirs to that parent
 # This is conditional to avoid warnings in a standalone build.
-get_directory_property(HAS_PARENT PARENT_DIRECTORY)
 if (HAS_PARENT)
     # Export the UT coverage compiler/linker flags to the parent build.
     # These flags are based on the target system type and should be used
@@ -420,3 +444,35 @@ else(HAS_PARENT)
     # Note that in a CFE/integrated build, it is expected this will be built separately.
     add_subdirectory(docs/src docs)
 endif(HAS_PARENT)
+
+if (OSAL_INSTALL_LIBRARIES)
+
+    # Install and also export this library, so it can be found via
+    # "find_package()" from some other CMake build
+    install(
+        TARGETS osal_public_api osal_bsp osal
+        EXPORT nasa-osal-export
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/osal
+        INCLUDES DESTINATION include/osal
+    )
+    install(DIRECTORY
+        ${OSAL_SOURCE_DIR}/src/os/inc/
+        ${CMAKE_CURRENT_BINARY_DIR}/inc/
+      DESTINATION include/osal
+    )
+    install(EXPORT nasa-osal-export
+      FILE NasaOsalTargets.cmake
+      DESTINATION lib/cmake
+    )
+    configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/NasaOsalConfig.cmake.in
+        "${CMAKE_CURRENT_BINARY_DIR}/NasaOsalConfig.cmake"
+        INSTALL_DESTINATION lib/cmake
+    )
+    install(FILES
+          "${CMAKE_CURRENT_BINARY_DIR}/NasaOsalConfig.cmake"
+        DESTINATION lib/cmake
+    )
+
+endif()

--- a/NasaOsalConfig.cmake.in
+++ b/NasaOsalConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/NasaOsalTargets.cmake")
+
+check_required_components(NasaOsal)
+

--- a/src/ut-stubs/CMakeLists.txt
+++ b/src/ut-stubs/CMakeLists.txt
@@ -106,3 +106,11 @@ target_link_libraries(ut_osapi_stubs PUBLIC
     ut_assert
 )
 
+if (OSAL_INSTALL_LIBRARIES)
+    install(
+        TARGETS ut_osapi_stubs
+        EXPORT nasa-osal-export
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+endif()

--- a/ut_assert/CMakeLists.txt
+++ b/ut_assert/CMakeLists.txt
@@ -82,4 +82,25 @@ target_link_libraries(ut_coverage_compile INTERFACE ut_assert)
 add_library(ut_coverage_link INTERFACE)
 target_link_libraries(ut_coverage_link INTERFACE ut_assert)
 
+if (OSAL_INSTALL_LIBRARIES)
 
+    install(
+        TARGETS ut_assert ut_coverage_compile ut_coverage_link
+        EXPORT nasa-osal-export
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/ut_assert
+        INCLUDES DESTINATION include/ut_assert
+    )
+    install(DIRECTORY
+        ${UT_ASSERT_SOURCE_DIR}/inc/
+        DESTINATION include/ut_assert
+    )
+    install(
+        PROGRAMS scripts/generate_stubs.pl
+        DESTINATION bin
+        RENAME utassert_generate_stubs.pl
+    )
+
+endif()


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds optional "install" commands to CMake script, which is useful when building OSAL as a standalone software package.  The public API and static libraries will be installed to the specified system location, and can then be used to compile and link external OSAL applications without the need for the original OSAL source or build trees.

Note this also installs the "osconfig.h" file as this does affect the binary formats of some items (i.e. size of items using OS_MAX_API_NAME and other similar structure members).  The external application must be compiled using the same osconfig.h after installation.

Fixes #1284

**Testing performed**
Build OSAL with both CFE and standalone and run all tests (existing build)

Then run "make install" on standalone build to stage headers and library binaries to a build tree.  Tested an external application to using `find_package(NasaOsal)` and building against the OSAL headers and binaries provided by that exported package.

**Expected behavior changes**
Exports a CMake package containing targets that can be used by OTHER builds without necessarily having the full OSAL source tree integrated into that project.

**System(s) tested on**
Ubuntu 22.04

**Additional context**
This is necessary when developing standalone (non-CFE) software that still uses OSAL to provide portability to different systems and/or does any unit testing (the exported packages includes UT assert).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

