### PR TITLE
Fix #1322, add BUGCHECK_VOID macro

### DIFF
--- a/src/os/inc/osapi-macros.h
+++ b/src/os/inc/osapi-macros.h
@@ -136,4 +136,13 @@
  */
 #define LENGTHCHECK(str, len, errcode) ARGCHECK(memchr(str, '\0', len), errcode)
 
+/**
+ * @brief Bug-Check macro for void functions
+ *
+ * The basic BUGCHECK macro returns a value, which needs to be empty
+ * for functions that do not have a return value.  In this case the
+ * second argument (errcode) is intentionally left blank.
+ */
+#define BUGCHECK_VOID(cond) BUGCHECK(cond, )
+
 #endif /* OSAPI_MACROS_H */

--- a/src/os/shared/src/osapi-printf.c
+++ b/src/os/shared/src/osapi-printf.c
@@ -266,7 +266,7 @@ void OS_printf(const char *String, ...)
     char    msg_buffer[OS_BUFFER_SIZE];
     int     actualsz;
 
-    BUGCHECK((String) != NULL, )
+    BUGCHECK_VOID(String != NULL)
 
     if (OS_SharedGlobalVars.GlobalState != OS_INIT_MAGIC_NUMBER)
     {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a variant of the BUGCHECK macro that has no return value argument, which can be used in functions with no return value without the unusual syntax appearing in the code.

Fixes #1322

**Testing performed**
Basic build and run tests
Run cppcheck against source

**Expected behavior changes**
Cppcheck does not report a syntax error

**System(s) tested on**
Ubuntu 22.04 (using cppcheck v2.7)

**Additional context**
Just a wrapper macro is enough to satisfy cppcheck.  Added a note that the missing second argument (return value) is intentional on a void function.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

