### PR TITLE
Fix #1330, Move variables declared mid-function to the top

### DIFF
--- a/src/tests/time-base-api-test/time-base-api-test.c
+++ b/src/tests/time-base-api-test/time-base-api-test.c
@@ -74,6 +74,7 @@ void TestTimeBaseApi(void)
     osal_id_t          tb_id[OS_MAX_TIMEBASES];
     char               timebase_name[OS_MAX_API_NAME + 5];
     OS_timebase_prop_t timebase_prop;
+    int                i;
 
     /*
      * Test Case For:
@@ -89,7 +90,7 @@ void TestTimeBaseApi(void)
     UtAssert_INT32_EQ(OS_TimeBaseCreate(&time_base_id, timebase_name, 0), OS_ERR_NAME_TOO_LONG);
 
     /* Checking for OS_MAX_TIMEBASES */
-    for (int i = 0; i < OS_MAX_TIMEBASES; i++)
+    for (i = 0; i < OS_MAX_TIMEBASES; i++)
     {
         /* On the final setup pass, while there is still one free slot,
          * check attempting to create a duplicate name (index 0) - this

--- a/src/unit-test-coverage/shared/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-idmap.c
@@ -1157,6 +1157,8 @@ void Test_OS_ObjectIDInteger(void)
     int32             recordscount = 0;
     osal_objtype_t    idtype;
     char              str[OS_MAX_API_NAME];
+    int               i;
+    int               j;
 
     memset(&token, 0, sizeof(token));
 
@@ -1181,11 +1183,11 @@ void Test_OS_ObjectIDInteger(void)
 
     UtAssert_True(recordscount < OS_MAX_TOTAL_RECORDS, "All Id types checked");
 
-    for (int i = 0; i < recordscount; i++)
+    for (i = 0; i < recordscount; i++)
     {
         UtAssert_True(OS_ObjectIdDefined(typesI[i]), "%lu Is defined", OS_ObjectIdToInteger(typesI[i]));
 
-        for (int j = 0; j < recordscount; j++)
+        for (j = 0; j < recordscount; j++)
         {
             if (i == j)
             {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1330
  - A couple stray variables that were declared mid-function were moved to the top of their respective functions.

**Testing performed**
GitHub CI actions all passing successfully (excl. cppcheck issues being addressed in https://github.com/nasa/osal/issues/1325)

**Expected behavior changes**
All variables declared top of function as per cFS conventions/guidelines.

**Contributor Info**
Avi Weiss @thnkslprpt