### PR TITLE
Fix #1270: Truncate symbol name if > OS_MAX_SYM_LEN

### DIFF
--- a/src/os/vxworks/src/os-impl-symtab.c
+++ b/src/os/vxworks/src/os-impl-symtab.c
@@ -161,11 +161,20 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
      */
     state = &OS_VxWorks_SymbolDumpState;
 
+    /*
+    ** Copy symbol name
+    */
+    strncpy(symRecord.SymbolName, name, sizeof(symRecord.SymbolName) - 1);
+    symRecord.SymbolName[sizeof(symRecord.SymbolName) - 1] = '\0';
+
+    /*
+    ** Check to see if the max length of each symbol name has been reached
+    */
     if (memchr(name, 0, OS_MAX_SYM_LEN) == NULL)
     {
+        symRecord.SymbolName[sizeof(symRecord.SymbolName) - 2] = '*';
         OS_DEBUG("%s(): symbol name too long\n", __func__);
         state->StatusCode = OS_ERR_NAME_TOO_LONG;
-        return false;
     }
 
     /*
@@ -182,12 +191,6 @@ BOOL OS_SymTableIterator_Impl(char *name, SYM_VALUE val, SYM_TYPE type, _Vx_usr_
         state->StatusCode = OS_ERR_OUTPUT_TOO_LARGE;
         return false;
     }
-
-    /*
-    ** Copy symbol name
-    */
-    strncpy(symRecord.SymbolName, name, sizeof(symRecord.SymbolName) - 1);
-    symRecord.SymbolName[sizeof(symRecord.SymbolName) - 1] = 0;
 
     /*
     ** Save symbol address

--- a/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-symtab.c
@@ -77,7 +77,7 @@ void Test_OS_SymTableIterator_Impl(void)
 
     /* Check case where entry has a name that is too long */
     UT_SetDefaultReturnValue(UT_KEY(OCS_memchr), OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), false);
+    OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_CallIteratorFunc("ut", &Data, 100, 1000), true);
     OSAPI_TEST_FUNCTION_RC(UT_SymTabTest_GetIteratorStatus(), OS_ERR_NAME_TOO_LONG);
     UT_ClearDefaultReturnValue(UT_KEY(OCS_memchr));
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Truncates symbol name in symbol table dump if the length exceeds OS_MAX_SYM_LEN.

**Testing performed**
Tested against VxWorks 6.9 

**Expected behavior changes**
Dump completes successfully when symbol names exceed OS_MAX_SYM_LEN.

**System(s) tested on**
 - Hardware: SP0
 - OS: VxWorks 6.9

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
