### PR TITLE
Fix #1324, Fix #1325, cppcheck updates 

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,10 +4,12 @@ name: Static Analysis
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   static-analysis:
-    name: Run cppcheck
+    name: Run Static Analysis
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with: 
       strict-dir-list: './src/bsp ./src/os'
+      cmake-project-options: -DENABLE_UNIT_TESTS=TRUE -DOSAL_OMIT_DEPRECATED=TRUE -DOSAL_SYSTEM_BSPTYPE=generic-linux

--- a/src/os/portable/os-impl-posix-dl-symtab.c
+++ b/src/os/portable/os-impl-posix-dl-symtab.c
@@ -137,7 +137,7 @@ int32 OS_GenericSymbolLookup_Impl(void *dl_handle, cpuaddr *SymbolAddress, const
 int32 OS_SymbolLookup_Impl(cpuaddr *SymbolAddress, const char *SymbolName)
 {
     int32            status;
-    int32            local_status = OS_ERROR;
+    int32            local_status;
     OS_object_iter_t iter;
 
     /* First search global table */

--- a/src/os/posix/src/os-impl-console.c
+++ b/src/os/posix/src/os-impl-console.c
@@ -80,6 +80,7 @@ static void *OS_ConsoleTask_Entry(void *arg)
     OS_impl_console_internal_record_t *local;
     OS_object_token_t                  token;
 
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
     local_arg.opaque_arg = arg;
     if (OS_ObjectIdGetById(OS_LOCK_MODE_REFCOUNT, OS_OBJECT_TYPE_OS_CONSOLE, local_arg.id, &token) == OS_SUCCESS)
     {
@@ -125,6 +126,7 @@ int32 OS_ConsoleCreate_Impl(const OS_object_token_t *token)
             }
             else
             {
+                /* cppcheck-suppress unreadVariable // intentional use of other union member */
                 local_arg.id = OS_ObjectIdFromToken(token);
                 return_code  = OS_Posix_InternalTaskCreate_Impl(&consoletask, OS_CONSOLE_TASK_PRIORITY, 0,
                                                                OS_ConsoleTask_Entry, local_arg.opaque_arg);

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -114,6 +114,7 @@ static void *OS_PthreadTaskEntry(void *arg)
 {
     OS_VoidPtrValueWrapper_t local_arg;
 
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
     local_arg.opaque_arg = arg;
     OS_TaskEntryPoint(local_arg.id); /* Never returns */
 
@@ -574,8 +575,10 @@ int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
     OS_impl_task_internal_record_t *impl;
     OS_task_internal_record_t *     task;
 
-    arg.opaque_arg = NULL;
-    arg.id         = OS_ObjectIdFromToken(token);
+    memset(&arg, 0, sizeof(arg));
+
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
+    arg.id = OS_ObjectIdFromToken(token);
 
     task = OS_OBJECT_TABLE_GET(OS_task_table, *token);
     impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
@@ -787,8 +790,10 @@ int32 OS_TaskRegister_Impl(osal_id_t global_task_id)
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
     pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &old_type);
 
-    arg.opaque_arg = 0;
-    arg.id         = global_task_id;
+    memset(&arg, 0, sizeof(arg));
+
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
+    arg.id = global_task_id;
 
     return_code = pthread_setspecific(POSIX_GlobalVars.ThreadKey, arg.opaque_arg);
     if (return_code == 0)
@@ -814,6 +819,7 @@ osal_id_t OS_TaskGetId_Impl(void)
 {
     OS_VoidPtrValueWrapper_t self_record;
 
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
     self_record.opaque_arg = pthread_getspecific(POSIX_GlobalVars.ThreadKey);
 
     return self_record.id;

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -305,8 +305,10 @@ static void *OS_TimeBasePthreadEntry(void *arg)
 {
     OS_VoidPtrValueWrapper_t local_arg;
 
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
     local_arg.opaque_arg = arg;
     OS_TimeBase_CallbackThread(local_arg.id);
+
     return NULL;
 }
 
@@ -341,9 +343,11 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
      * Note the thread will not actually start running until this function exits and releases
      * the global table lock.
      */
-    arg.opaque_arg = NULL;
-    arg.id         = OS_ObjectIdFromToken(token);
-    return_code    = OS_Posix_InternalTaskCreate_Impl(&local->handler_thread, OSAL_PRIORITY_C(0), 0,
+    memset(&arg, 0, sizeof(arg));
+
+    /* cppcheck-suppress unreadVariable // intentional use of other union member */
+    arg.id      = OS_ObjectIdFromToken(token);
+    return_code = OS_Posix_InternalTaskCreate_Impl(&local->handler_thread, OSAL_PRIORITY_C(0), 0,
                                                    OS_TimeBasePthreadEntry, arg.opaque_arg);
     if (return_code != OS_SUCCESS)
     {

--- a/src/os/rtems/src/os-impl-filesys.c
+++ b/src/os/rtems/src/os-impl-filesys.c
@@ -168,11 +168,13 @@ int32 OS_FileSysStartVolume_Impl(const OS_object_token_t *token)
                 OS_DEBUG("rtems_blkdev_create() failed: %s.\n", rtems_status_text(sc));
                 return_code = OS_ERROR;
             }
+            else
+            {
+                OS_DEBUG("RAM disk initialized: volume=%s device=%s address=0x%08lX\n", local->volume_name,
+                         impl->blockdev_name, (unsigned long)local->address);
 
-            OS_DEBUG("RAM disk initialized: volume=%s device=%s address=0x%08lX\n", local->volume_name,
-                     impl->blockdev_name, (unsigned long)local->address);
-
-            return_code = OS_SUCCESS;
+                return_code = OS_SUCCESS;
+            }
             break;
         }
         default:

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -471,8 +471,10 @@ int32 OS_TimeBaseSet_Impl(const OS_object_token_t *token, uint32 start_time, uin
             */
             OS_UsecsToTicks(start_time, &start_ticks);
 
-            user_data.opaque_arg = NULL;
-            user_data.id         = OS_ObjectIdFromToken(token);
+            memset(&user_data, 0, sizeof(user_data));
+
+            /* cppcheck-suppress unreadVariable // intentional use of other union member */
+            user_data.id = OS_ObjectIdFromToken(token);
 
             status = rtems_timer_fire_after(local->rtems_timer_id, start_ticks, OS_TimeBase_ISR, user_data.opaque_arg);
             if (status != RTEMS_SUCCESSFUL)

--- a/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
+++ b/src/unit-tests/oscore-test/ut_oscore_countsem_test.c
@@ -93,16 +93,18 @@ void UT_os_count_sem_create_test()
     /* #4 Initial-count-too-high */
 
     /*
-     * This test can only be done if the OS defines a specific "SEM_VALUE_MAX"
-     * The OSAL should define this for itself, but it currently does not.
-     *  (This macro is not currently defined in RTEMS)
+     * The intent with this test case is to call OS_CountSemCreate() with an initial
+     * value greater than SEM_VALUE_MAX and confirm it returns OS_INVALID_SEM_VALUE.
+     *
+     * However, none of the currently available test platforms are able to produce
+     * this condition, because SEM_VALUE_MAX is either not defined/exposed or it
+     * is equal to UINT32_MAX and thus impossible to pass a value greater than this.
+     *
+     * Therefore a placeholder is here in case a platform in the future does permit
+     * it to be tested.  Note that the check and return value is still tested in the
+     * coverage test for this function.
      */
-#if defined(SEM_VALUE_MAX) && SEM_VALUE_MAX < UINT32_MAX
-    UT_RETVAL(OS_CountSemCreate(&count_sem_ids[0], "CountSem1", ((uint32)SEM_VALUE_MAX) + 1, 0), OS_INVALID_SEM_VALUE,
-              "#4 Initial-count-too-high");
-#else
     UtAssert_NA("#4 Initial-count-too-high");
-#endif
 
     /*-----------------------------------------------------*/
     /* #5 No-free-IDs */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Passes a cmake configuration so cppcheck can use the exported commands, allowing it to use all header files that the actual build uses.

Also Resolves a number of other issues reported by cppcheck

Fixes #1324
Fixes #1325

**Testing performed**
Build and run tests
Verify results of static analysis workflow

**Expected behavior changes**
Static analysis workflow should be clean

**System(s) tested on**
Github workflow

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
