### PR TITLE
Fix #1339, add doc-prebuild dependency

### DIFF
--- a/.github/workflows/build-osal-documentation.yml
+++ b/.github/workflows/build-osal-documentation.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Build OSAL API Guide
         run: |
-          make osal-apiguide > make_osal-apiguide_stdout.txt 2> make_osal-apiguide_stderr.txt
-          mv build/docs/osal-apiguide-warnings.log osal-apiguide-warnings.log          
+          make osal-apiguide 2>&1 > make_osal-apiguide_stdout.txt | tee make_osal-apiguide_stderr.txt
+          mv build/docs/osal-apiguide-warnings.log osal-apiguide-warnings.log
 
       - name: Archive Osal Guide Build Logs
         uses: actions/upload-artifact@v2

--- a/docs/src/CMakeLists.txt
+++ b/docs/src/CMakeLists.txt
@@ -68,16 +68,24 @@ endif ()
 # Generate the list of actual header files from the directories specified.  This is done
 # as a target that runs a separate script such that generator expressions can be evaluated.
 # This is done as a custom target such that it runs and gets updated every build
-add_custom_target(osal_public_api_headerlist 
+add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/docs/osal-public-api.doxyfile"
     COMMAND ${CMAKE_COMMAND}
         -DINCLUDE_DIRECTORIES="${OSAL_API_INCLUDE_DIRECTORIES}"
         -DCOMPILE_DEFINITIONS="${OSAL_API_COMPILE_DEFINITIONS}"
         -DINPUT_TEMPLATE="${CMAKE_CURRENT_SOURCE_DIR}/osal-public-api.doxyfile.in"
         -DOUTPUT_FILE="${CMAKE_BINARY_DIR}/docs/osal-public-api.doxyfile"
         -P "${CMAKE_CURRENT_SOURCE_DIR}/generate-public-api-doxyfile.cmake"
-    BYPRODUCTS "${CMAKE_BINARY_DIR}/docs/osal-public-api.doxyfile"
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
+
+add_custom_target(osal_public_api_headerlist
+    DEPENDS "${CMAKE_BINARY_DIR}/docs/osal-public-api.doxyfile")
+
+# if building as part of CFS, then generate the doxygen header list as part of the prebuild step
+# The "doc-prebuild" target is defined by the CFS build, and thus will not exist if building standalone
+if (TARGET doc-prebuild)
+   add_dependencies(doc-prebuild osal_public_api_headerlist)
+endif ()
 
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/osal-apiguide-warnings.log OSAL_NATIVE_LOGFILE)
 file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/docs/osal-common.doxyfile OSAL_NATIVE_COMMON_CFGFILE)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
When building as part of CFE/CFS, register the osal header list file (osal-public-api.doxyfile) as a dependency of the doc-prebuild abstract target.  This way, CFE and any other CFS apps that refer to the OSAL headers in their documentation can easily ensure that this (and any other file produced by other modules) exist prior to attempting to run doxygen.

Fixes #1339

**Testing performed**
Build documentation

**Expected behavior changes**
None directly to OSAL, but dependent items can now operate correctly

**System(s) tested on**
Github hosted runner

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
