### PR TITLE
Fix #1345, Support adding default flags at task creation

### DIFF
--- a/default_config.cmake
+++ b/default_config.cmake
@@ -347,3 +347,14 @@ set(OSAL_CONFIG_MAX_CMD_LEN             1000
 set(OSAL_CONFIG_QUEUE_MAX_DEPTH         50
     CACHE STRING "Maximum depth of message queue"
 )
+
+# Flags added to all tasks on creation
+#
+# Some OS's use floating point under the hood, this supports
+# adding the floating point flag on creation of all tasks instead of
+# just when OS_FP_ENABLED flag is passed in to OS_TaskCreate
+#
+# Set to 0 to not add any
+set(OSAL_CONFIG_ADD_TASK_FLAGS              0
+    CACHE STRING "Flags added to all tasks"
+)

--- a/osconfig.h.in
+++ b/osconfig.h.in
@@ -244,6 +244,15 @@
   */
 #define OS_PRINTF_CONSOLE_NAME          "@OSAL_CONFIG_PRINTF_CONSOLE_NAME@"
 
+ /**
+  * \brief Flags added to all tasks on creation
+  *
+  * Added to the task flags on creation
+  *
+  * Supports adding floating point support for all tasks when the OS requires it
+  */
+#define OS_ADD_TASK_FLAGS               @OSAL_CONFIG_ADD_TASK_FLAGS@
+
 /*
  * OSAL fixed resource limits
  *

--- a/src/os/shared/src/osapi-task.c
+++ b/src/os/shared/src/osapi-task.c
@@ -192,6 +192,9 @@ int32 OS_TaskCreate(osal_id_t *task_id, const char *task_name, osal_task_entry f
         task->entry_function_pointer = function_pointer;
         task->stack_pointer          = stack_pointer;
 
+        /* Add default flags */
+        flags |= OS_ADD_TASK_FLAGS;
+
         /* Now call the OS-specific implementation.  This reads info from the task table. */
         return_code = OS_TaskCreate_Impl(&token, flags);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1345 

**Testing performed**
CI, also tested on RTEMS5/leon3 with OS_FP_ENABLED

**Expected behavior changes**
No default change but supports adding flags at task creation

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC