### PR TITLE
Fix #1349 #1447, Break up pc-rtems to support generic configuration and add tarfs support

### DIFF
--- a/src/bsp/generic-rtems/CMakeLists.txt
+++ b/src/bsp/generic-rtems/CMakeLists.txt
@@ -1,0 +1,85 @@
+######################################################################
+#
+# CMAKE build recipe for GENERIC-RTEMS Board Support Package (BSP)
+#
+######################################################################
+
+# Basic set of files
+set(OS_BSP_SRCLIST
+    src/bsp_console.c
+    src/bsp_init.c
+    src/bsp_start.c
+)
+
+# Source select file system setup implementation
+if (RTEMS_INCLUDE_TARFS)
+    list(APPEND OS_BSP_SRCLIST
+        src/bsp_tarfs_setupfs.c
+    )
+else ()
+    # NOTE: rtems config needs to define supporting configuration (FILESYSTEM and DRIVERs)
+    list(APPEND OS_BSP_SRCLIST
+        src/bsp_mount_setupfs.c
+    )
+endif ()
+
+# Link rtemscpu to osal public api if not dynamic loading
+if (NOT RTEMS_DYNAMIC_LOAD)
+    target_link_libraries(osal_public_api INTERFACE
+          rtemscpu
+    )
+endif ()
+
+if (RTEMS_NO_SHELL)
+    list(APPEND OS_BSP_SRCLIST
+        src/bsp_no_shell.c
+    )
+else ()
+    list(APPEND OS_BSP_SRCLIST
+        src/bsp_shell.c
+    )
+endif ()
+
+if (RTEMS_NO_CMDLINE)
+    list(APPEND OS_BSP_SRCLIST
+        src/bsp_no_cmdline.c
+    )
+else ()
+    list(APPEND OS_BSP_SRCLIST
+        src/bsp_cmdline.c
+    )
+endif ()
+
+add_library(osal_generic-rtems_impl OBJECT
+    ${OS_BSP_SRCLIST}
+)
+
+# This definition is needed for the gethostname call
+# By defining this, it avoids the need to use the -std=gnu99
+#  instead of the preferred -std=c99 GCC switch
+target_compile_definitions(osal_public_api INTERFACE
+   _BSD_SOURCE
+)
+
+set_property(TARGET osal_generic-rtems_impl PROPERTY OSAL_EXPECTED_OSTYPE "rtems")
+
+# The list of header files that control configuration
+set(BSP_RTEMS_CONFIG_FILE_LIST
+  bsp_rtems_cfg.h
+)
+
+# Create wrappers around all the config header files
+# This makes them individually overridable by the missions, without modifying
+# the distribution default copies
+foreach(BSP_RTEMS_CFGFILE ${BSP_RTEMS_CONFIG_FILE_LIST})
+  get_filename_component(CFGKEY "${BSP_RTEMS_CFGFILE}" NAME_WE)
+  if (DEFINED BSP_RTEMS_CFGFILE_SRC_${CFGKEY})
+    set(DEFAULT_SOURCE GENERATED_FILE "${BSP_RTEMS_CFGFILE_SRC_${CFGKEY}}")
+  else()
+    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${BSP_RTEMS_CFGFILE}")
+  endif()
+  generate_config_includefile(
+    FILE_NAME           "${BSP_RTEMS_CFGFILE}"
+    ${DEFAULT_SOURCE}
+  )
+endforeach()

--- a/src/bsp/generic-rtems/config/default_bsp_rtems_cfg.h
+++ b/src/bsp/generic-rtems/config/default_bsp_rtems_cfg.h
@@ -1,0 +1,82 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as �~@~\core Flight System: Bootes�~@~]
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Default RTEMS OS Configuration definitions
+ *
+ * @note
+ *   This file may be overridden/superseded by mission-provided definitions
+ *   by overriding this header.
+ */
+#ifndef BSP_RTEMS_CFG_H
+#define BSP_RTEMS_CFG_H
+
+#include "osconfig.h"
+
+#define TASK_INTLEVEL 0
+#define CONFIGURE_INIT
+#define CONFIGURE_INIT_TASK_ATTRIBUTES \
+    (RTEMS_FLOATING_POINT | RTEMS_PREEMPT | RTEMS_NO_TIMESLICE | RTEMS_ASR | RTEMS_INTERRUPT_LEVEL(TASK_INTLEVEL))
+#define CONFIGURE_INIT_TASK_STACK_SIZE (20 * 1024)
+#define CONFIGURE_INIT_TASK_PRIORITY   10
+
+/*
+ * Note that these resources are shared with RTEMS itself (e.g. the init task, the shell)
+ * so they should be allocated slightly higher than the user limits in osconfig.h
+ *
+ * Many RTEMS services use tasks internally, including the idle task, BSWP, ATA driver,
+ * low level console I/O, the shell, TCP/IP network stack, and DHCP (if enabled).
+ * Many of these also use semaphores for synchronization.
+ *
+ * Budgeting for additional:
+ *   8 internal tasks
+ *   2 internal timers
+ *   4 internal queues
+ *   16 internal semaphores
+ *
+ */
+#define CONFIGURE_MAXIMUM_TASKS          (OS_MAX_TASKS + 8)
+#define CONFIGURE_MAXIMUM_TIMERS         (OS_MAX_TIMERS + 2)
+#define CONFIGURE_MAXIMUM_SEMAPHORES     (OS_MAX_BIN_SEMAPHORES + OS_MAX_COUNT_SEMAPHORES + OS_MAX_MUTEXES + 16)
+#define CONFIGURE_MAXIMUM_MESSAGE_QUEUES (OS_MAX_QUEUES + 4)
+#define CONFIGURE_MAXIMUM_DRIVERS        10
+#define CONFIGURE_MAXIMUM_POSIX_KEYS     4
+#ifdef OS_RTEMS_4_DEPRECATED
+#define CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS (OS_MAX_NUM_OPEN_FILES + 8)
+#else
+#define CONFIGURE_MAXIMUM_FILE_DESCRIPTORS (OS_MAX_NUM_OPEN_FILES + 8)
+#endif
+
+#define CONFIGURE_RTEMS_INIT_TASKS_TABLE
+#define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER
+#define CONFIGURE_APPLICATION_NEEDS_CLOCK_DRIVER
+#define CONFIGURE_USE_IMFS_AS_BASE_FILESYSTEM
+#define CONFIGURE_FILESYSTEM_RFS
+#define CONFIGURE_FILESYSTEM_IMFS
+#define CONFIGURE_FILESYSTEM_DOSFS
+#define CONFIGURE_FILESYSTEM_DEVFS
+#define CONFIGURE_APPLICATION_NEEDS_LIBBLOCK
+#define CONFIGURE_APPLICATION_NEEDS_IDE_DRIVER
+#define CONFIGURE_APPLICATION_NEEDS_ATA_DRIVER
+
+#define CONFIGURE_EXECUTIVE_RAM_SIZE       (8 * 1024 * 1024)
+#define CONFIGURE_MICROSECONDS_PER_TICK    10000
+#define CONFIGURE_ATA_DRIVER_TASK_PRIORITY 9
+
+#endif

--- a/src/bsp/generic-rtems/src/bsp_cmdline.c
+++ b/src/bsp/generic-rtems/src/bsp_cmdline.c
@@ -1,0 +1,128 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP command line implementation
+ */
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <bsp.h>
+#include <rtems.h>
+
+#include "pcrtems_bsp_internal.h"
+
+/*
+ * BSP compile-time tuning
+ */
+#define RTEMS_MAX_USER_OPTIONS 4
+#define RTEMS_MAX_CMDLINE      256
+
+void OS_BSP_CmdLine(void)
+{
+    char        userargbuffer[RTEMS_MAX_CMDLINE];
+    const char *cmdlinestr;
+    const char *cmdp;
+    char *      cmdi, *cmdo;
+
+    cmdlinestr = bsp_cmdline();
+
+    /*
+     * Parse command line string (passed in from bootloader)
+     *
+     * Known arguments are handled here, and unknown args are
+     * saved for the UT application.
+     *
+     * Batch mode is intended for non-interactive execution.
+     *
+     * It does two things:
+     * - do not start the shell task
+     * - when tests are complete, shutdown the executive
+     *
+     * The BSP should be configured with these options to
+     * make this most useful:
+     *   USE_COM1_AS_CONSOLE=1
+     *   BSP_PRESS_KEY_FOR_RESET=0
+     *   BSP_RESET_BOARD_AT_EXIT=1
+     *
+     * This way all the test output will be sent to COM1
+     * and then immediately resets the CPU when done.
+     *
+     * When running under QEMU the "-no-reboot" flag is
+     * also useful to shutdown QEMU rather than resetting.
+     */
+    if (cmdlinestr != NULL)
+    {
+        printf(" Bootloader Command Line: %s\n", cmdlinestr);
+
+        cmdp = cmdlinestr;
+        cmdo = NULL;
+        cmdi = NULL;
+
+        while (1)
+        {
+            if (isgraph((int)*cmdp))
+            {
+                if (cmdo == NULL)
+                {
+                    cmdo = userargbuffer;
+                }
+                else
+                {
+                    ++cmdo;
+                }
+                if (cmdi == NULL)
+                {
+                    cmdi = cmdo;
+                }
+                *cmdo = *cmdp;
+            }
+            else if (cmdi != NULL)
+            {
+                ++cmdo;
+                *cmdo = 0;
+                if (strcmp(cmdi, "--batch-mode") == 0)
+                {
+                    OS_BSP_PcRtemsGlobal.BatchMode = true;
+                }
+                else if (OS_BSP_Global.ArgC < RTEMS_MAX_USER_OPTIONS)
+                {
+                    /* save other args for app */
+                    OS_BSP_Global.ArgV[OS_BSP_Global.ArgC] = cmdi;
+                    ++OS_BSP_Global.ArgC;
+                }
+                cmdi = NULL;
+            }
+
+            if (*cmdp == 0)
+            {
+                break;
+            }
+
+            ++cmdp;
+        }
+    }
+}

--- a/src/bsp/generic-rtems/src/bsp_cmdline.h
+++ b/src/bsp/generic-rtems/src/bsp_cmdline.h
@@ -1,0 +1,31 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * Purpose:
+ *   Header file for bsp cmdline
+ */
+
+#ifndef BSP_CMDLINE_H
+#define BSP_CMDLINE_H
+
+void OS_BSP_CmdLine(void);
+
+#endif

--- a/src/bsp/generic-rtems/src/bsp_console.c
+++ b/src/bsp/generic-rtems/src/bsp_console.c
@@ -1,0 +1,54 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP debug console abstraction
+ */
+
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "pcrtems_bsp_internal.h"
+#include "bsp-impl.h"
+
+/****************************************************************************************
+                    BSP CONSOLE IMPLEMENTATION FUNCTIONS
+ ****************************************************************************************/
+
+/*----------------------------------------------------------------
+   OS_BSP_ConsoleOutput_Impl
+   See full description in header
+ ------------------------------------------------------------------*/
+void OS_BSP_ConsoleOutput_Impl(const char *Str, size_t DataLen)
+{
+    /* writes the raw data directly to STDOUT_FILENO (unbuffered) */
+    write(STDOUT_FILENO, Str, DataLen);
+}
+
+/*----------------------------------------------------------------
+   OS_BSP_ConsoleSetMode_Impl() definition
+   See full description in header
+ ------------------------------------------------------------------*/
+void OS_BSP_ConsoleSetMode_Impl(uint32 ModeBits)
+{
+    /* no-op on RTEMS */
+}

--- a/src/bsp/generic-rtems/src/bsp_init.c
+++ b/src/bsp/generic-rtems/src/bsp_init.c
@@ -1,0 +1,39 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   RTEMS main entry point
+ *   Configures RTEMS and wraps OS_BSPMain for use in a stand alone executable
+ */
+#include "bsp_start.h"
+#include "bsp-impl.h"
+
+/* BSP RTEMS configuration, must be in this order */
+#include <rtems.h>
+#include "bsp_rtems_cfg.h"
+#include <rtems/confdefs.h>
+
+/*
+ * A simple entry point to start from the loader
+ */
+rtems_task Init(rtems_task_argument ignored)
+{
+    OS_BSPMain();
+}

--- a/src/bsp/generic-rtems/src/bsp_mount_setupfs.c
+++ b/src/bsp/generic-rtems/src/bsp_mount_setupfs.c
@@ -1,0 +1,118 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP set up file system with user mount
+ */
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <rtems.h>
+#include <rtems/bdbuf.h>
+#include <rtems/blkdev.h>
+#include <rtems/diskdevs.h>
+#include <rtems/bdpart.h>
+#include <rtems/error.h>
+#include <rtems/ramdisk.h>
+#include <rtems/dosfs.h>
+#include <rtems/fsmount.h>
+
+#if defined(OS_RTEMS_4_DEPRECATED) || defined(OS_RTEMS_5)
+#include <rtems/mkrootfs.h>
+#endif
+
+#include "bsp-impl.h"
+#include "bsp_setupfs.h"
+
+/*
+ * The location which the general purpose file system will be mounted
+ */
+#define RTEMS_USER_FS_MOUNTPOINT "/mnt"
+
+/*
+**  External Declarations
+*/
+extern rtems_status_code rtems_ide_part_table_initialize(const char *);
+
+void OS_BSP_SetupFS(void)
+{
+    int         status;
+    struct stat statbuf;
+
+#if defined(OS_RTEMS_4_DEPRECATED) || defined(OS_RTEMS_5)
+    /*
+    ** Create the RTEMS Root file system
+    */
+    status = rtems_create_root_fs();
+    if (status != RTEMS_SUCCESSFUL)
+    {
+        printf("Creating Root file system failed: %s\n", rtems_status_text(status));
+    }
+#endif
+
+    /*
+     * Create the mountpoint for the general purpose file system
+     */
+    if (stat(RTEMS_USER_FS_MOUNTPOINT, &statbuf) < 0)
+    {
+        status = mkdir(RTEMS_USER_FS_MOUNTPOINT,
+                       S_IFDIR | S_IRWXU | S_IRWXG | S_IRWXO); /* For nonvol filesystem mountpoint */
+        if (status < 0)
+        {
+            printf("mkdir failed: %s\n", strerror(errno));
+        }
+    }
+
+    /*
+     * Register the IDE partition table.
+     */
+    status = rtems_ide_part_table_initialize("/dev/hda");
+    if (status != RTEMS_SUCCESSFUL)
+    {
+        /* note this is not necessarily an error, it just means there
+         * will be no persistent storage in this instance.  The IMFS
+         * is still available. */
+        BSP_DEBUG("warning: /dev/hda partition table not found: %s / %s\n", rtems_status_text(status), strerror(errno));
+        BSP_DEBUG("Persistent storage will NOT be mounted\n");
+    }
+    else
+    {
+        status = mount("/dev/hda1", RTEMS_USER_FS_MOUNTPOINT, RTEMS_FILESYSTEM_TYPE_DOSFS, RTEMS_FILESYSTEM_READ_WRITE,
+                       NULL);
+        if (status < 0)
+        {
+            BSP_DEBUG("mount failed: %s\n", strerror(errno));
+        }
+    }
+
+    /*
+     * Change to the user storage mountpoint dir, which
+     * will be the basis of relative directory refs.
+     * If mounted, it will be persistent, otherwise
+     * it will be an IMFS dir, but should generally work.
+     */
+    chdir(RTEMS_USER_FS_MOUNTPOINT);
+}

--- a/src/bsp/generic-rtems/src/bsp_no_cmdline.c
+++ b/src/bsp/generic-rtems/src/bsp_no_cmdline.c
@@ -1,0 +1,32 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP no command line implementation
+ */
+
+#include <stdio.h>
+
+#include "bsp_cmdline.h"
+
+void OS_BSP_CmdLine(void)
+{
+    printf("RTEMS_NO_CMDLINE:TRUE, command line not implemented");
+}

--- a/src/bsp/generic-rtems/src/bsp_no_shell.c
+++ b/src/bsp/generic-rtems/src/bsp_no_shell.c
@@ -1,0 +1,33 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP no shell implementation
+ */
+
+#include <stdio.h>
+#include "pcrtems_bsp_internal.h"
+#include "bsp_shell.h"
+
+void OS_BSP_Shell(void)
+{
+    printf("RTEMS_NO_SHELL:TRUE, shell not implemented");
+    OS_BSP_PcRtemsGlobal.BatchMode = true;
+}

--- a/src/bsp/generic-rtems/src/bsp_setupfs.h
+++ b/src/bsp/generic-rtems/src/bsp_setupfs.h
@@ -1,0 +1,31 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * Purpose:
+ *   Header file for bsp setup file system
+ */
+
+#ifndef BSP_SETUPFS_H
+#define BSP_SETUPFS_H
+
+void OS_BSP_SetupFS(void);
+
+#endif

--- a/src/bsp/generic-rtems/src/bsp_shell.c
+++ b/src/bsp/generic-rtems/src/bsp_shell.c
@@ -1,0 +1,97 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP shell implementation
+ */
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <bsp.h>
+#include <rtems.h>
+#include <rtems/shell.h>
+#include <rtems/rtl/dlfcn-shell.h>
+
+#include "pcrtems_bsp_internal.h"
+
+#include "bsp_shell.h"
+
+/*
+ * By default put the shell at the same priority
+ * as the utility task which handles OS_printf()
+ */
+#define RTEMS_SHELL_PRIORITY OS_UTILITYTASK_PRIORITY
+
+/*
+**  External Declarations
+*/
+extern int rtems_rtl_shell_command(int argc, char *argv[]);
+
+/*
+ * Additional shell commands for the RTL functionality
+ */
+rtems_shell_cmd_t rtems_shell_RTL_Command = {
+    .name = "rtl", .usage = "rtl COMMAND...", .topic = "misc", .command = rtems_rtl_shell_command};
+rtems_shell_cmd_t rtems_shell_dlopen_Command = {
+    .name = "dlopen", .usage = "dlopen COMMAND...", .topic = "misc", .command = shell_dlopen};
+rtems_shell_cmd_t rtems_shell_dlsym_Command = {
+    .name = "dlsym", .usage = "dlsym COMMAND...", .topic = "misc", .command = shell_dlsym};
+
+void OS_BSP_Shell(void)
+{
+    int status;
+
+    /* Supports command line enable/disable of batch mode */
+    if (!OS_BSP_PcRtemsGlobal.BatchMode)
+    {
+        printf("RTEMS_NO_SHELL:FALSE, BatchMode:FALSE, shell implemented and initialized");
+
+        status = rtems_shell_init("SHLL", RTEMS_MINIMUM_STACK_SIZE * 4, RTEMS_SHELL_PRIORITY, "/dev/console", false,
+                                  false, NULL);
+        if (status < 0)
+        {
+            printf("shell init failed: %d / %s\n", status, strerror(errno));
+        }
+
+        /* give a small delay to let the shell start,
+           avoids having the login prompt show up mid-test,
+           and gives a little time for pending output to actually
+           be sent to the console in case of a slow port */
+        rtems_task_wake_after(50);
+    }
+    else
+    {
+        printf("RTEMS_NO_SHELL:FALSE, BatchMode:TRUE, shell implemented but not initialized");
+    }
+}
+
+#define CONFIGURE_SHELL_COMMANDS_INIT
+#define CONFIGURE_SHELL_COMMANDS_ALL
+#define CONFIGURE_SHELL_MOUNT_MSDOS
+
+#define CONFIGURE_SHELL_USER_COMMANDS &rtems_shell_RTL_Command, &rtems_shell_dlopen_Command, &rtems_shell_dlsym_Command
+
+#include <rtems/shellconfig.h>

--- a/src/bsp/generic-rtems/src/bsp_shell.h
+++ b/src/bsp/generic-rtems/src/bsp_shell.h
@@ -1,0 +1,31 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * Purpose:
+ *   Header file for bsp shell
+ */
+
+#ifndef BSP_SHELL_H
+#define BSP_SHELL_H
+
+void OS_BSP_Shell(void);
+
+#endif

--- a/src/bsp/generic-rtems/src/bsp_start.c
+++ b/src/bsp/generic-rtems/src/bsp_start.c
@@ -1,0 +1,223 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP main entry point.
+ */
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <bsp.h>
+#include <rtems.h>
+#include <rtems/bdbuf.h>
+#include <rtems/error.h>
+
+#include "pcrtems_bsp_internal.h"
+
+#include "bsp_setupfs.h"
+#include "bsp_shell.h"
+#include "bsp_cmdline.h"
+
+/*
+ * Handle the differences between RTEMS 5 and 4.11 copyright notice
+ */
+#ifdef OS_RTEMS_4_DEPRECATED
+#define OSAL_BSP_COPYRIGHT_NOTICE _Copyright_Notice
+#else
+#define OSAL_BSP_COPYRIGHT_NOTICE rtems_get_copyright_notice()
+#endif
+
+/*
+** Global variables
+*/
+OS_BSP_PcRtemsGlobalData_t OS_BSP_PcRtemsGlobal;
+
+void OS_BSP_Setup(void)
+{
+    int status;
+
+    printf("\n\n*** RTEMS Info ***\n");
+    printf("%s\n", OSAL_BSP_COPYRIGHT_NOTICE);
+    printf("%s\n\n", rtems_get_version_string());
+    printf(" Stack size=%d\n", (int)rtems_configuration_get_stack_space_size());
+    printf(" Workspace size=%d\n", (int)rtems_configuration_get_work_space_size());
+
+    /* Process command line based on selected implementation */
+    OS_BSP_CmdLine();
+
+    printf("\n");
+    printf("*** End RTEMS info ***\n\n");
+
+    /*
+     * Initialize the low level access sem
+     */
+    status = rtems_semaphore_create(rtems_build_name('B', 'S', 'P', '\0'), 1,
+                                    RTEMS_PRIORITY | RTEMS_BINARY_SEMAPHORE | RTEMS_INHERIT_PRIORITY, 0,
+                                    &OS_BSP_PcRtemsGlobal.AccessMutex);
+    if (status != RTEMS_SUCCESSFUL)
+    {
+        BSP_DEBUG("rtems_semaphore_create: %s\n", rtems_status_text(status));
+    }
+
+    /* Set up file system based on selected implementation */
+    OS_BSP_SetupFS();
+
+    /*
+     * Start the shell now based on selected implementation
+     *
+     * This way, if there is an issue with the application startup,
+     * the shell can still be used to debug the system.
+     *
+     * The shell is _NOT_ started if BatchMode global is TRUE
+     * which supports completely autonomous execution
+     */
+    OS_BSP_Shell();
+
+    printf("\n\n");
+}
+
+/*----------------------------------------------------------------
+   OS_BSP_Lock_Impl
+   See full description in header
+ ------------------------------------------------------------------*/
+void OS_BSP_Lock_Impl(void)
+{
+    rtems_status_code status;
+    status = rtems_semaphore_obtain(OS_BSP_PcRtemsGlobal.AccessMutex, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
+    if (status != RTEMS_SUCCESSFUL)
+    {
+        BSP_DEBUG("rtems_semaphore_obtain: %s\n", rtems_status_text(status));
+    }
+}
+
+/*----------------------------------------------------------------
+   OS_BSP_Unlock_Impl
+   See full description in header
+ ------------------------------------------------------------------*/
+void OS_BSP_Unlock_Impl(void)
+{
+    rtems_status_code status;
+    status = rtems_semaphore_release(OS_BSP_PcRtemsGlobal.AccessMutex);
+    if (status != RTEMS_SUCCESSFUL)
+    {
+        BSP_DEBUG("rtems_semaphore_release: %s\n", rtems_status_text(status));
+    }
+}
+
+/* ---------------------------------------------------------
+    OS_BSP_GetReturnStatus()
+
+     Helper function to convert an OSAL status code into
+     a code suitable for returning to the OS.
+   --------------------------------------------------------- */
+rtems_status_code OS_BSP_GetReturnStatus(void)
+{
+    rtems_status_code retcode;
+    const char *      StatusStr;
+
+    switch (OS_BSP_Global.AppStatus)
+    {
+        case OS_SUCCESS:
+            /* translate OS_SUCCESS to the system RTEMS_SUCCESSFUL value */
+            StatusStr = "SUCCESS";
+            retcode   = RTEMS_SUCCESSFUL;
+            break;
+
+        default:
+            /* translate anything else to a generic non-success code,
+             * this basically just means the main task exited */
+            StatusStr = "ERROR";
+            retcode   = RTEMS_TASK_EXITTED;
+            break;
+    }
+
+    printf("\nApplication exit status: %s (%d)\n\n", StatusStr, (int)OS_BSP_Global.AppStatus);
+    rtems_task_wake_after(100);
+
+    return retcode;
+}
+
+/* ---------------------------------------------------------
+    OS_BSP_Shutdown_Impl()
+
+     Helper function to abort the running task
+   --------------------------------------------------------- */
+void OS_BSP_Shutdown_Impl(void)
+{
+    /*
+     * Not calling exit() under RTEMS, this simply shuts down the executive,
+     * forcing the user to reboot the system.
+     *
+     * Calling suspend causes execution to get stuck here, but the RTEMS
+     * shell thread will still be active so the user can poke around, read results,
+     * then use a shell command to reboot when ready.
+     */
+    while (!OS_BSP_PcRtemsGlobal.BatchMode)
+    {
+        printf("\n\nInit thread idle.\nPress <enter> for shell or reset machine...\n\n");
+        rtems_task_suspend(rtems_task_self());
+    }
+
+    rtems_shutdown_executive(OS_BSP_GetReturnStatus());
+}
+
+/*
+ ** A simple entry point callable from Init or can be loaded and started within an rki
+ */
+void OS_BSPMain(void)
+{
+    /*
+     * Initially clear the global object
+     */
+    memset(&OS_BSP_Global, 0, sizeof(OS_BSP_Global));
+    memset(&OS_BSP_PcRtemsGlobal, 0, sizeof(OS_BSP_PcRtemsGlobal));
+
+    /*
+     * Perform BSP setup -
+     * Initialize the root file system, create mount points, etc.
+     */
+    OS_BSP_Setup();
+
+    /*
+     * Call application specific entry point.
+     * This should set up all user tasks and resources, then return
+     */
+    OS_Application_Startup();
+
+    /*
+     * OS_Application_Run() implements the background task.
+     * The user application may provide this, or a default implementation
+     * is used which just calls OS_IdleLoop().
+     */
+    OS_Application_Run();
+
+    /*
+     * Enter the BSP default shutdown mode
+     * depending on config, this may reset/reboot or suspend
+     * so the operator can use the shell.
+     */
+    OS_BSP_Shutdown_Impl();
+}

--- a/src/bsp/generic-rtems/src/bsp_start.h
+++ b/src/bsp/generic-rtems/src/bsp_start.h
@@ -1,0 +1,31 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * Purpose:
+ *   Header file for bsp start
+ */
+
+#ifndef BSP_START_H
+#define BSP_START_H
+
+void OS_BSPMain(void);
+
+#endif

--- a/src/bsp/generic-rtems/src/bsp_tarfs_setupfs.c
+++ b/src/bsp/generic-rtems/src/bsp_tarfs_setupfs.c
@@ -1,0 +1,43 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * \file
+ *
+ *   OSAL BSP set up file system with tarfs
+ */
+#include <stdio.h>
+#include <rtems/untar.h>
+#include "bsp_setupfs.h"
+
+/* Tar file symbols */
+extern int _binary_tarfile_start;
+extern int _binary_tarfile_size;
+
+void OS_BSP_SetupFS(void)
+{
+    int status;
+
+    /* Initialize the file system using tarfs */
+    printf("Populating Root file system from TAR file.\n");
+    status = Untar_FromMemory((unsigned char *)(&_binary_tarfile_start), (unsigned long)&_binary_tarfile_size);
+    if (status != UNTAR_SUCCESSFUL)
+    {
+        printf("Error while untaring from memory\n");
+    }
+}

--- a/src/bsp/generic-rtems/src/pcrtems_bsp_internal.h
+++ b/src/bsp/generic-rtems/src/pcrtems_bsp_internal.h
@@ -1,0 +1,45 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ *   Header file for internal data to the PC-RTEMS BSP
+ */
+
+#ifndef PCRTEMS_BSP_INTERNAL_H
+#define PCRTEMS_BSP_INTERNAL_H
+
+#include "bsp-impl.h"
+#include <rtems.h>
+
+/*
+ * BSP types
+ */
+typedef struct
+{
+    bool     BatchMode;
+    rtems_id AccessMutex;
+} OS_BSP_PcRtemsGlobalData_t;
+
+/*
+ * Global Data object
+ */
+extern OS_BSP_PcRtemsGlobalData_t OS_BSP_PcRtemsGlobal;
+
+#endif


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1349 
- Fix #1447

Splits up bsp_start.c so features can be optionally included: cmdline, shell, stand alone exe vs module
RTEMS configuration is now in bsp_init.c, included based on stand alone/module selection

**Testing performed**
Ran w/ LEON3 QEMU with/without shell and stand alone/module options.

**Expected behavior changes**
PC behavior shouldn't change based on default options matching previous behavior
Except for the file system and command line, the rest is usable by LEON3

**System(s) tested on**
LEON3 QEMU modified as documented by RCC:
```
apt-get update && apt-get install -y ninja-build pkg-config libglib2.0-dev python3 python3-pip python3-setuptools python3-wheel libpixman-1-dev && pip3 install meson
tar xvJf qemu-7.1.0.tar.xz
cd qemu-7.1.0
./configure --target-list=sparc-softmmu --enable-debug
make install
```
RCC-1.3.1
For running as a module I based it on https://github.com/alanc98/rki2, although there are mods...

**Additional context**
See notes in comments below for latest information

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC