### PR TITLE
Fix #1344, UT assert stub return values

### DIFF
--- a/ut_assert/inc/utgenstub.h
+++ b/ut_assert/inc/utgenstub.h
@@ -40,7 +40,7 @@
  * \param ReturnType The type of return value
  */
 #define UT_GenStub_SetupReturnBuffer(FuncName, ReturnType) \
-    UT_Stub_RegisterReturnType(UT_KEY(FuncName), sizeof(ReturnType))
+    UT_Stub_RegisterReturnType(UT_KEY(FuncName), sizeof(ReturnType), #ReturnType)
 
 /**
  * Helper macro to get the return value from the handler
@@ -51,7 +51,7 @@
  * \param ReturnType The type of return value
  */
 #define UT_GenStub_GetReturnValue(FuncName, ReturnType) \
-    (*(ReturnType *)UT_Stub_GetReturnValuePtr(UT_KEY(FuncName), sizeof(ReturnType)))
+    (*(ReturnType *)UT_Stub_GetReturnValuePtr(UT_KEY(FuncName), sizeof(ReturnType), #ReturnType))
 
 /**
  * Helper macro to add a local parameter to the current context

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -48,6 +48,15 @@
 typedef cpuaddr UT_EntryKey_t;
 
 /**
+ * Type for generic integer value return codes
+ *
+ * By using the C99 "ptrdiff_t" type, this should be large enough to also
+ * store pointer values on the target system, in addition to all normal
+ * integer values.
+ */
+typedef ptrdiff_t UT_IntReturn_t;
+
+/**
  * Macro to obtain a UT_EntryKey_t value from any function name
  */
 #define UT_KEY(Func) ((UT_EntryKey_t)&Func)
@@ -69,6 +78,18 @@ typedef enum
     UT_STUBCONTEXT_ARG_TYPE_DIRECT,  /**< Indicates "ArgPtr" is a direct copy of the actual parameter value */
     UT_STUBCONTEXT_ARG_TYPE_INDIRECT /**< Indicates "ArgPtr" is a pointer to the argument value on the stack */
 } UT_StubContext_Arg_Type_t;
+
+/**
+ * Identifies different genres of return values.  This serves as a hint to determine how to adapt
+ * or convert a return value if the stub has a different return size.
+ */
+typedef enum UT_ValueGenre
+{
+    UT_ValueGenre_OPAQUE  = 0, /**< The nature of the value is opaque, reference is stored directly (NOT copied!) */
+    UT_ValueGenre_INTEGER = 1, /**< The value is an integer and may be converted to integers of other sizes */
+    UT_ValueGenre_FLOAT   = 2, /**< The value is a floating point and may be converted to floats of other sizes */
+    UT_ValueGenre_POINTER = 3  /**< The value is a pointer and should only be used to fulfill a pointer return */
+} UT_ValueGenre_t;
 
 /**
  * Complete Metadata associated with a context argument
@@ -170,9 +191,15 @@ void UT_ResetState(UT_EntryKey_t FuncKey);
  *
  * \param FuncKey The stub function to add the return code to.
  * \param Count   The number of times after which the Retcode should be triggered
- * \param Retcode The code to return after Count calls.
+ * \param Retcode The signed integer value to return after Count calls.
  */
-void UT_SetDeferredRetcode(UT_EntryKey_t FuncKey, int32 Count, int32 Retcode);
+void UT_SetDeferredRetcode(UT_EntryKey_t FuncKey, int32 Count, UT_IntReturn_t Retcode);
+
+/**
+ * \param FuncKey The stub function to add the return code to.
+ */
+void UT_ConfigureGenericStubReturnValue(UT_EntryKey_t FuncKey, const void *ValuePtr, size_t ValueSize,
+                                        UT_ValueGenre_t ValueGenre, int32 DeferCount, const char *TypeName);
 
 /**
  * Add a data buffer for a given stub function
@@ -220,9 +247,9 @@ void UT_GetDataBuffer(UT_EntryKey_t FuncKey, void **DataBuffer, size_t *MaxSize,
  * User needs to use UT_ClearDefaultReturnValue to clear the value.
  *
  * \param FuncKey The stub function to add the return code to.
- * \param Value Arbitrary return value (may or may not be used by the stub)
+ * \param Value Arbitrary signed integer return value (may or may not be used by the stub)
  */
-void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, int32 Value);
+void UT_SetDefaultReturnValue(UT_EntryKey_t FuncKey, UT_IntReturn_t Value);
 
 /**
  * Disable the default return for the given stub function
@@ -345,38 +372,6 @@ uint32 UT_GetStubCount(UT_EntryKey_t FuncKey);
 void UT_Stub_CallOnce(void (*Func)(void));
 
 /**
- * Check for a deferred return code entry for the given stub function
- *
- * This is a default implementation for deferred retcodes and can be used
- * by stub functions as a common implementation.  If a deferred retcode
- * for the given function is present, this will decrement the associated
- * count.  If the count becomes zero, this function returns true and
- * the Retcode parameter is assigned the originally requested code.
- * Otherwise this function returns false which indicates the default
- * stub implementation should be used.
- *
- * Once the counter reaches zero, this clears the entry so that if a
- * second deferred code is recorded it will be found next.
- *
- * \param FuncKey The stub function to check the return code.
- * \param Retcode Buffer to store deferred return code, if available.
- * \returns true if deferred code is present and counter reached zero
- */
-bool UT_Stub_CheckDeferredRetcode(UT_EntryKey_t FuncKey, int32 *Retcode);
-
-/**
- * Check for a default return value entry for the given stub function
- *
- * If a UT_SetDefaultReturnValue() option is in place for the given function this
- * will return true and increment the internal usage counter.
- *
- * \param FuncKey The stub function to check the return code.
- * \param Value Set to the value supplied to UT_SetDefaultReturnValue()
- * \returns true if force fail mode is active
- */
-bool UT_Stub_CheckDefaultReturnValue(UT_EntryKey_t FuncKey, int32 *Value);
-
-/**
  * Copies data from a test-supplied buffer to the local buffer
  *
  * If a UT_SetDataBuffer() option is in place for the given function this
@@ -460,8 +455,9 @@ void UT_Stub_SetReturnValue(UT_EntryKey_t FuncKey, const void *BufferPtr, size_t
  *
  * \param FuncKey    The stub function associated with the buffer
  * \param ReturnSize Size of the return value
+ * \param TypeName   Expected return value type, as a string
  */
-void UT_Stub_RegisterReturnType(UT_EntryKey_t FuncKey, size_t ReturnSize);
+void UT_Stub_RegisterReturnType(UT_EntryKey_t FuncKey, size_t ReturnSize, const char *TypeName);
 
 /**
  * Obtains direct pointer to buffer for stub return value
@@ -474,8 +470,9 @@ void UT_Stub_RegisterReturnType(UT_EntryKey_t FuncKey, size_t ReturnSize);
  *
  * \param FuncKey    The stub function associated with the buffer
  * \param ReturnSize Size of the return value
+ * \param TypeName   Expected return value type, as a string
  */
-void *UT_Stub_GetReturnValuePtr(UT_EntryKey_t FuncKey, size_t ReturnSize);
+void *UT_Stub_GetReturnValuePtr(UT_EntryKey_t FuncKey, size_t ReturnSize, const char *TypeName);
 
 /**
  * Exports a value from a hook/handler and stages it to be returned to the caller.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Improves default support for return values of sizes other than 32 bits. Previously this required a custom handler for any value that was not a 32 bit integer.  With this update any integer value can be used, and a value translation will occur if the size is different.  Thus boolean values, 8,16, and 64-bit ints can be configured through the same basic API without needing to add a handler.
Fixes #1344

**Testing performed**
Build and run all tests, including CFS app tests, to confirm all still run as expected.

**Expected behavior changes**
No change to _existing_ behavior - all currently-implemented test cases should continue to behave as they have in the past, whether they used a 32-bit integer return or if they had a custom hook/handler.

Going forward, it should no longer be required to implement a custom handler for the sole purpose of adjusting the size of the return value in case it is not a 32-bit integer.  As a fallback default, any return value that is unset by a test will be memset to 0.  So a pointer stub return will get `NULL`, a boolean will get `FALSE`, and any numeric value of any time will be zero.  

The `UT_SetDeferredRetcode` and `UT_SetDefaultReturnValue` functions now accept a `UT_IntReturn_t` value instead of `int32`.  This typedef is defined using the C99 `ptrdiff_t` type, which will be 64 bits in size on modern hardware.  When passing by value from an int32, this should be transparent, but it is large enough to also allow test cases to pass in pointer values here without truncating.

**System(s) tested on**
Debian 

**Additional context**
API to set return values is still numeric in nature.  This adds some framework to allow fully-typed values and abstract objects bigger than `ptrdiff_t` values to be returned, but there is no API yet - that can be added in a future change.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
