### PR TITLE
Fix #1356, Remove stray remaining 'goto' in OSAL test code

### DIFF
--- a/src/unit-tests/osfile-test/ut_osfile_test.c
+++ b/src/unit-tests/osfile-test/ut_osfile_test.c
@@ -78,18 +78,17 @@ int32 UT_os_setup_fs()
     if (res != OS_SUCCESS)
     {
         UtPrintf("OS_mkfs() returns %d\n", (int)res);
-        goto UT_os_setup_fs_exit_tag;
     }
-
-    res = OS_mount(g_devName, g_mntName);
-    if (res != OS_SUCCESS)
+    else
     {
-        UtPrintf("OS_mount() returns %d\n", (int)res);
-        OS_rmfs(g_devName);
-        goto UT_os_setup_fs_exit_tag;
+        res = OS_mount(g_devName, g_mntName);
+        if (res != OS_SUCCESS)
+        {
+            UtPrintf("OS_mount() returns %d\n", (int)res);
+            OS_rmfs(g_devName);
+        }
     }
 
-UT_os_setup_fs_exit_tag:
     return res;
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1356 
  - 2 uses of `goto` are replaced with simple return statements.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to logic.
Program flow is clearer, and removes the only remaining use of `goto` in OSAL.

**Contributor Info**
Avi Weiss @thnkslprpt