### PR TITLE
Fix #1365, fixup API headers for C++

### DIFF
--- a/src/os/inc/osapi-clock.h
+++ b/src/os/inc/osapi-clock.h
@@ -147,7 +147,8 @@ static inline int64 OS_TimeGetTotalSeconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalSeconds(int64 tm)
 {
-    return (OS_time_t) {.ticks = (tm * OS_TIME_TICKS_PER_SECOND)};
+    OS_time_t ostm = {tm * OS_TIME_TICKS_PER_SECOND};
+    return ostm;
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -180,7 +181,8 @@ static inline int64 OS_TimeGetTotalMilliseconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalMilliseconds(int64 tm)
 {
-    return (OS_time_t) {.ticks = (tm * OS_TIME_TICKS_PER_MSEC)};
+    OS_time_t ostm = {tm * OS_TIME_TICKS_PER_MSEC};
+    return ostm;
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -213,7 +215,8 @@ static inline int64 OS_TimeGetTotalMicroseconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalMicroseconds(int64 tm)
 {
-    return (OS_time_t) {.ticks = (tm * OS_TIME_TICKS_PER_USEC)};
+    OS_time_t ostm = {tm * OS_TIME_TICKS_PER_USEC};
+    return ostm;
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -250,7 +253,8 @@ static inline int64 OS_TimeGetTotalNanoseconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalNanoseconds(int64 tm)
 {
-    return (OS_time_t) {.ticks = (tm / OS_TIME_TICK_RESOLUTION_NS)};
+    OS_time_t ostm = {tm / OS_TIME_TICK_RESOLUTION_NS};
+    return ostm;
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -462,7 +466,8 @@ static inline OS_time_t OS_TimeAssembleFromSubseconds(int64 seconds, uint32 subs
  */
 static inline OS_time_t OS_TimeAdd(OS_time_t time1, OS_time_t time2)
 {
-    return ((OS_time_t) {time1.ticks + time2.ticks});
+    OS_time_t ostm = {time1.ticks + time2.ticks};
+    return ostm;
 }
 
 /*-------------------------------------------------------------------------------------*/
@@ -476,7 +481,8 @@ static inline OS_time_t OS_TimeAdd(OS_time_t time1, OS_time_t time2)
  */
 static inline OS_time_t OS_TimeSubtract(OS_time_t time1, OS_time_t time2)
 {
-    return ((OS_time_t) {time1.ticks - time2.ticks});
+    OS_time_t ostm = {time1.ticks - time2.ticks};
+    return ostm;
 }
 
 /**@}*/

--- a/src/os/inc/osapi-file.h
+++ b/src/os/inc/osapi-file.h
@@ -106,7 +106,7 @@ typedef enum
 {
     OS_FILE_FLAG_NONE     = 0x00,
     OS_FILE_FLAG_CREATE   = 0x01,
-    OS_FILE_FLAG_TRUNCATE = 0x02,
+    OS_FILE_FLAG_TRUNCATE = 0x02
 } OS_file_flag_t;
 
 /*

--- a/src/os/inc/osapi-idmap.h
+++ b/src/os/inc/osapi-idmap.h
@@ -102,10 +102,12 @@ static inline unsigned long OS_ObjectIdToInteger(osal_id_t object_id)
 static inline osal_id_t OS_ObjectIdFromInteger(unsigned long value)
 {
 #ifdef OSAL_OMIT_DEPRECATED
-    return (osal_id_t) {value};
+    osal_id_t idv = {(uint32)value};
 #else
-    return (osal_id_t)value;
+    osal_id_t idv = (osal_id_t)value;
 #endif
+
+    return idv;
 }
 
 /*-------------------------------------------------------------------------------------*/

--- a/src/os/inc/osapi-macros.h
+++ b/src/os/inc/osapi-macros.h
@@ -32,6 +32,15 @@
 #include "osconfig.h"
 #include "common_types.h"
 
+/*
+ * C++ does not support variadic macros until C++11
+ * These macros should only be used from C code, not headers
+ * or inline functions.  This ifdef prevents the C++ compiler
+ * from throwing an error about these definitions - as a result
+ * these macros are NOT available in C++ source files.
+ */
+#ifndef __cplusplus
+
 #ifdef OSAL_CONFIG_BUGCHECK_DISABLE
 
 /**
@@ -144,5 +153,7 @@
  * second argument (errcode) is intentionally left blank.
  */
 #define BUGCHECK_VOID(cond) BUGCHECK(cond, )
+
+#endif /* __cplusplus */
 
 #endif /* OSAPI_MACROS_H */

--- a/src/os/inc/osapi-select.h
+++ b/src/os/inc/osapi-select.h
@@ -57,7 +57,7 @@ typedef enum
     OS_STREAM_STATE_BOUND     = 0x01, /**< @brief whether the stream is bound     */
     OS_STREAM_STATE_CONNECTED = 0x02, /**< @brief whether the stream is connected */
     OS_STREAM_STATE_READABLE  = 0x04, /**< @brief whether the stream is readable  */
-    OS_STREAM_STATE_WRITABLE  = 0x08, /**< @brief whether the stream is writable  */
+    OS_STREAM_STATE_WRITABLE  = 0x08  /**< @brief whether the stream is writable  */
 } OS_StreamState_t;
 
 /** @defgroup OSAPISelect OSAL Select APIs


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Correct a few syntactical items that are valid C99 but not valid for C++03.  This includes use of the designated initializer, compound literals, variadic macros, and a trailing comma in enum declarations.

Note this only matters for public API headers, as some users may need to include these directly from a c++ file.  For normal C source files, these are all compiled as C99 and thus the syntax is fine.

Fixes #1365

**Testing performed**
Build and run all OSAL tests

**Expected behavior changes**
No impact to behavior, headers are now valid syntax for C++03 (and C99, of course)

**System(s) tested on**
Debian (using g++ 12.2 to check C++ syntax)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

