### PR TITLE
Fix #958, Convert some UT_GetStubCount to UtAssert_STUB_COUNT

### DIFF
--- a/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
+++ b/src/unit-test-coverage/portable/src/coveragetest-posix-io.c
@@ -123,7 +123,7 @@ void Test_OS_GenericRead_Impl(void)
     UT_SetDataBuffer(UT_KEY(OCS_read), SrcData, sizeof(SrcData), false);
     UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
     OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (&token, DestData, sizeof(DestData), 0), sizeof(DestData));
-    UtAssert_True(UT_GetStubCount(UT_KEY(OS_SelectSingle_Impl)) == 1, "OS_SelectSingle() called");
+    UtAssert_STUB_COUNT(OS_SelectSingle_Impl, 1);
 
     /* Read 0 bytes */
     OSAPI_TEST_FUNCTION_RC(OS_GenericRead_Impl, (&token, DestData, 0, 0), OS_SUCCESS);
@@ -164,7 +164,7 @@ void Test_OS_GenericWrite_Impl(void)
     UT_SetDataBuffer(UT_KEY(OCS_write), DestData, sizeof(DestData), false);
     UT_PortablePosixIOTest_Set_Selectable(UT_INDEX_0, true);
     OSAPI_TEST_FUNCTION_RC(OS_GenericWrite_Impl, (&token, SrcData, sizeof(SrcData), 0), sizeof(SrcData));
-    UtAssert_True(UT_GetStubCount(UT_KEY(OS_SelectSingle_Impl)) == 1, "OS_SelectSingle() called");
+    UtAssert_STUB_COUNT(OS_SelectSingle_Impl, 1);
 
     /* Fail select */
     UT_SetDeferredRetcode(UT_KEY(OS_SelectSingle_Impl), 1, OS_ERROR_TIMEOUT);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-console.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-console.c
@@ -44,7 +44,7 @@ void Test_OS_ConsoleWakeup_Impl(void)
 
     /* this just gives the sem, only called in async mode */
     OS_ConsoleWakeup_Impl(&token);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_semGive)) == 1, "semGive() called in async mode");
+    UtAssert_STUB_COUNT(OCS_semGive, 1);
 
     /* Failure only causes a debug message to be generated, no error handling here */
     UT_SetDefaultReturnValue(UT_KEY(OCS_semGive), -1);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
@@ -96,17 +96,17 @@ void Test_OS_FileSysStopVolume_Impl(void)
     UT_FileSysTest_SetupFileSysEntry(1, NULL, 1, 4);
     token = UT_TOKEN_1;
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStopVolume_Impl(&token), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_xbdBlkDevDelete)) == 1, "xbdBlkDevDelete() called");
+    UtAssert_STUB_COUNT(OCS_xbdBlkDevDelete, 1);
 
     /* Test alternative branches */
     UT_ResetState(UT_KEY(OCS_xbdBlkDevDelete));
     UT_FileSysTest_SetupFileSysEntry(1, NULL, OCS_NULLDEV, 4);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStopVolume_Impl(&token), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_xbdBlkDevDelete)) == 0, "xbdBlkDevDelete() not called");
+    UtAssert_STUB_COUNT(OCS_xbdBlkDevDelete, 0);
 
     UT_FileSysTest_SetupFileSysEntry(1, NULL, 1, 0);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStopVolume_Impl(&token), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_xbdBlkDevDelete)) == 0, "xbdBlkDevDelete() not called");
+    UtAssert_STUB_COUNT(OCS_xbdBlkDevDelete, 0);
 }
 
 void Test_OS_FileSysFormatVolume_Impl(void)

--- a/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
@@ -44,7 +44,7 @@ void Test_OS_ShellOutputToFile_Impl(void)
      */
     UT_SetDeferredRetcode(UT_KEY(OCS_taskNameToId), 2, -1);
     OSAPI_TEST_FUNCTION_RC(OS_ShellOutputToFile_Impl(&token, "TestCmd"), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_shellGenericInit)) == 1, "shellGenericInit() called");
+    UtAssert_STUB_COUNT(OCS_shellGenericInit, 1);
 
     /* failure to open the output file */
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -53,7 +53,7 @@ void Test_OS_VxWorksEntry(void)
      * static int OS_VxWorksEntry(int arg)
      */
     OSAPI_TEST_FUNCTION_RC(UT_TaskTest_CallEntryPoint(OS_OBJECT_ID_UNDEFINED), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OS_TaskEntryPoint)) == 1, "OS_TaskEntryPoint() called");
+    UtAssert_STUB_COUNT(OS_TaskEntryPoint, 1);
 }
 
 void Test_OS_TaskCreate_Impl(void)
@@ -76,32 +76,32 @@ void Test_OS_TaskCreate_Impl(void)
 
     UT_ClearDefaultReturnValue(UT_KEY(OCS_malloc));
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(&token, OS_FP_ENABLED), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 2, "malloc() called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 0, "free() not called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskInit)) == 1, "taskInit() called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskActivate)) == 1, "taskActivate() called");
+    UtAssert_STUB_COUNT(OCS_malloc, 2);
+    UtAssert_STUB_COUNT(OCS_free, 0);
+    UtAssert_STUB_COUNT(OCS_taskInit, 1);
+    UtAssert_STUB_COUNT(OCS_taskActivate, 1);
 
     /* create again with smaller stack - this should re-use existing buffer */
     OS_task_table[0].stack_size = 100;
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(&token, OS_FP_ENABLED), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 2, "malloc() not called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 0, "free() not called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskInit)) == 2, "taskInit() called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskActivate)) == 2, "taskActivate() called");
+    UtAssert_STUB_COUNT(OCS_malloc, 2);
+    UtAssert_STUB_COUNT(OCS_free, 0);
+    UtAssert_STUB_COUNT(OCS_taskInit, 2);
+    UtAssert_STUB_COUNT(OCS_taskActivate, 2);
 
     /* create again with larger stack - this should free existing and malloc() new buffer */
     OS_task_table[0].stack_size = 400;
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(&token, OS_FP_ENABLED), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 3, "malloc() called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_free)) == 1, "free() called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskInit)) == 3, "taskInit() called");
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_taskActivate)) == 3, "taskActivate() called");
+    UtAssert_STUB_COUNT(OCS_malloc, 3);
+    UtAssert_STUB_COUNT(OCS_free, 1);
+    UtAssert_STUB_COUNT(OCS_taskInit, 3);
+    UtAssert_STUB_COUNT(OCS_taskActivate, 3);
 
     /* create again with nonzero userstackbase */
     OS_task_table[0].stack_pointer = userstack;
     OS_task_table[0].stack_size    = sizeof(userstack);
     OSAPI_TEST_FUNCTION_RC(OS_TaskCreate_Impl(&token, OS_FP_ENABLED), OS_SUCCESS);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OCS_malloc)) == 3, "malloc() not called");
+    UtAssert_STUB_COUNT(OCS_malloc, 3);
 
     /* other failure modes */
     UT_SetDefaultReturnValue(UT_KEY(OCS_taskInit), -1);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #958 
  - The cases of `UT_GetStubCount()` which were just being checked via `UtAssert_True()` have been converted to use `UtAssert_STUB_COUNT()`, which automatically writes the expected and actual stub count to the test log.

**Testing performed**
GitHub CI actions all passing successfully.
Local testing with standard cFS suite shows all tests passing and no change in coverage.

**Expected behavior changes**
No change to code.
Tests also essentially identical, just a bit simpler, clearer and more useful for debugging.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt