### PR TITLE
Fix #1103, Implement OS_ERR_INVALID_PRIORITY return code check for RTEMS

### DIFF
--- a/src/os/inc/osapi-task.h
+++ b/src/os/inc/osapi-task.h
@@ -103,7 +103,7 @@ typedef osal_task((*osal_task_entry)(void)); /**< @brief For task entry point */
  * @retval #OS_INVALID_POINTER if any of the necessary pointers are NULL
  * @retval #OS_ERR_INVALID_SIZE if the stack_size argument is zero
  * @retval #OS_ERR_NAME_TOO_LONG name length including null terminator greater than #OS_MAX_API_NAME
- * @retval #OS_ERR_INVALID_PRIORITY if the priority is bad @covtest
+ * @retval #OS_ERR_INVALID_PRIORITY if the initial priority is invalid @covtest
  * @retval #OS_ERR_NO_FREE_IDS if there can be no more tasks created
  * @retval #OS_ERR_NAME_TAKEN if the name specified is already used by a task
  * @retval #OS_ERROR if an unspecified/other error occurs @covtest
@@ -176,7 +176,7 @@ int32 OS_TaskDelay(uint32 millisecond);
  * @return Execution status, see @ref OSReturnCodes
  * @retval #OS_SUCCESS @copybrief OS_SUCCESS
  * @retval #OS_ERR_INVALID_ID if the ID passed to it is invalid
- * @retval #OS_ERR_INVALID_PRIORITY if the priority is greater than the max allowed @covtest
+ * @retval #OS_ERR_INVALID_PRIORITY if the new priority is invalid @covtest
  * @retval #OS_ERROR if an unspecified/other error occurs @covtest
  */
 int32 OS_TaskSetPriority(osal_id_t task_id, osal_priority_t new_priority);

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -119,7 +119,11 @@ int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
     status = rtems_task_create(r_name, task->priority, task->stack_size, r_mode, r_attributes, &impl->id);
 
     /* check if task_create failed */
-    if (status != RTEMS_SUCCESSFUL)
+    if (status == RTEMS_INVALID_PRIORITY)
+    {
+        return OS_ERR_INVALID_PRIORITY;
+    }
+    else if (status != RTEMS_SUCCESSFUL)
     {
         /* Provide some feedback as to why this failed */
         OS_printf("rtems_task_create failed: %s\n", rtems_status_text(status));
@@ -230,18 +234,23 @@ int32 OS_TaskSetPriority_Impl(const OS_object_token_t *token, osal_priority_t ne
     rtems_task_priority             old_pri;
     rtems_status_code               status;
     OS_impl_task_internal_record_t *impl;
+    int32                           return_code = OS_SUCCESS;
 
     impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
 
     /* Set RTEMS Task Priority */
     status = rtems_task_set_priority(impl->id, new_priority, &old_pri);
-    if (status != RTEMS_SUCCESSFUL)
+    if (status == RTEMS_INVALID_PRIORITY)
+    {
+        return_code = OS_ERR_INVALID_PRIORITY;
+    }
+    else if (status != RTEMS_SUCCESSFUL)
     {
         OS_DEBUG("Unhandled task_set_priority error: %s\n", rtems_status_text(status));
-        return OS_ERROR;
+        return_code = OS_ERROR;
     }
 
-    return OS_SUCCESS;
+    return return_code;
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1103 
  - Implements the `OS_ERR_INVALID_PRIORITY` error return code for RTEMS (in `OS_TaskCreate()`) and `OS_TaskSetPriority()`.

For POSIX, OSAL uses the internal function `OS_PriorityRemap()` to convert to a suitable (and not invalid) priority value before calling `pthread_setschedprio()`.

For VxWorks, `taskPrioritySet()` does set `ERRNO` to `S_taskLib_ILLEGAL_PRIORITY`, but I have not tried to include it in this PR. The issue can be left open if someone wants to look at that, or closed for now with this PR.

**Testing performed**
I don't think this file (`rtems/src/os-impl-tasks.c`) has any tests currently (see https://github.com/nasa/osal/issues/1207).
If someone can advise if this needs to be tested, and the best way of doing so, I would appreciate it.

**Expected behavior changes**
Calls on the RTEMS implementation to `OS_TaskCreate()` (which calls `rtems_task_create()`) and `OS_TaskSetPriority()` (which calls `rtems_task_set_priority()`) will now actually return `OS_ERR_INVALID_PRIORITY` if the RTEMS calls return `RTEMS_INVALID_PRIORITY`, rather than simply returning OS_ERROR.

**Contributor Info**
Avi Weiss @thnkslprpt