### PR TITLE
Fix #1193, Change format of UtAssert_StringBufCompare

### DIFF
--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -702,6 +702,6 @@ bool UtAssert_StringBufCompare(const char *String1, size_t String1Max, const cha
     }
     ScrubbedString2[FormatLen2] = 0;
 
-    return UtAssertEx(Result, UTASSERT_CASETYPE_FAILURE, File, Line, "String: \'%s\' == \'%s\'", ScrubbedString1,
-                      ScrubbedString2);
+    return UtAssertEx(Result, UTASSERT_CASETYPE_FAILURE, File, Line, "String:\nReceived: \'%s\'\nExpected: \'%s\'",
+                      ScrubbedString1, ScrubbedString2);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1193 
  - Comparison strings are now formatted one above the other and aligned to make identifying the discrepancy easier.

An example:
![Screenshot 2023-03-24 13 52 31](https://user-images.githubusercontent.com/9024662/227426004-6dc906a5-0746-463d-895a-e975d27aa3a5.png)

**Testing performed**
GitHub CI actions and local cFS test suite run all passing successfully.

**Expected behavior changes**
The change makes it easier to identify the discrepancy between the strings in case of a failed test.

Only slight downside is the increase in length of the test log... (each call to `UtAssert_StringBufCompare()` now results in 3 lines printed instead of 1).
There are currently ~40 uses of `UtAssert_StringBufCompare()` in cFE and OSAL.

**Contributor Info**
Avi Weiss @thnkslprpt