### PR TITLE
Fix #1386, Refactor initializations of POSIX `return_code` variables to simplify code

### DIFF
--- a/src/os/posix/src/os-impl-binsem.c
+++ b/src/os/posix/src/os-impl-binsem.c
@@ -121,7 +121,7 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
     int                               attr_created;
     int                               mutex_created;
     int                               cond_created;
-    int32                             return_code;
+    int32                             return_code = OS_SEM_FAILURE;
     pthread_mutexattr_t               mutex_attr;
     OS_impl_binsem_internal_record_t *sem;
 
@@ -150,7 +150,6 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_init failed: %s\n", strerror(ret));
-            return_code = OS_SEM_FAILURE;
             break;
         }
 
@@ -164,7 +163,6 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_setprotocol failed: %s\n", strerror(ret));
-            return_code = OS_SEM_FAILURE;
             break;
         }
 
@@ -175,7 +173,6 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutex_init failed: %s\n", strerror(ret));
-            return_code = OS_SEM_FAILURE;
             break;
         }
 
@@ -188,7 +185,6 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_cond_init failed: %s\n", strerror(ret));
-            return_code = OS_SEM_FAILURE;
             break;
         }
 
@@ -201,7 +197,6 @@ int32 OS_BinSemCreate_Impl(const OS_object_token_t *token, uint32 initial_value,
         if (ret != 0)
         {
             OS_DEBUG("Error: initial pthread_cond_signal failed: %s\n", strerror(ret));
-            return_code = OS_SEM_FAILURE;
             break;
         }
 

--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -181,7 +181,7 @@ void OS_WaitForStateChange_Impl(osal_objtype_t idtype, uint32 attempts)
 int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
 {
     int                     ret;
-    int32                   return_code = OS_SUCCESS;
+    int32                   return_code = OS_ERROR;
     pthread_mutexattr_t     mutex_attr;
     OS_impl_objtype_lock_t *impl;
 
@@ -200,7 +200,6 @@ int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_init failed: %s\n", strerror(ret));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -211,7 +210,6 @@ int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_setprotocol failed: %s\n", strerror(ret));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -223,7 +221,6 @@ int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_settype failed: %s\n", strerror(ret));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -231,7 +228,6 @@ int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_mutex_init failed: %s\n", strerror(ret));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -241,9 +237,10 @@ int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype)
         if (ret != 0)
         {
             OS_DEBUG("Error: pthread_cond_init failed: %s\n", strerror(ret));
-            return_code = OS_ERROR;
             break;
         }
+
+        return_code = OS_SUCCESS;
     } while (0);
 
     return return_code;

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -197,9 +197,7 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
     osal_index_t        idx;
     pthread_mutexattr_t mutex_attr;
     struct timespec     clock_resolution;
-    int32               return_code;
-
-    return_code = OS_SUCCESS;
+    int32               return_code = OS_ERROR;
 
     do
     {
@@ -215,7 +213,6 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
         if (status != 0)
         {
             OS_DEBUG("failed in clock_getres: %s\n", strerror(errno));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -242,7 +239,6 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
         if (status != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_init failed: %s\n", strerror(status));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -253,7 +249,6 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
         if (status != 0)
         {
             OS_DEBUG("Error: pthread_mutexattr_setprotocol failed: %s\n", strerror(status));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -268,7 +263,6 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
             if (status != 0)
             {
                 OS_DEBUG("Error: Mutex could not be created: %s\n", strerror(status));
-                return_code = OS_ERROR;
                 break;
             }
         }
@@ -280,7 +274,6 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
         if (OS_SharedGlobalVars.TicksPerSecond <= 0)
         {
             OS_DEBUG("Error: Unable to determine OS ticks per second: %s\n", strerror(errno));
-            return_code = OS_ERROR;
             break;
         }
 
@@ -292,6 +285,8 @@ int32 OS_Posix_TimeBaseAPI_Impl_Init(void)
          */
         OS_SharedGlobalVars.MicroSecPerTick =
             (1000000 + (OS_SharedGlobalVars.TicksPerSecond / 2)) / OS_SharedGlobalVars.TicksPerSecond;
+
+        return_code = OS_SUCCESS;
     } while (0);
 
     return return_code;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1386 
  - 3 `return_code` variables initialized to their `ERROR`/`FAILURE` state which removes the need to assign inside each error path.

**Testing performed**
GitHub CI actions all passing successfully, as do local Unit tests.

**Expected behavior changes**
No change to behavior.
code is simplified slightly - improving future maintainability.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt