### PR TITLE
Fix #864, Refactor duplicate `addrlen` swtiches into an inline function

### DIFF
--- a/src/os/portable/os-impl-bsd-sockets.c
+++ b/src/os/portable/os-impl-bsd-sockets.c
@@ -210,6 +210,33 @@ int32 OS_SocketOpen_Impl(const OS_object_token_t *token)
 
 /*----------------------------------------------------------------
  *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
+static inline socklen_t OS_GetAddrLen(sa_family_t sa_family)
+{
+    socklen_t addrlen;
+
+    switch (sa_family)
+    {
+        case AF_INET:
+            addrlen = sizeof(struct sockaddr_in);
+            break;
+#ifdef OS_NETWORK_SUPPORTS_IPV6
+        case AF_INET6:
+            addrlen = sizeof(struct sockaddr_in6);
+            break;
+#endif
+        default:
+            addrlen = 0;
+            break;
+    }
+
+    return addrlen;
+}
+
+/*----------------------------------------------------------------
+ *
  *  Purpose: Implemented per internal OSAL API
  *           See prototype for argument/return detail
  *
@@ -225,22 +252,8 @@ int32 OS_SocketBind_Impl(const OS_object_token_t *token, const OS_SockAddr_t *Ad
     impl   = OS_OBJECT_TABLE_GET(OS_impl_filehandle_table, *token);
     stream = OS_OBJECT_TABLE_GET(OS_stream_table, *token);
 
-    sa = (const struct sockaddr *)&Addr->AddrData;
-
-    switch (sa->sa_family)
-    {
-        case AF_INET:
-            addrlen = sizeof(struct sockaddr_in);
-            break;
-#ifdef OS_NETWORK_SUPPORTS_IPV6
-        case AF_INET6:
-            addrlen = sizeof(struct sockaddr_in6);
-            break;
-#endif
-        default:
-            addrlen = 0;
-            break;
-    }
+    sa      = (const struct sockaddr *)&Addr->AddrData;
+    addrlen = OS_GetAddrLen(sa->sa_family);
 
     if (addrlen == 0)
     {
@@ -285,21 +298,8 @@ int32 OS_SocketConnect_Impl(const OS_object_token_t *token, const OS_SockAddr_t 
 
     impl = OS_OBJECT_TABLE_GET(OS_impl_filehandle_table, *token);
 
-    sa = (const struct sockaddr *)&Addr->AddrData;
-    switch (sa->sa_family)
-    {
-        case AF_INET:
-            slen = sizeof(struct sockaddr_in);
-            break;
-#ifdef OS_NETWORK_SUPPORTS_IPV6
-        case AF_INET6:
-            slen = sizeof(struct sockaddr_in6);
-            break;
-#endif
-        default:
-            slen = 0;
-            break;
-    }
+    sa   = (const struct sockaddr *)&Addr->AddrData;
+    slen = OS_GetAddrLen(sa->sa_family);
 
     if (slen != Addr->ActualLength)
     {
@@ -564,21 +564,8 @@ int32 OS_SocketSendTo_Impl(const OS_object_token_t *token, const void *buffer, s
 
     impl = OS_OBJECT_TABLE_GET(OS_impl_filehandle_table, *token);
 
-    sa = (const struct sockaddr *)&RemoteAddr->AddrData;
-    switch (sa->sa_family)
-    {
-        case AF_INET:
-            addrlen = sizeof(struct sockaddr_in);
-            break;
-#ifdef OS_NETWORK_SUPPORTS_IPV6
-        case AF_INET6:
-            addrlen = sizeof(struct sockaddr_in6);
-            break;
-#endif
-        default:
-            addrlen = 0;
-            break;
-    }
+    sa      = (const struct sockaddr *)&RemoteAddr->AddrData;
+    addrlen = OS_GetAddrLen(sa->sa_family);
 
     if (addrlen != RemoteAddr->ActualLength)
     {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #864
  - `switch` to get `addrlen` from 3 functions refactored into into a single inline implementation
  - If someone can see a clear and worthwhile way to add `OS_SocketAddrInit_Impl()` I can add it.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Local tests confirm net coverage unchanged.

**Expected behavior changes**
No change to behavior.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt