### PR TITLE
Fix #1102, Correct return value bug in VxWorks `OS_ShellOutputToFile_Impl`

### DIFF
--- a/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-shell.c
@@ -57,7 +57,7 @@ void Test_OS_ShellOutputToFile_Impl(void)
     /* ID failure */
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetById), OS_ERROR);
     UT_SetDefaultReturnValue(UT_KEY(OCS_taskNameToId), -1);
-    OSAPI_TEST_FUNCTION_RC(OS_ShellOutputToFile_Impl(&token, "TestCmd"), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_ShellOutputToFile_Impl(&token, "TestCmd"), OS_ERROR);
 }
 
 /* ------------------- End of test cases --------------------------------------*/


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1102
  - Corrects use of `ReturnCode` (instead of `Return`) to hold result of `OS_OpenCreate()`
  - Moves call to `OS_ObjectIdGetById()` out before the `if` to make code clearer (and remove the side-effect from the `if` condition)
  - Moves `if (Result == OK)` to inside the block, immediately after the one and only assignment to the `Result` variable (this check being outside that block was part of what caused the mixed-up OSAL/VxWorks returns previously)
  - Sets `ReturnCode` to `OS_ERROR` if `shellGenericInit()` does not return `OK` - thus correcting the behavior of the function (and the coverage test) to actually return an error if that call fails
  - Updated the coverage test return value from `OS_SUCCESS` to `OS_ERROR` when `OS_ObjectIdGetById()` is seeded with an error return 

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Coverage Tests etc.).

**Expected behavior changes**
`OS_ShellOutputToFile_Impl()` will actually return an error on all failure cases now.
Function logic and flow is clearer now - easing future maintenance.

**Contributor Info**
Avi Weiss @thnkslprpt