### PR TITLE
Fix #1396, do not use intmax_t/uintmax_t types

### DIFF
--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -45,8 +45,8 @@ static char            CurrentSegment[64];
 
 typedef union
 {
-    intmax_t  s; /**< If value is signed */
-    uintmax_t u; /**< If value is unsigned */
+    long          s; /**< If value is signed */
+    unsigned long u; /**< If value is unsigned */
 } UtAssert_IntBuf_t;
 
 #define UT_COMPARE_TYPE(t, s) (((t) << 1) | (s))
@@ -417,7 +417,7 @@ static const char *UtAssert_GetValueText(char *TempBuf, size_t TempSz, UT_IntChe
     return TempBuf;
 }
 
-static bool UtAssert_DoCompare(intmax_t ActualValueIn, UtAssert_Compare_t CompareType, UT_IntCheck_t ReferenceValueIn,
+static bool UtAssert_DoCompare(long ActualValueIn, UtAssert_Compare_t CompareType, UT_IntCheck_t ReferenceValueIn,
                                bool IsUnsigned)
 {
     bool              Result;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Replace these with long and unsigned long, respectively, as some old systems might not have these types even if it does provide stdint.h

Fixes #1396

**Testing performed**
Build on vxworks 6.9 (gcc 4.3.3)

**Expected behavior changes**
Build should succeed

**System(s) tested on**
GSFC VxWorks build host

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
