### PR TITLE
Fix #1402, Fixes errors in IC Bundle workflow file

### DIFF
--- a/.github/workflows/icbundle.yml
+++ b/.github/workflows/icbundle.yml
@@ -58,11 +58,10 @@ jobs:
             see_entry="${see_entry}"$' <https://github.com/nasa/cFE/pull/'${pr}$'>'
           done
           changelog_entry="${changelog_entry}\n${see_entry}\n"
-          echo "s|# Changelog|$changelog_entry|"
-          sed -ir "s|Changelog|$changelog_entry|" CHANGELOG.md
+          sed -ir "s|# Changelog|$changelog_entry|" CHANGELOG.md
           
           buildnumber_entry=$'#define OS_BUILD_NUMBER   '${rev_num}
-          sed -ir "s|define OS_BUILD_NUMBER.*|$buildnumber_entry|" src/os/inc/osapi-version.h
+          sed -ir "s|#define OS_BUILD_NUMBER.*|$buildnumber_entry|" src/os/inc/osapi-version.h
       - name: Commit and Push Updates to IC Branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Addresses issue #1402.

**Testing performed**
Generated IC branch in fork.

**Expected behavior changes**
No additional "#" is placed in front of "#Changelog" in Changelog.md
No additional "#" is placed in front of "#define OS_BUILD_NUMBER ..." in src/os/inc/osapi-version.h
Additional occurrences of the string "Changelog" are not replaced in the Changelog.md file

**System(s) tested on**
GitHub

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC