### PR TITLE
Fix #1404, skip condvar tests if not implemented

### DIFF
--- a/src/tests/condvar-test/condvar-test.c
+++ b/src/tests/condvar-test/condvar-test.c
@@ -366,6 +366,20 @@ void CondVarTest_Ops(void)
     }
 }
 
+bool CondVarTest_CheckImpl(void)
+{
+    int32_t   status;
+    osal_id_t cvid;
+
+    status = OS_CondVarCreate(&cvid, "ut", 0);
+    if (status == OS_SUCCESS)
+    {
+        OS_CondVarDelete(cvid);
+    }
+
+    return (status != OS_ERR_NOT_IMPLEMENTED);
+}
+
 void UtTest_Setup(void)
 {
     if (OS_API_Init() != OS_SUCCESS)
@@ -376,10 +390,17 @@ void UtTest_Setup(void)
     /* the test should call OS_API_Teardown() before exiting */
     UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
 
-    /*
-     * Register the test setup and check routines in UT assert
-     */
-    UtTest_Add(CondVarTest_Ops, NULL, NULL, "CondVarOps");
-    UtTest_Add(CondVarTest_Execute, CondVarTest_Setup, CondVarTest_Teardown, "CondVarBasic");
-    UtTest_Add(CondVarTimedWait_Execute, CondVarTimedWait_Setup, CondVarTimedWait_Teardown, "CondVarTimed");
+    if (CondVarTest_CheckImpl())
+    {
+        /*
+         * Register the test setup and check routines in UT assert
+         */
+        UtTest_Add(CondVarTest_Ops, NULL, NULL, "CondVarOps");
+        UtTest_Add(CondVarTest_Execute, CondVarTest_Setup, CondVarTest_Teardown, "CondVarBasic");
+        UtTest_Add(CondVarTimedWait_Execute, CondVarTimedWait_Setup, CondVarTimedWait_Teardown, "CondVarTimed");
+    }
+    else
+    {
+        UtAssert_MIR("Condition variables not implemented; skipping tests");
+    }
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This reports that the functionality is not implemented and reports it as an MIR result, instead of having most/all of the tests fail.

Fixes #1404

**Testing performed**
Build with "no-condvar" implementation and run tests

**Expected behavior changes**
Confirm that the tests now succeed with a single MIR output, rather than reporting many failures.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

