### PR TITLE
Fix #1281, Set RTEMS task name for cpuuse

### DIFF
--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -33,6 +33,9 @@
                                     INCLUDE FILES
  ***************************************************************************************/
 
+#define _GNU_SOURCE
+#include <pthread.h>
+
 #include "os-rtems.h"
 #include "os-impl-tasks.h"
 
@@ -125,6 +128,8 @@ int32 OS_TaskCreate_Impl(const OS_object_token_t *token, uint32 flags)
         OS_printf("rtems_task_create failed: %s\n", rtems_status_text(status));
         return OS_ERROR;
     }
+
+    pthread_setname_np(impl->id, task->task_name);
 
     /* will place the task in 'ready for scheduling' state */
     status = rtems_task_start(impl->id,                        /*rtems task id*/


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1281 

**Testing performed**
Ran on RTEMS 5.  Sample output:

```
-------------------------------------------------------------------------------
                              CPU USAGE BY THREAD
------------+----------------------------------------+---------------+---------
 ID         | NAME                                   | SECONDS       | PERCENT
------------+----------------------------------------+---------------+---------
 0x09010001 | IDLE                                   |      6.924443 |  86.332
 0x0a010001 | UI1                                    |      0.000000 |   0.000
 0x0a010002 | ntwk                                   |      0.002736 |   0.034
 0x0a010003 | ETH0                                   |      0.000000 |   0.000
 0x0a010004 | FTPa                                   |      0.000000 |   0.000
 0x0a010005 | FTPD                                   |      0.000000 |   0.000
 0x0a010007 | cFS                                    |      0.000000 |   0.000
 0x0a010008 |                                        |      0.000213 |   0.002
 0x0a010009 |                                        |      0.330194 |   4.115
 0x0a01000a | BSWP                                   |      0.003068 |   0.038
 0x0a01000b | BRDA                                   |      0.010960 |   0.136
 0x0a01000c | CFE_EVS                                |      0.001207 |   0.015
 0x0a01000d | shel                                   |      0.015485 |   0.193
 0x0a01000e | CFE_SB                                 |      0.001240 |   0.015
 0x0a01000f | CFE_ES                                 |      0.035894 |   0.447
 0x0a010010 | ES_BG_TASK                             |      0.001430 |   0.017
 0x0a010011 | CFE_TIME                               |      0.009163 |   0.114
 0x0a010012 | TIME_TONE_TASK                         |      0.005439 |   0.067
 0x0a010013 | TIME_1HZ_TASK                          |      0.003104 |   0.038
 0x0a010014 | CFE_TBL                                |      0.001444 |   0.018
 0x0a010015 | FIFO_LIB_ChildT                        |      0.011508 |   0.143
 0x0a010016 | CI_LAB_APP                             |      0.005689 |   0.070
 0x0a010017 | TO_LAB_APP                             |      0.012372 |   0.154
 0x0a010018 | SCH_LAB_APP                            |      0.003868 |   0.048
 0x0a010019 | HW                                     |      0.023436 |   0.291
 0x0a01001a | CF                                     |      0.002247 |   0.028
 0x0a01001b | DS                                     |      0.025332 |   0.315
 0x0a01001c | FM                                     |      0.015175 |   0.189
 0x0a01001d | FM_CHILD_TASK                          |      0.029992 |   0.373
 0x0a01001e | LC                                     |      0.021521 |   0.268
 0x0a01001f | SC                                     |      0.025404 |   0.316
 0x0a010020 | VENDI                                  |      0.019558 |   0.243
 0x0a010021 | DP                                     |      0.481416 |   5.996
------------+----------------------------------------+---------------+---------
 TIME SINCE LAST CPU USAGE RESET IN SECONDS:                          8.028488
-------------------------------------------------------------------------------
```

**Expected behavior changes**
Reports task names (and doesn't conflict with classic task names used for OSAL taskids)

**System(s) tested on**
 - Leon3 QEMU
 - OS: RTEMS 5
 - Versions: basically main w/ local RTEMS updates

**Additional context**
Ping @thesamprice
Discussed at recent CCB, note adds posix/pthread dependency

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC