### PR TITLE
Fix #1412, Wrong memory alignment calculation

### DIFF
--- a/src/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/libc-stdlib-stubs.c
@@ -150,7 +150,7 @@ void *OCS_malloc(size_t sz)
         return NULL;
     }
 
-    NextSize  = (NextSize + MPOOL_ALIGN - 1) & ~((size_t)MPOOL_ALIGN);
+    NextSize  = (NextSize + MPOOL_ALIGN - 1) & ~((size_t)MPOOL_ALIGN - 1);
     NextBlock = Rec->BlockAddr + MPOOL_ALIGN;
     Rec->BlockAddr += NextSize;
     Rec->Size += NextSize;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Fix #1412
- This corrects the memory alignment calculation as already described in the issue.

**Testing performed**
Steps taken to test the contribution:
- I rebuild and tested this fix with exactly the cFS/OSAL code, configuration and environment in which bug caused a crash of the test `coverage-vxworks-tasks-testrunner.exe`. The test executed successfully (with out crash) when build with `-O2` as well as `-O0`. This was  RTEMS 6, ARM architecture and BSP `xilinx_zynq_a9_qemu` and tests run on QEMU.
- Moreover, I build and run the current cFS (with OSAL) git head with and without this patch and did run all tests. cFS: `2402f753b6e45341437bb352fad59a97485f27ce` and OSAL `7e1ffbb61053e1805a0f7dd401b17f9d90e25fbd`. These where the standard "ouf-of-box" cFS builds for `SIMULATION=native` (Linux) and for `SIMULATION=i686-rtems6`.

**Expected behavior changes**
Test `coverage-vxworks-tasks-testrunner.exe` should not crash.

**System(s) tested on**
 See above.

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Frank Kuehndel, embedded brains GmbH & Co. KG

