### PR TITLE
Fix #1415, Update misnamed member variable in `OS_BSP_GlobalData_t`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/src/bsp/shared/inc/bsp-impl.h
+++ b/src/bsp/shared/inc/bsp-impl.h
@@ -102,7 +102,7 @@ typedef struct
      * for each resource type.  Flags are all platform-defined, and not every platform uses this
      * feature.
      */
-    uint32 ResoureConfig[OS_OBJECT_TYPE_USER];
+    uint32 ResourceConfig[OS_OBJECT_TYPE_USER];
 } OS_BSP_GlobalData_t;
 
 /*

--- a/src/bsp/shared/src/bsp_default_resourcecfg.c
+++ b/src/bsp/shared/src/bsp_default_resourcecfg.c
@@ -37,7 +37,7 @@ void OS_BSP_SetResourceTypeConfig(uint32 ResourceType, uint32 ConfigOptionValue)
 {
     if (ResourceType < OS_OBJECT_TYPE_USER)
     {
-        OS_BSP_Global.ResoureConfig[ResourceType] = ConfigOptionValue;
+        OS_BSP_Global.ResourceConfig[ResourceType] = ConfigOptionValue;
     }
 }
 
@@ -52,7 +52,7 @@ uint32 OS_BSP_GetResourceTypeConfig(uint32 ResourceType)
 
     if (ResourceType < OS_OBJECT_TYPE_USER)
     {
-        ConfigOptionValue = OS_BSP_Global.ResoureConfig[ResourceType];
+        ConfigOptionValue = OS_BSP_Global.ResourceConfig[ResourceType];
     }
     else
     {

--- a/src/os/rtems/CMakeLists.txt
+++ b/src/os/rtems/CMakeLists.txt
@@ -63,7 +63,7 @@ if (OSAL_CONFIG_INCLUDE_NETWORK)
         ../portable/os-impl-bsd-select.c
     )
 
-    # In RTEMS 6+ the networking subsystem is not included with the defualt libs,
+    # In RTEMS 6+ the networking subsystem is not included with the default libs,
     # it needs to be explicitly added to the final link.  Note the "VERSION_GREATER_EQUAL"
     # operation was not added until CMake 3.7, so this uses not "VERSION_LESS" instead.
     if(NOT CMAKE_SYSTEM_VERSION VERSION_LESS 6.0)

--- a/src/os/vxworks/inc/os-impl-dirs.h
+++ b/src/os/vxworks/inc/os-impl-dirs.h
@@ -34,7 +34,7 @@
 
 /*
  * In VxWorks 6.x the system mkdir() function only has a path argument
- * In VxWorks 7 it is now POSIX compilant and adds a mode argument
+ * In VxWorks 7 it is now POSIX-compliant and adds a mode argument
  *
  * This macro simply discards the second argument, allowing code to use
  * mkdir() in a consistent, POSIX compliant fashion.

--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -1068,7 +1068,7 @@ int32 UT_DefaultStubImplWithArgs(const char *FunctionName, UT_EntryKey_t FuncKey
 
     RvcPtr = UT_Stub_FindRetvalConfig(FuncKey);
 
-    /* For legacy compatibility, determine the int32 status code (this may or may not be relevent) */
+    /* For legacy compatibility, determine the int32 status code (this may or may not be relevant) */
     if (RvcPtr != NULL && UT_Stub_IsValueCompatible(&RvcPtr->Data.Rvc, "int32", UT_ValueGenre_INTEGER))
     {
         LocalContext.Int32StatusIsSet =


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1415 
  - Corrected the spelling of the `ResoureConfig` variable in `OS_BSP_GlobalData_t`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change. Avoids potential confusion during future maintenance.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt