### PR TITLE
Fix #1421, Add RTEMS console and timebase posix task names

### DIFF
--- a/src/os/rtems/src/os-impl-console.c
+++ b/src/os/rtems/src/os-impl-console.c
@@ -32,6 +32,8 @@
 /****************************************************************************************
                                     INCLUDE FILES
  ***************************************************************************************/
+#define _GNU_SOURCE
+#include <pthread.h>
 
 #include "os-rtems.h"
 #include "os-shared-printf.h"
@@ -170,6 +172,8 @@ int32 OS_ConsoleCreate_Impl(const OS_object_token_t *token)
                 }
                 else
                 {
+                    pthread_setname_np(r_task_id, "OS_CONSOLE");
+
                     /* will place the task in 'ready for scheduling' state */
                     status = rtems_task_start(r_task_id,                    /*rtems task id*/
                                               OS_ConsoleTask_Entry,         /* task entry point */

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -26,6 +26,9 @@
 /****************************************************************************************
                                     INCLUDE FILES
  ***************************************************************************************/
+#define _GNU_SOURCE
+#include <pthread.h>
+
 #include "os-rtems.h"
 
 #include "os-shared-common.h"
@@ -388,6 +391,8 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
         }
         else
         {
+            pthread_setname_np(local->handler_task, "OS_TIMEBASE");
+
             /* will place the task in 'ready for scheduling' state */
             rtems_sc = rtems_task_start(local->handler_task,             /* rtems task id */
                                         OS_TimeBase_CallbackThreadEntry, /* task entry point */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1421 

**Testing performed**
CI and RTEMS in gr712 QEMU
Output:
```
-------------------------------------------------------------------------------
                              CPU USAGE BY THREAD
------------+----------------------------------------+---------------+---------
 ID         | NAME                                   | SECONDS       | PERCENT
------------+----------------------------------------+---------------+---------
 0x09010001 | IDLE                                   |     19.496490 |  70.025
 0x0a010001 | UI1                                    |      0.624546 |   2.243
 0x0a010002 | ntwk                                   |      0.008347 |   0.029
 0x0a010003 | ETH0                                   |      0.000051 |   0.000
 0x0a010004 | FTPa                                   |      0.000020 |   0.000
 0x0a010005 | FTPD                                   |      0.000090 |   0.000
 0x0a010007 | cFS                                    |      4.779459 |  17.165
 0x0a010008 | OS_CONSOLE                             |      0.047190 |   0.169
 0x0a010009 | OS_TIMEBASE                            |      0.905112 |   3.250
 0x0a01000a | BSWP                                   |      0.004801 |   0.017
 0x0a01000b | BRDA                                   |      0.028832 |   0.103
 0x0a01000c | CFE_EVS                                |      0.005492 |   0.019
 0x0a01000d | shel                                   |      0.033969 |   0.121
 0x0a01000e | CFE_SB                                 |      0.006340 |   0.022
 0x0a01000f | CFE_ES                                 |      0.114867 |   0.412
 0x0a010010 | ES_BG_TASK                             |      0.003897 |   0.013
 0x0a010011 | CFE_TIME                               |      0.030046 |   0.107
 0x0a010012 | TIME_TONE_TASK                         |      0.014532 |   0.052
 0x0a010013 | TIME_1HZ_TASK                          |      0.008746 |   0.031
 0x0a010014 | CFE_TBL                                |      0.006459 |   0.023
 0x0a010015 | FIFO_LIB_ChildT                        |      0.080315 |   0.288
 0x0a010016 | CI_LAB_APP                             |      0.018528 |   0.066
 0x0a010017 | TO_LAB_APP                             |      0.039913 |   0.143
 0x0a010018 | SCH_LAB_APP                            |      0.014559 |   0.052
 0x0a010019 | HW                                     |      0.014163 |   0.050
 0x0a01001a | CF                                     |      0.288871 |   1.037
 0x0a01001b | DS                                     |      0.065165 |   0.234
 0x0a01001c | FM                                     |      0.034307 |   0.123
 0x0a01001d | FM_CHILD_TASK                          |      0.000994 |   0.003
 0x0a01001e | LC                                     |      0.078651 |   0.282
 0x0a01001f | SC                                     |      0.162945 |   0.585
 0x0a010020 | VENDI                                  |      0.050446 |   0.181
 0x0a010021 | DP                                     |      0.873796 |   3.137
------------+----------------------------------------+---------------+---------
 TIME SINCE LAST CPU USAGE RESET IN SECONDS:                         27.849941
-------------------------------------------------------------------------------
```

**Expected behavior changes**
Shows all task names now

**System(s) tested on**
 - QEMU gr712
 - OS: RTEMS 5
 - Versions: main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC