### PR TITLE
Fix #1427, Add default build/install scripts

### DIFF
--- a/mk-osal-no-test.sh
+++ b/mk-osal-no-test.sh
@@ -1,0 +1,8 @@
+mkdir -p ../build_osal
+cd ../build_osal
+cmake -DOSAL_SYSTEM_BSPTYPE=generic-linux \
+-DCMAKE_INSTALL_PREFIX=../local \
+../osal
+make
+make install
+

--- a/mk-osal-test.sh
+++ b/mk-osal-test.sh
@@ -1,0 +1,10 @@
+mkdir -p ../build_osal_test
+cd ../build_osal_test
+cmake -DENABLE_UNIT_TESTS=true \
+-DOSAL_SYSTEM_BSPTYPE=generic-linux \
+-DOSAL_CONFIG_DEBUG_PERMISSIVE_MODE=TRUE \
+-DCMAKE_INSTALL_PREFIX=../local \
+../osal 
+make
+make test
+make install


### PR DESCRIPTION
**Description**
Fixes issue 1427. Added two default build/install scripts.
`mk-osal-no-test.sh` - Builds OSAL and installs in ../local
`mk-osal-test.sh` - Builds OSAL, runs OSAL tests, and installs in ../local

**Testing performed**
Steps taken to test the contribution:
1. Ran both build scripts successfully.
1. All OSAL tests in the build passed.

**Expected behavior changes**
The default build scripts provide example build commands using relative paths.

**System(s) tested on**
 - Hardware: AWS
 - OS: Ubuntu 20.04 LTS
 - Versions: OSAL 5.0.99

**Contributor Info - All information REQUIRED for consideration of pull request**
Grafton S. Kennedy, III - Vantage Systems, Inc.
