### PR TITLE
Fix #1441, patch build for old RTEMS

### DIFF
--- a/src/os/rtems/inc/os-rtems.h
+++ b/src/os/rtems/inc/os-rtems.h
@@ -60,6 +60,9 @@
 #define OSAL_UNRESOLVED_SYMBOL  rtems_rtl_unresolved_name
 #define OSAL_UNRESOLVED_ITERATE rtems_rtl_unresolved_interate
 
+/* RTEMS 4.x does not implement thread names, so this becomes a no-op */
+#define pthread_setname_np(...)
+
 #else
 
 #define OSAL_HEAP_INFO_BLOCK    Heap_Information_block


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Ignore the call to pthread_setname_np() on RTEMS 4.x.  This becomes a no-op, and OSAL is able to build again.

Fixes #1441

**Testing performed**
Build on RTEMS 4.11

**Expected behavior changes**
Build succeeds

**System(s) tested on**
Debian with RTEMS 4.11 toolchain

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
