### PR TITLE
Fix #1433, use virtual path as name for FS_BASED maps

### DIFF
--- a/src/os/rtems/src/os-impl-filesys.c
+++ b/src/os/rtems/src/os-impl-filesys.c
@@ -187,11 +187,12 @@ int32 OS_FileSysStartVolume_Impl(const OS_object_token_t *token)
      *
      * The path will be simply /<VOLNAME>
      */
-    if (return_code == OS_SUCCESS && local->system_mountpt[0] == 0)
+    if (return_code == OS_SUCCESS && local->system_mountpt[0] == 0 && local->volume_name[0] != 0)
     {
-        local->system_mountpt[0]                                 = '/';
-        local->system_mountpt[sizeof(local->system_mountpt) - 1] = 0;
+        local->system_mountpt[0] = '/';
         strncpy(&local->system_mountpt[1], local->volume_name, sizeof(local->system_mountpt) - 2);
+        local->system_mountpt[sizeof(local->system_mountpt) - 1] = 0;
+
         OS_DEBUG("OSAL: using mount point %s for %s\n", local->system_mountpt, local->volume_name);
     }
 

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -243,7 +243,6 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
     OS_filesys_internal_record_t *filesys;
     int32                         return_code;
     OS_object_token_t             token;
-    const char *                  dev_name;
 
     /*
      * Validate inputs
@@ -252,33 +251,14 @@ int32 OS_FileSysAddFixedMap(osal_id_t *filesys_id, const char *phys_path, const 
     OS_CHECK_STRING(phys_path, sizeof(filesys->system_mountpt), OS_FS_ERR_PATH_TOO_LONG);
     OS_CHECK_PATHNAME(virt_path);
 
-    /*
-     * Generate a dev name by taking the basename of the phys_path.
-     */
-    dev_name = strrchr(phys_path, '/');
-    if (dev_name == NULL)
-    {
-        dev_name = phys_path;
-    }
-    else
-    {
-        ++dev_name;
-    }
-
-    if (memchr(dev_name, 0, sizeof(filesys->volume_name)) == NULL)
-    {
-        return OS_ERR_NAME_TOO_LONG;
-    }
-
-    return_code = OS_ObjectIdAllocateNew(LOCAL_OBJID_TYPE, dev_name, &token);
+    return_code = OS_ObjectIdAllocateNew(LOCAL_OBJID_TYPE, virt_path, &token);
     if (return_code == OS_SUCCESS)
     {
         filesys = OS_OBJECT_TABLE_GET(OS_filesys_table, token);
 
         /* Reset the table entry and save the name */
-        OS_OBJECT_INIT(token, filesys, device_name, dev_name);
+        OS_OBJECT_INIT(token, filesys, virtual_mountpt, virt_path);
 
-        strncpy(filesys->volume_name, dev_name, sizeof(filesys->volume_name) - 1);
         strncpy(filesys->system_mountpt, phys_path, sizeof(filesys->system_mountpt) - 1);
         strncpy(filesys->virtual_mountpt, virt_path, sizeof(filesys->virtual_mountpt) - 1);
 

--- a/src/os/vxworks/src/os-impl-filesys.c
+++ b/src/os/vxworks/src/os-impl-filesys.c
@@ -140,6 +140,12 @@ int32 OS_FileSysStartVolume_Impl(const OS_object_token_t *token)
             OS_DEBUG("OSAL: Error creating low level block device\n");
             return_code = OS_FS_ERR_DRIVE_NOT_CREATED;
         }
+        else if (local->volume_name[0] == 0)
+        {
+            /* this requires that the user has specified the volume name to mount */
+            OS_DEBUG("OSAL: No volume name specified to mount\n");
+            return_code = OS_FS_ERR_DRIVE_NOT_CREATED;
+        }
         else
         {
             /*

--- a/src/tests/file-sys-add-fixed-map-api-test/file-sys-add-fixed-map-api-test.c
+++ b/src/tests/file-sys-add-fixed-map-api-test/file-sys-add-fixed-map-api-test.c
@@ -67,10 +67,6 @@ void TestFileSysAddFixedMapApi(void)
 
     UtAssert_INT32_EQ(OS_FileSysAddFixedMap(&fs_id, "./test", long_path), OS_FS_ERR_PATH_TOO_LONG);
     UtAssert_INT32_EQ(OS_FileSysAddFixedMap(&fs_id, translated_path, "/test"), OS_FS_ERR_PATH_TOO_LONG);
-
-    /* create a path where only the "name" part is too long, but the overall path length is within limit */
-    translated_path[OS_MAX_LOCAL_PATH_LEN - 1] = 0;
-    UtAssert_INT32_EQ(OS_FileSysAddFixedMap(&fs_id, translated_path, "/test"), OS_ERR_NAME_TOO_LONG);
 }
 
 void UtTest_Setup(void)

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -63,12 +63,6 @@ void Test_OS_FileSysAddFixedMap(void)
     UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 2, OS_ERROR);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_FS_ERR_PATH_TOO_LONG);
 
-    UT_SetDefaultReturnValue(UT_KEY(OCS_strrchr), -1);
-    UT_SetDeferredRetcode(UT_KEY(OCS_memchr), 3, OS_ERROR);
-    OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_ERR_NAME_TOO_LONG);
-    UT_ResetState(UT_KEY(OCS_memchr));
-    UT_ResetState(UT_KEY(OCS_strrchr));
-
     UT_SetDeferredRetcode(UT_KEY(OS_ObjectIdAllocateNew), 1, OS_ERR_NO_FREE_IDS);
     OSAPI_TEST_FUNCTION_RC(OS_FileSysAddFixedMap(&id, "/phys", "/virt"), OS_ERR_NO_FREE_IDS);
     UT_SetDeferredRetcode(UT_KEY(OS_FileSysStartVolume_Impl), 1, OS_ERROR);

--- a/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-filesys.c
@@ -57,8 +57,13 @@ void Test_OS_FileSysStartVolume_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStartVolume_Impl(&token), OS_SUCCESS);
 
     /* Emulate a VOLATILE_DISK entry (ramdisk) */
+    /* Without a volumne name specified, this should fail  */
     OS_filesys_table[1].fstype = OS_FILESYS_TYPE_VOLATILE_DISK;
     token.obj_idx              = UT_INDEX_1;
+    OSAPI_TEST_FUNCTION_RC(OS_FileSysStartVolume_Impl(&token), OS_FS_ERR_DRIVE_NOT_CREATED);
+
+    /* Filling the volume name should permit success (nominal)  */
+    strncpy(OS_filesys_table[1].volume_name, "UT", sizeof(OS_filesys_table[1].volume_name));
     OSAPI_TEST_FUNCTION_RC(OS_FileSysStartVolume_Impl(&token), OS_SUCCESS);
 
     /* Emulate a NORMAL_DISK entry (ATA) */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Use the "virtual_path" instead of "device_name" as the name record for FS_BASED entries.  This should allow duplicate detection to work as expected.

The device_name on mappings made via this method will now be an empty string.  It is not relevant because this type of map is used for devices that are already mounted.

Fixes #1433

**Testing performed**
Run all tests, validate OSAL behavior 

**Expected behavior changes**
Using `OS_FileSysAddFixedMap()` with similar system paths should work as expected.

**System(s) tested on**
Debian

**Additional context**
Duplicate detection is now done on virtual path, not system path.  Therefore it is (theoretically) possible to mount the same system path in more than one virtual location, but the same virtual location cannot be mapped to multiple system paths.  This makes more sense than the inverse.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.