### PR TITLE
Fix #1449, POSIX implementation honors stack pointer

### DIFF
--- a/src/examples/tasking-example/tasking-example.c
+++ b/src/examples/tasking-example/tasking-example.c
@@ -30,7 +30,7 @@
 /* Task 1 */
 
 #define TASK_1_ID         1
-#define TASK_1_STACK_SIZE 1024
+#define TASK_1_STACK_SIZE 4096
 #define TASK_1_PRIORITY   101
 
 uint32 task_1_stack[TASK_1_STACK_SIZE];
@@ -40,7 +40,7 @@ void task_1(void);
 /* Task 2 */
 
 #define TASK_2_ID         2
-#define TASK_2_STACK_SIZE 1024
+#define TASK_2_STACK_SIZE 4096
 #define TASK_2_PRIORITY   102
 
 uint32 task_2_stack[TASK_2_STACK_SIZE];
@@ -50,7 +50,7 @@ void task_2(void);
 /* Task 3 */
 
 #define TASK_3_ID         3
-#define TASK_3_STACK_SIZE 1024
+#define TASK_3_STACK_SIZE 4096
 #define TASK_3_PRIORITY   103
 
 uint32 task_3_stack[TASK_3_STACK_SIZE];

--- a/src/os/posix/inc/os-impl-tasks.h
+++ b/src/os/posix/inc/os-impl-tasks.h
@@ -40,7 +40,7 @@ typedef struct
 /* Tables where the OS object information is stored */
 extern OS_impl_task_internal_record_t OS_impl_task_table[OS_MAX_TASKS];
 
-int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority, size_t stacksz,
-                                       PthreadFuncPtr_t entry, void *entry_arg);
+int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority, osal_stackptr_t stackptr,
+                                       size_t stacksz, PthreadFuncPtr_t entry, void *entry_arg);
 
 #endif /* OS_IMPL_TASKS_H */

--- a/src/os/posix/src/os-impl-console.c
+++ b/src/os/posix/src/os-impl-console.c
@@ -128,8 +128,9 @@ int32 OS_ConsoleCreate_Impl(const OS_object_token_t *token)
             {
                 /* cppcheck-suppress unreadVariable // intentional use of other union member */
                 local_arg.id = OS_ObjectIdFromToken(token);
-                return_code  = OS_Posix_InternalTaskCreate_Impl(&consoletask, OS_CONSOLE_TASK_PRIORITY, 0,
-                                                               OS_ConsoleTask_Entry, local_arg.opaque_arg);
+                return_code =
+                    OS_Posix_InternalTaskCreate_Impl(&consoletask, OS_CONSOLE_TASK_PRIORITY, OSAL_TASK_STACK_ALLOCATE,
+                                                     PTHREAD_STACK_MIN, OS_ConsoleTask_Entry, local_arg.opaque_arg);
 
                 if (return_code != OS_SUCCESS)
                 {

--- a/src/os/posix/src/os-impl-timebase.c
+++ b/src/os/posix/src/os-impl-timebase.c
@@ -347,8 +347,8 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
 
     /* cppcheck-suppress unreadVariable // intentional use of other union member */
     arg.id      = OS_ObjectIdFromToken(token);
-    return_code = OS_Posix_InternalTaskCreate_Impl(&local->handler_thread, OSAL_PRIORITY_C(0), 0,
-                                                   OS_TimeBasePthreadEntry, arg.opaque_arg);
+    return_code = OS_Posix_InternalTaskCreate_Impl(&local->handler_thread, OSAL_PRIORITY_C(0), OSAL_TASK_STACK_ALLOCATE,
+                                                   PTHREAD_STACK_MIN, OS_TimeBasePthreadEntry, arg.opaque_arg);
     if (return_code != OS_SUCCESS)
     {
         return return_code;

--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -23,7 +23,7 @@
 #include "utassert.h"
 #include "uttest.h"
 
-#define TASK_STACK_SIZE 1024
+#define TASK_STACK_SIZE 16384
 
 uint32 task_counter[3];
 

--- a/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
+++ b/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
@@ -32,9 +32,9 @@ void BinSemTimeoutSetup(void);
 void BinSemTimeoutCheck(void);
 
 /* Task 1 */
-#define TASK_1_STACK_SIZE 1024
+#define TASK_1_STACK_SIZE 4096
 #define TASK_1_PRIORITY   101
-#define TASK_2_STACK_SIZE 1024
+#define TASK_2_STACK_SIZE 4096
 #define TASK_2_PRIORITY   50
 
 uint32    task_1_stack[TASK_1_STACK_SIZE];

--- a/src/tests/count-sem-test/count-sem-test.c
+++ b/src/tests/count-sem-test/count-sem-test.c
@@ -23,7 +23,7 @@
 #include "utassert.h"
 #include "uttest.h"
 
-#define TASK_STACK_SIZE 1024
+#define TASK_STACK_SIZE 4096
 
 uint32 task_counter[3];
 

--- a/src/tests/osal-core-test/osal-core-test.c
+++ b/src/tests/osal-core-test/osal-core-test.c
@@ -39,6 +39,7 @@ typedef struct
 } TestCallbackState_t;
 
 void TestTasks(void);
+void TestTaskWithStackPtr(void);
 void InitializeTaskIds(void);
 void InitializeQIds(void);
 void InitializeBinIds(void);
@@ -98,6 +99,16 @@ void UtTest_Setup(void)
     UtTest_AddTeardown(OS_API_Teardown, "Cleanup");
 
     UtTest_Add(TestTasks, NULL, NULL, "TASK");
+
+    /*
+     * NOTE: The current RTEMS implementation does not adhere to passed-in stack pointers.
+     * The facility to create a task with a user-specified stack pointer is not available
+     * until RTEMS 6.x (development version at the time of this writing).  This test will
+     * fail on currently-released RTEMS versions, so it is skipped.
+     */
+#ifndef _RTEMS_OS_
+    UtTest_Add(TestTaskWithStackPtr, NULL, NULL, "TASKSTACK");
+#endif
     UtTest_Add(TestQueues, NULL, NULL, "MSGQ");
     UtTest_Add(TestBinaries, NULL, NULL, "BSEM");
     UtTest_Add(TestMutexes, NULL, NULL, "MSEM");
@@ -268,6 +279,12 @@ void TestTasks(void)
     UtAssert_True(OS_TaskDelete(task_1_id) != OS_SUCCESS, "OS_TaskDelete, Task 1");
     UtAssert_True(OS_TaskDelete(task_2_id) == OS_SUCCESS, "OS_TaskDelete, Task 2");
     UtAssert_True(OS_TaskDelete(task_3_id) == OS_SUCCESS, "OS_TaskDelete, Task 3");
+}
+
+void TestTaskWithStackPtr(void)
+{
+    OS_task_prop_t      taskprop;
+    int                 loopcnt;
 
     /*
      * Validate that the user-specified stack pointer parameter is implemented correctly.

--- a/src/tests/osal-core-test/osal-core-test.h
+++ b/src/tests/osal-core-test/osal-core-test.h
@@ -29,19 +29,19 @@
 #define OSAL_CORE_TEST_H
 
 /* Task 0 */
-#define TASK_0_STACK_SIZE 1024
+#define TASK_0_STACK_SIZE 4096
 #define TASK_0_PRIORITY   230
 
 /* Task 1 */
-#define TASK_1_STACK_SIZE 1024
+#define TASK_1_STACK_SIZE 4096
 #define TASK_1_PRIORITY   231
 
 /* Task 2 */
-#define TASK_2_STACK_SIZE 1024
+#define TASK_2_STACK_SIZE 4096
 #define TASK_2_PRIORITY   232
 
 /* Task 3 */
-#define TASK_3_STACK_SIZE 1024
+#define TASK_3_STACK_SIZE 4096
 #define TASK_3_PRIORITY   233
 
 /* Global Data */

--- a/src/tests/queue-test/queue-test.c
+++ b/src/tests/queue-test/queue-test.c
@@ -36,9 +36,9 @@ void QueueTimeoutCheck(void);
 #define MSGQ_BURST 3
 
 /* Task 1 */
-#define TASK_1_STACK_SIZE 1024
+#define TASK_1_STACK_SIZE 4096
 #define TASK_1_PRIORITY   101
-#define TASK_2_STACK_SIZE 1024
+#define TASK_2_STACK_SIZE 4096
 #define TASK_2_PRIORITY   50
 
 uint32    task_1_stack[TASK_1_STACK_SIZE];


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
When the OS_TaskCreate() function is called with a non-NULL stack pointer, the POSIX implementation now should use this pointer as intended.  Previously it was always allocating a new stack buffer, ignoring the passed-in pointer.

NOTE: When using this feature, the caller must use caution to make sure the buffer being passed in is large enough to use as a task stack.  Particularly when running under a desktop Linux/Glibc environment, the infrastructure puts a considerably large object on the stack.  For example, in the osal-core-tests, the stack size was too small.

Fixes #1449

**Testing performed**
Build and run all tests.  Added tests that ensure the stack pointer is being honored as expected.

**Expected behavior changes**
User-supplied stack buffer will be used on POSIX.

**System(s) tested on**
Debian

**Additional context**
This could have negative consequences if the user was assuming RTOS-like behavior (e.g. no thread local storage) and was using very small stack sizes.  If the supplied stack size is less than 16k, (or `PTHREAD_STACK_MIN`) then the call will now fail, whereas previously it would quietly be made bigger than requested.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
