### PR TITLE
Fix #1440, Split up BinSemGetInfo() to avoid partial success returns

### DIFF
--- a/src/os/inc/osapi-binsem.h
+++ b/src/os/inc/osapi-binsem.h
@@ -178,6 +178,8 @@ int32 OS_BinSemDelete(osal_id_t sem_id);
  */
 int32 OS_BinSemGetIdByName(osal_id_t *sem_id, const char *sem_name);
 
+#ifdef OSAL_OMIT_DEPRECATED
+#else
 /*-------------------------------------------------------------------------------------*/
 /**
  * @brief Fill a property object buffer with details regarding the resource
@@ -196,6 +198,56 @@ int32 OS_BinSemGetIdByName(osal_id_t *sem_id, const char *sem_name);
  * @retval #OS_ERR_NOT_IMPLEMENTED @copybrief OS_ERR_NOT_IMPLEMENTED
  */
 int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop);
+#endif
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Get the name of the binary semaphore
+ *
+ * This function retrieves the name of the specified binary semaphore.
+ *
+ * @param[in] sem_id The object ID to operate on
+ * @param[out] bin_prop The property object buffer to fill @nonnull
+ *
+ * @return Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
+ * @retval #OS_ERR_INVALID_ID if the id passed in is not a valid semaphore
+ * @retval #OS_INVALID_POINTER if the bin_prop pointer is null
+ */
+int32 OS_BinSemGetName(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop);
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Get the creator of the binary semaphore
+ *
+ * This function retrieves the creator of the specified binary semaphore.
+ *
+ * @param[in] sem_id The object ID to operate on
+ * @param[out] bin_prop The property object buffer to fill @nonnull
+ *
+ * @return Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
+ * @retval #OS_ERR_INVALID_ID if the id passed in is not a valid semaphore
+ * @retval #OS_INVALID_POINTER if the bin_prop pointer is null
+ */
+int32 OS_BinSemGetCreator(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop);
+
+/*-------------------------------------------------------------------------------------*/
+/**
+ * @brief Get the value of the binary semaphore
+ *
+ * This function retrieves the value of the specified binary semaphore.
+ *
+ * @param[in] sem_id The object ID to operate on
+ * @param[out] bin_prop The property object buffer to fill @nonnull
+ *
+ * @return Execution status, see @ref OSReturnCodes
+ * @retval #OS_SUCCESS @copybrief OS_SUCCESS
+ * @retval #OS_ERR_INVALID_ID if the id passed in is not a valid semaphore
+ * @retval #OS_INVALID_POINTER if the bin_prop pointer is null
+ * @retval #OS_ERR_NOT_IMPLEMENTED @copybrief OS_ERR_NOT_IMPLEMENTED
+ */
+int32 OS_BinSemGetValue(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop);
 
 /**@}*/
 

--- a/src/os/posix/src/os-impl-binsem.c
+++ b/src/os/posix/src/os-impl-binsem.c
@@ -466,6 +466,8 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs)
     return (OS_GenericBinSemTake_Impl(token, &ts));
 }
 
+#ifdef OSAL_OMIT_DEPRECATED
+#else
 /*----------------------------------------------------------------
  *
  *  Purpose: Implemented per internal OSAL API
@@ -473,6 +475,24 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs)
  *
  *-----------------------------------------------------------------*/
 int32 OS_BinSemGetInfo_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *sem_prop)
+{
+    OS_impl_binsem_internal_record_t *sem;
+
+    sem = OS_OBJECT_TABLE_GET(OS_impl_bin_sem_table, *token);
+
+    /* put the info into the structure */
+    sem_prop->value = sem->current_value;
+    return OS_SUCCESS;
+}
+#endif
+
+/*----------------------------------------------------------------
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetValue_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *sem_prop)
 {
     OS_impl_binsem_internal_record_t *sem;
 

--- a/src/os/rtems/src/os-impl-binsem.c
+++ b/src/os/rtems/src/os-impl-binsem.c
@@ -266,6 +266,8 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs)
     return OS_SUCCESS;
 }
 
+#ifdef OSAL_OMIT_DEPRECATED
+#else
 /*----------------------------------------------------------------
  *
  *  Purpose: Implemented per internal OSAL API
@@ -273,6 +275,19 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs)
  *
  *-----------------------------------------------------------------*/
 int32 OS_BinSemGetInfo_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop)
+{
+    /* RTEMS has no API for obtaining the current value of a semaphore */
+    return OS_ERR_NOT_IMPLEMENTED;
+}
+#endif
+
+/*----------------------------------------------------------------
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetValue_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop)
 {
     /* RTEMS has no API for obtaining the current value of a semaphore */
     return OS_ERR_NOT_IMPLEMENTED;

--- a/src/os/shared/inc/os-shared-binsem.h
+++ b/src/os/shared/inc/os-shared-binsem.h
@@ -105,6 +105,9 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs);
  ------------------------------------------------------------------*/
 int32 OS_BinSemDelete_Impl(const OS_object_token_t *token);
 
+
+#ifdef OSAL_OMIT_DEPRECATED
+#else
 /*----------------------------------------------------------------
 
     Purpose: Obtain OS-specific information about the semaphore
@@ -112,5 +115,14 @@ int32 OS_BinSemDelete_Impl(const OS_object_token_t *token);
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
 int32 OS_BinSemGetInfo_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop);
+#endif
+
+/*----------------------------------------------------------------
+
+    Purpose: Obtain the value of a semaphore (if possible/implemented in the relevent OS)
+
+    Returns: OS_SUCCESS on success, or relevant error code
+ ------------------------------------------------------------------*/
+int32 OS_BinSemGetValue_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop);
 
 #endif /* OS_SHARED_BINSEM_H */

--- a/src/os/shared/src/osapi-binsem.c
+++ b/src/os/shared/src/osapi-binsem.c
@@ -243,6 +243,8 @@ int32 OS_BinSemGetIdByName(osal_id_t *sem_id, const char *sem_name)
     return return_code;
 }
 
+#ifdef OSAL_OMIT_DEPRECATED
+#else
 /*----------------------------------------------------------------
  *
  *  Purpose: Implemented per public OSAL API
@@ -250,6 +252,36 @@ int32 OS_BinSemGetIdByName(osal_id_t *sem_id, const char *sem_name)
  *
  *-----------------------------------------------------------------*/
 int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+{
+    OS_common_record_t *record;
+    OS_object_token_t   token;
+    int32               return_code;
+    /* Check parameters */
+    OS_CHECK_POINTER(bin_prop);
+    memset(bin_prop, 0, sizeof(OS_bin_sem_prop_t));
+    /* Check Parameters */
+    return_code = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, sem_id, &token);
+    if (return_code == OS_SUCCESS)
+    {
+        record = OS_OBJECT_TABLE_GET(OS_global_bin_sem_table, token);
+
+        strncpy(bin_prop->name, record->name_entry, sizeof(bin_prop->name) - 1);
+        bin_prop->creator = record->creator;
+        return_code       = OS_BinSemGetInfo_Impl(&token, bin_prop);
+
+        OS_ObjectIdRelease(&token);
+    }
+    return return_code;
+}
+#endif
+
+/*----------------------------------------------------------------
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetName(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
 {
     OS_common_record_t *record;
     OS_object_token_t   token;
@@ -267,8 +299,66 @@ int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
         record = OS_OBJECT_TABLE_GET(OS_global_bin_sem_table, token);
 
         strncpy(bin_prop->name, record->name_entry, sizeof(bin_prop->name) - 1);
+        bin_prop->name[sizeof(bin_prop->name) - 1] = '\0'; /* Ensure null termination */
+
+        OS_ObjectIdRelease(&token);
+    }
+
+    return return_code;
+}
+
+/*----------------------------------------------------------------
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetCreator(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+{
+    OS_common_record_t *record;
+    OS_object_token_t   token;
+    int32               return_code;
+
+    /* Check parameters */
+    OS_CHECK_POINTER(bin_prop);
+
+    memset(bin_prop, 0, sizeof(OS_bin_sem_prop_t));
+
+    /* Check Parameters */
+    return_code = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, sem_id, &token);
+    if (return_code == OS_SUCCESS)
+    {
+        record = OS_OBJECT_TABLE_GET(OS_global_bin_sem_table, token);
+
         bin_prop->creator = record->creator;
-        return_code       = OS_BinSemGetInfo_Impl(&token, bin_prop);
+
+        OS_ObjectIdRelease(&token);
+    }
+
+    return return_code;
+}
+
+/*----------------------------------------------------------------
+ *
+ *  Purpose: Implemented per public OSAL API
+ *           See description in API and header file for detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetValue(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+{
+    OS_object_token_t token;
+    int32             return_code;
+
+    /* Check parameters */
+    OS_CHECK_POINTER(bin_prop);
+
+    memset(bin_prop, 0, sizeof(OS_bin_sem_prop_t));
+
+    /* Check Parameters */
+    return_code = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, LOCAL_OBJID_TYPE, sem_id, &token);
+    if (return_code == OS_SUCCESS)
+    {
+        return_code = OS_BinSemGetValue_Impl(&token, bin_prop);
 
         OS_ObjectIdRelease(&token);
     }

--- a/src/os/vxworks/src/os-impl-binsem.c
+++ b/src/os/vxworks/src/os-impl-binsem.c
@@ -184,6 +184,8 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs)
     return status;
 }
 
+#ifdef OSAL_OMIT_DEPRECATED
+#else
 /*----------------------------------------------------------------
  *
  *  Purpose: Implemented per internal OSAL API
@@ -193,5 +195,18 @@ int32 OS_BinSemTimedWait_Impl(const OS_object_token_t *token, uint32 msecs)
 int32 OS_BinSemGetInfo_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop)
 {
     /* VxWorks has no API for obtaining the current value of a semaphore */
-    return OS_SUCCESS;
+    return OS_ERR_NOT_IMPLEMENTED;
+}
+#endif
+
+/*----------------------------------------------------------------
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetValue_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop)
+{
+    /* VxWorks has no API for obtaining the current value of a semaphore */
+    return OS_ERR_NOT_IMPLEMENTED;
 }

--- a/src/tests/bin-sem-test/bin-sem-test.c
+++ b/src/tests/bin-sem-test/bin-sem-test.c
@@ -77,23 +77,32 @@ void Test_BinSem(void)
     char              long_name[OS_MAX_API_NAME + 1];
     OS_bin_sem_prop_t sem_prop;
     uint32            test_val;
-    bool              get_info_implemented;
+    bool              get_value_implemented;
 
     memset(&sem_prop, 0, sizeof(sem_prop));
     memset(task_counter, 0, sizeof(task_counter));
 
     /* Invalid id checks */
-    UtAssert_INT32_EQ(OS_BinSemGetInfo(OS_OBJECT_ID_UNDEFINED, &sem_prop), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_BinSemGetName(OS_OBJECT_ID_UNDEFINED, &sem_prop), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_BinSemGetCreator(OS_OBJECT_ID_UNDEFINED, &sem_prop), OS_ERR_INVALID_ID);
+    UtAssert_INT32_EQ(OS_BinSemGetValue(OS_OBJECT_ID_UNDEFINED, &sem_prop), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_BinSemFlush(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_BinSemGive(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_BinSemTake(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_BinSemTimedWait(OS_OBJECT_ID_UNDEFINED, 0), OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(OS_BinSemDelete(OS_OBJECT_ID_UNDEFINED), OS_ERR_INVALID_ID);
 
-    /* Null checks */
+    /* OS_BinSemCreate NULL checks */
     UtAssert_INT32_EQ(OS_BinSemCreate(NULL, "Test_Sem", 0, 0), OS_INVALID_POINTER);
     UtAssert_INT32_EQ(OS_BinSemCreate(&sem_id[0], NULL, 0, 0), OS_INVALID_POINTER);
-    UtAssert_INT32_EQ(OS_BinSemGetInfo(sem_id[0], NULL), OS_INVALID_POINTER);
+
+    // Initialize sem_id[0] to a valid value for the following NULL checks
+    sem_id[0] = OS_OBJECT_ID_UNDEFINED;
+
+    // OS_BinSemGet* NULL checks
+    UtAssert_INT32_EQ(OS_BinSemGetName(sem_id[0], NULL), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_BinSemGetCreator(sem_id[0], NULL), OS_INVALID_POINTER);
+    UtAssert_INT32_EQ(OS_BinSemGetValue(sem_id[0], NULL), OS_INVALID_POINTER);
     UtAssert_INT32_EQ(OS_BinSemGetIdByName(NULL, "Test_Sem"), OS_INVALID_POINTER);
     UtAssert_INT32_EQ(OS_BinSemGetIdByName(&sem_id[0], NULL), OS_INVALID_POINTER);
 
@@ -109,15 +118,15 @@ void Test_BinSem(void)
     /* Nonzero create */
     UtAssert_INT32_EQ(OS_BinSemCreate(&sem_id[1], "Test_Sem_Nonzero", 1, 0), OS_SUCCESS);
 
-    /* Check get info implementation */
-    get_info_implemented = (OS_BinSemGetInfo(sem_id[0], &sem_prop) != OS_ERR_NOT_IMPLEMENTED);
+    /* Check get value implementation */
+    get_value_implemented = (OS_BinSemGetValue(sem_id[0], &sem_prop) != OS_ERR_NOT_IMPLEMENTED);
 
     /* Validate values */
-    if (get_info_implemented)
+    if (get_value_implemented)
     {
-        UtAssert_INT32_EQ(OS_BinSemGetInfo(sem_id[0], &sem_prop), OS_SUCCESS);
+        UtAssert_INT32_EQ(OS_BinSemGetValue(sem_id[0], &sem_prop), OS_SUCCESS);
         UtAssert_INT32_EQ(sem_prop.value, 0);
-        UtAssert_INT32_EQ(OS_BinSemGetInfo(sem_id[1], &sem_prop), OS_SUCCESS);
+        UtAssert_INT32_EQ(OS_BinSemGetValue(sem_id[1], &sem_prop), OS_SUCCESS);
         UtAssert_INT32_EQ(sem_prop.value, 1);
     }
 
@@ -141,11 +150,11 @@ void Test_BinSem(void)
     UtAssert_INT32_EQ(OS_BinSemTimedWait(sem_id[1], 0), OS_SUCCESS);
 
     /* Validate zeros */
-    if (get_info_implemented)
+    if (get_value_implemented)
     {
-        UtAssert_INT32_EQ(OS_BinSemGetInfo(sem_id[0], &sem_prop), OS_SUCCESS);
+        UtAssert_INT32_EQ(OS_BinSemGetValue(sem_id[0], &sem_prop), OS_SUCCESS);
         UtAssert_INT32_EQ(sem_prop.value, 0);
-        UtAssert_INT32_EQ(OS_BinSemGetInfo(sem_id[1], &sem_prop), OS_SUCCESS);
+        UtAssert_INT32_EQ(OS_BinSemGetValue(sem_id[1], &sem_prop), OS_SUCCESS);
         UtAssert_INT32_EQ(sem_prop.value, 0);
     }
     else
@@ -162,9 +171,9 @@ void Test_BinSem(void)
     UtAssert_INT32_EQ(OS_TaskDelete(task_id[0]), OS_SUCCESS);
     UtAssert_UINT32_EQ(task_counter[0], 0);
 
-    if (get_info_implemented)
+    if (get_value_implemented)
     {
-        UtAssert_INT32_EQ(OS_BinSemGetInfo(sem_id[0], &sem_prop), OS_SUCCESS);
+        UtAssert_INT32_EQ(OS_BinSemGetValue(sem_id[0], &sem_prop), OS_SUCCESS);
         UtAssert_INT32_EQ(sem_prop.value, 0);
     }
     else

--- a/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
+++ b/src/tests/bin-sem-timeout-test/bin-sem-timeout-test.c
@@ -98,7 +98,7 @@ void task_1(void)
         if (status == OS_SUCCESS)
         {
             OS_printf("TASK 1:   Doing some work: %d\n", (int)counter++);
-            status = OS_BinSemGetInfo(bin_sem_id, &bin_sem_prop);
+            status = OS_BinSemGetValue(bin_sem_id, &bin_sem_prop);
             if (status == OS_SUCCESS)
             {
                 if (bin_sem_prop.value > 1)

--- a/src/tests/select-test/select-test.c
+++ b/src/tests/select-test/select-test.c
@@ -73,7 +73,7 @@ void BinSemSetup(void)
     UtAssert_INT32_EQ(OS_BinSemCreate(&bin_sem_id, "BinSem1", 0, 0), OS_SUCCESS);
     UtAssert_True(OS_ObjectIdDefined(bin_sem_id), "bin_sem_id (%lu) != UNDEFINED", OS_ObjectIdToInteger(bin_sem_id));
 
-    UtAssert_INT32_EQ(OS_BinSemGetInfo(bin_sem_id, &bin_sem_prop), OS_SUCCESS);
+    UtAssert_INT32_EQ(OS_BinSemGetValue(bin_sem_id, &bin_sem_prop), OS_SUCCESS);
     UtPrintf("BinSem1 value=%d", (int)bin_sem_prop.value);
 }
 

--- a/src/unit-test-coverage/shared/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-binsem.c
@@ -147,11 +147,11 @@ void Test_OS_BinSemGetIdByName(void)
     OSAPI_TEST_FUNCTION_RC(OS_BinSemGetIdByName(&objid, NULL), OS_INVALID_POINTER);
 }
 
-void Test_OS_BinSemGetInfo(void)
+void Test_OS_BinSemGetName(void)
 {
     /*
      * Test Case For:
-     * int32 OS_BinSemGetInfo (uint32 sem_id, OS_bin_sem_prop_t *bin_prop)
+     * int32 OS_BinSemGetName (osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
      */
     int32             expected = OS_SUCCESS;
     int32             actual   = ~OS_SUCCESS;
@@ -161,16 +161,64 @@ void Test_OS_BinSemGetInfo(void)
 
     OS_UT_SetupBasicInfoTest(OS_OBJECT_TYPE_OS_BINSEM, UT_INDEX_1, "ABC", UT_OBJID_OTHER);
 
-    actual = OS_BinSemGetInfo(UT_OBJID_1, &prop);
+    actual = OS_BinSemGetName(UT_OBJID_1, &prop);
 
-    UtAssert_True(actual == expected, "OS_BinSemGetInfo() (%ld) == OS_SUCCESS", (long)actual);
-    OSAPI_TEST_OBJID(prop.creator, ==, UT_OBJID_OTHER);
+    UtAssert_True(actual == expected, "OS_BinSemGetName() (%ld) == OS_SUCCESS", (long)actual);
     UtAssert_True(strcmp(prop.name, "ABC") == 0, "prop.name (%s) == ABC", prop.name);
 
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetInfo(UT_OBJID_1, NULL), OS_INVALID_POINTER);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetName(UT_OBJID_1, NULL), OS_INVALID_POINTER);
 
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetById), OS_ERR_INVALID_ID);
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetInfo(UT_OBJID_1, &prop), OS_ERR_INVALID_ID);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetName(UT_OBJID_1, &prop), OS_ERR_INVALID_ID);
+}
+
+void Test_OS_BinSemGetCreator(void)
+{
+    /*
+     * Test Case For:
+     * int32 OS_BinSemGetCreator (osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+     */
+    int32             expected = OS_SUCCESS;
+    int32             actual   = ~OS_SUCCESS;
+    OS_bin_sem_prop_t prop;
+
+    memset(&prop, 0, sizeof(prop));
+
+    OS_UT_SetupBasicInfoTest(OS_OBJECT_TYPE_OS_BINSEM, UT_INDEX_1, "ABC", UT_OBJID_OTHER);
+
+    actual = OS_BinSemGetCreator(UT_OBJID_1, &prop);
+
+    UtAssert_True(actual == expected, "OS_BinSemGetCreator() (%ld) == OS_SUCCESS", (long)actual);
+    OSAPI_TEST_OBJID(prop.creator, ==, UT_OBJID_OTHER);
+
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetCreator(UT_OBJID_1, NULL), OS_INVALID_POINTER);
+
+    UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetById), OS_ERR_INVALID_ID);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetCreator(UT_OBJID_1, &prop), OS_ERR_INVALID_ID);
+}
+
+void Test_OS_BinSemGetValue(void)
+{
+    /*
+     * Test Case For:
+     * int32 OS_BinSemGetValue (osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+     */
+    int32             expected = OS_SUCCESS;
+    int32             actual   = ~OS_SUCCESS;
+    OS_bin_sem_prop_t prop;
+
+    memset(&prop, 0, sizeof(prop));
+
+    OS_UT_SetupBasicInfoTest(OS_OBJECT_TYPE_OS_BINSEM, UT_INDEX_1, "ABC", UT_OBJID_OTHER);
+
+    actual = OS_BinSemGetValue(UT_OBJID_1, &prop);
+
+    UtAssert_True(actual == expected, "OS_BinSemGetValue() (%ld) == OS_SUCCESS", (long)actual);
+
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetValue(UT_OBJID_1, NULL), OS_INVALID_POINTER);
+
+    UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetById), OS_ERR_INVALID_ID);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetValue(UT_OBJID_1, &prop), OS_ERR_INVALID_ID);
 }
 
 /* Osapi_Test_Setup
@@ -204,5 +252,7 @@ void UtTest_Setup(void)
     ADD_TEST(OS_BinSemFlush);
     ADD_TEST(OS_BinSemTimedWait);
     ADD_TEST(OS_BinSemGetIdByName);
-    ADD_TEST(OS_BinSemGetInfo);
+    ADD_TEST(OS_BinSemGetName);
+    ADD_TEST(OS_BinSemGetCreator);
+    ADD_TEST(OS_BinSemGetValue);
 }

--- a/src/unit-test-coverage/ut-stubs/src/os-shared-binsem-impl-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/os-shared-binsem-impl-stubs.c
@@ -77,19 +77,19 @@ int32 OS_BinSemFlush_Impl(const OS_object_token_t *token)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for OS_BinSemGetInfo_Impl()
+ * Generated stub function for OS_BinSemGetValue_Impl()
  * ----------------------------------------------------
  */
-int32 OS_BinSemGetInfo_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop)
+int32 OS_BinSemGetValue_Impl(const OS_object_token_t *token, OS_bin_sem_prop_t *bin_prop)
 {
-    UT_GenStub_SetupReturnBuffer(OS_BinSemGetInfo_Impl, int32);
+    UT_GenStub_SetupReturnBuffer(OS_BinSemGetValue_Impl, int32);
 
-    UT_GenStub_AddParam(OS_BinSemGetInfo_Impl, const OS_object_token_t *, token);
-    UT_GenStub_AddParam(OS_BinSemGetInfo_Impl, OS_bin_sem_prop_t *, bin_prop);
+    UT_GenStub_AddParam(OS_BinSemGetValue_Impl, const OS_object_token_t *, token);
+    UT_GenStub_AddParam(OS_BinSemGetValue_Impl, OS_bin_sem_prop_t *, bin_prop);
 
-    UT_GenStub_Execute(OS_BinSemGetInfo_Impl, Basic, NULL);
+    UT_GenStub_Execute(OS_BinSemGetValue_Impl, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(OS_BinSemGetInfo_Impl, int32);
+    return UT_GenStub_GetReturnValue(OS_BinSemGetValue_Impl, int32);
 }
 
 /*

--- a/src/unit-test-coverage/vxworks/src/coveragetest-binsem.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-binsem.c
@@ -123,17 +123,17 @@ void Test_OS_BinSemTimedWait_Impl(void)
     OSAPI_TEST_FUNCTION_RC(OS_BinSemTimedWait_Impl(&token, 100), OS_ERROR);
 }
 
-void Test_OS_BinSemGetInfo_Impl(void)
+void Test_OS_BinSemGetValue_Impl(void)
 {
     /*
      * Test Case For:
-     * int32 OS_BinSemGetInfo_Impl (uint32 sem_id, OS_bin_sem_prop_t *sem_prop)
+     * int32 OS_BinSemGetValue_Impl (uint32 sem_id, OS_bin_sem_prop_t *sem_prop)
      */
     OS_bin_sem_prop_t sem_prop;
     OS_object_token_t token = UT_TOKEN_0;
 
     memset(&sem_prop, 0xEE, sizeof(sem_prop));
-    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetInfo_Impl(&token, &sem_prop), OS_SUCCESS);
+    OSAPI_TEST_FUNCTION_RC(OS_BinSemGetValue_Impl(&token, &sem_prop), OS_ERR_NOT_IMPLEMENTED);
 }
 
 /* ------------------- End of test cases --------------------------------------*/
@@ -175,5 +175,5 @@ void UtTest_Setup(void)
     ADD_TEST(OS_BinSemFlush_Impl);
     ADD_TEST(OS_BinSemTake_Impl);
     ADD_TEST(OS_BinSemTimedWait_Impl);
-    ADD_TEST(OS_BinSemGetInfo_Impl);
+    ADD_TEST(OS_BinSemGetValue_Impl);
 }

--- a/src/ut-stubs/osapi-binsem-handlers.c
+++ b/src/ut-stubs/osapi-binsem-handlers.c
@@ -55,10 +55,10 @@ void UT_DefaultHandler_OS_BinSemCreate(void *UserObj, UT_EntryKey_t FuncKey, con
 
 /*
  * -----------------------------------------------------------------
- * Default handler implementation for 'OS_BinSemGetInfo' stub
+ * Default handler implementation for 'OS_BinSemGetName' stub
  * -----------------------------------------------------------------
  */
-void UT_DefaultHandler_OS_BinSemGetInfo(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void UT_DefaultHandler_OS_BinSemGetName(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     OS_bin_sem_prop_t *bin_prop = UT_Hook_GetArgValueByName(Context, "bin_prop", OS_bin_sem_prop_t *);
     int32              status;
@@ -66,11 +66,29 @@ void UT_DefaultHandler_OS_BinSemGetInfo(void *UserObj, UT_EntryKey_t FuncKey, co
     UT_Stub_GetInt32StatusCode(Context, &status);
 
     if (status == OS_SUCCESS &&
-        UT_Stub_CopyToLocal(UT_KEY(OS_BinSemGetInfo), bin_prop, sizeof(*bin_prop)) < sizeof(*bin_prop))
+        UT_Stub_CopyToLocal(UT_KEY(OS_BinSemGetName), bin_prop, sizeof(*bin_prop)) < sizeof(*bin_prop))
     {
-        UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &bin_prop->creator);
         strncpy(bin_prop->name, "Name", sizeof(bin_prop->name) - 1);
         bin_prop->name[sizeof(bin_prop->name) - 1] = '\0';
+    }
+}
+
+/*
+ * -----------------------------------------------------------------
+ * Default handler implementation for 'OS_BinSemGetCreator' stub
+ * -----------------------------------------------------------------
+ */
+void UT_DefaultHandler_OS_BinSemGetCreator(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    OS_bin_sem_prop_t *bin_prop = UT_Hook_GetArgValueByName(Context, "bin_prop", OS_bin_sem_prop_t *);
+    int32              status;
+
+    UT_Stub_GetInt32StatusCode(Context, &status);
+
+    if (status == OS_SUCCESS &&
+        UT_Stub_CopyToLocal(UT_KEY(OS_BinSemGetCreator), bin_prop, sizeof(*bin_prop)) < sizeof(*bin_prop))
+    {
+        UT_ObjIdCompose(1, OS_OBJECT_TYPE_OS_TASK, &bin_prop->creator);
     }
 }
 

--- a/src/ut-stubs/osapi-binsem-stubs.c
+++ b/src/ut-stubs/osapi-binsem-stubs.c
@@ -28,7 +28,8 @@
 void UT_DefaultHandler_OS_BinSemCreate(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_OS_BinSemDelete(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_OS_BinSemGetIdByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
-void UT_DefaultHandler_OS_BinSemGetInfo(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_OS_BinSemGetName(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_OS_BinSemGetCreator(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
 /*
  * ----------------------------------------------------
@@ -100,19 +101,36 @@ int32 OS_BinSemGetIdByName(osal_id_t *sem_id, const char *sem_name)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for OS_BinSemGetInfo()
+ * Generated stub function for OS_BinSemGetName()
  * ----------------------------------------------------
  */
-int32 OS_BinSemGetInfo(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+int32 OS_BinSemGetName(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
 {
-    UT_GenStub_SetupReturnBuffer(OS_BinSemGetInfo, int32);
+    UT_GenStub_SetupReturnBuffer(OS_BinSemGetName, int32);
 
-    UT_GenStub_AddParam(OS_BinSemGetInfo, osal_id_t, sem_id);
-    UT_GenStub_AddParam(OS_BinSemGetInfo, OS_bin_sem_prop_t *, bin_prop);
+    UT_GenStub_AddParam(OS_BinSemGetName, osal_id_t, sem_id);
+    UT_GenStub_AddParam(OS_BinSemGetName, OS_bin_sem_prop_t *, bin_prop);
 
-    UT_GenStub_Execute(OS_BinSemGetInfo, Basic, UT_DefaultHandler_OS_BinSemGetInfo);
+    UT_GenStub_Execute(OS_BinSemGetName, Basic, UT_DefaultHandler_OS_BinSemGetName);
 
-    return UT_GenStub_GetReturnValue(OS_BinSemGetInfo, int32);
+    return UT_GenStub_GetReturnValue(OS_BinSemGetName, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_BinSemGetCreator()
+ * ----------------------------------------------------
+ */
+int32 OS_BinSemGetCreator(osal_id_t sem_id, OS_bin_sem_prop_t *bin_prop)
+{
+    UT_GenStub_SetupReturnBuffer(OS_BinSemGetCreator, int32);
+
+    UT_GenStub_AddParam(OS_BinSemGetCreator, osal_id_t, sem_id);
+    UT_GenStub_AddParam(OS_BinSemGetCreator, OS_bin_sem_prop_t *, bin_prop);
+
+    UT_GenStub_Execute(OS_BinSemGetCreator, Basic, UT_DefaultHandler_OS_BinSemGetCreator);
+
+    return UT_GenStub_GetReturnValue(OS_BinSemGetCreator, int32);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1440 
  - Splits the `BinSemGetInfo()` API into 3, allowing clear success/failure (or not implemented) for each.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Tested locally to confirm no loss of coverage compared with the current main branch, and all lines/branches/functions in the new version are covered.

**Expected behavior changes**
Removes this source of 'partial success' which can be confusing and also increases complexity for dealing with the return for users calling into this API.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt