### PR TITLE
Fix #1482, rtems Timebase, and Console now have proper names.

### DIFF
--- a/src/os/rtems/src/os-impl-console.c
+++ b/src/os/rtems/src/os-impl-console.c
@@ -104,6 +104,8 @@ static void OS_ConsoleTask_Entry(rtems_task_argument arg)
     OS_object_token_t                  token;
     OS_impl_console_internal_record_t *local;
 
+    pthread_setname_np(pthread_self(), "OS_CONSOLE");
+
     if (OS_ObjectIdGetById(OS_LOCK_MODE_REFCOUNT, OS_OBJECT_TYPE_OS_CONSOLE, OS_ObjectIdFromInteger(arg), &token) ==
         OS_SUCCESS)
     {
@@ -172,8 +174,6 @@ int32 OS_ConsoleCreate_Impl(const OS_object_token_t *token)
                 }
                 else
                 {
-                    pthread_setname_np(r_task_id, "OS_CONSOLE");
-
                     /* will place the task in 'ready for scheduling' state */
                     status = rtems_task_start(r_task_id,                    /*rtems task id*/
                                               OS_ConsoleTask_Entry,         /* task entry point */

--- a/src/os/rtems/src/os-impl-timebase.c
+++ b/src/os/rtems/src/os-impl-timebase.c
@@ -286,6 +286,7 @@ void OS_UsecsToTicks(uint32 usecs, rtems_interval *ticks)
 static void OS_TimeBase_CallbackThreadEntry(rtems_task_argument arg)
 {
     osal_id_t id;
+    pthread_setname_np(pthread_self(), "OS_TIMEBASE"); 
     id = OS_ObjectIdFromInteger(arg);
     OS_TimeBase_CallbackThread(id);
 }
@@ -391,8 +392,6 @@ int32 OS_TimeBaseCreate_Impl(const OS_object_token_t *token)
         }
         else
         {
-            pthread_setname_np(local->handler_task, "OS_TIMEBASE");
-
             /* will place the task in 'ready for scheduling' state */
             rtems_sc = rtems_task_start(local->handler_task,             /* rtems task id */
                                         OS_TimeBase_CallbackThreadEntry, /* task entry point */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
When running rtems commands `cpuuse` and `task` the names will be displayed.
When running before they were not.

- Include explicitly what issue it addresses [e.g. Fixes #X]

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
2. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
