### PR TITLE
Adding a strstr() check

### DIFF
--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -656,6 +656,7 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
     OS_object_token_t             token;
     int32                         return_code;
     const char *                  name_ptr;
+    char *                        result;
     OS_filesys_internal_record_t *filesys;
     size_t                        SysMountPointLen;
     size_t                        VirtPathLen;
@@ -698,6 +699,15 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
     ** All valid Virtual paths must start with a '/' character
     */
     if (VirtualPath[0] != '/')
+    {
+        return OS_FS_ERR_PATH_INVALID;
+    }
+
+    /*
+    ** Preventing backing out of the virtual mount point
+    */
+    result = strstr(VirtualPath, "..");
+    if (result)
     {
         return OS_FS_ERR_PATH_INVALID;
     }

--- a/src/unit-test-coverage/shared/src/coveragetest-filesys.c
+++ b/src/unit-test-coverage/shared/src/coveragetest-filesys.c
@@ -451,6 +451,11 @@ void Test_OS_TranslatePath(void)
     actual   = OS_TranslatePath("invalid/", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
 
+    /* Invalid has '..' */
+    expected = OS_FS_ERR_PATH_INVALID;
+    actual   = OS_TranslatePath("/cf/../test", LocalBuffer);
+    UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);
+
     UT_SetDefaultReturnValue(UT_KEY(OS_ObjectIdGetBySearch), OS_ERR_NAME_NOT_FOUND);
     actual = OS_TranslatePath("/cf/test", LocalBuffer);
     UtAssert_True(actual == expected, "OS_TranslatePath() (%ld) == OS_FS_ERR_PATH_INVALID", (long)actual);

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_string.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_string.h
@@ -50,6 +50,7 @@ extern int    OCS_strncmp(const char *s1, const char *s2, size_t n);
 extern char * OCS_strncpy(char *dest, const char *src, size_t n);
 extern char * OCS_strchr(const char *s, int c);
 extern char * OCS_strrchr(const char *s, int c);
+extern char * OCS_strstr(const char *haystack, const char *needle);
 extern char * OCS_strcat(char *dest, const char *src);
 extern char * OCS_strncat(char *dest, const char *src, size_t n);
 extern char * OCS_strerror(int errnum);

--- a/src/unit-test-coverage/ut-stubs/override_inc/string.h
+++ b/src/unit-test-coverage/ut-stubs/override_inc/string.h
@@ -41,6 +41,7 @@
 #define strncpy  OCS_strncpy
 #define strchr   OCS_strchr
 #define strrchr  OCS_strrchr
+#define strstr   OCS_strstr
 #define strcat   OCS_strcat
 #define strncat  OCS_strncat
 #define strerror OCS_strerror

--- a/src/unit-test-coverage/ut-stubs/src/libc-string-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/libc-string-stubs.c
@@ -118,6 +118,25 @@ char *OCS_strrchr(const char *s, int c)
     return (char *)&s[Status - 1];
 }
 
+char *OCS_strstr(const char *haystack, const char *needle)
+{
+    int32 Status;
+
+    Status = UT_DEFAULT_IMPL(OCS_strstr);
+
+    if (Status == 0)
+    {
+        /* "nominal" response */
+        return strstr(haystack, needle);
+    }
+    if (Status < 0)
+    {
+        return (char *)0;
+    }
+
+    return (char *)&haystack[Status - 1];
+}
+
 size_t OCS_strlen(const char *s)
 {
     int32 Status;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).

**Describe the contribution**
Fixes #1485 - Adding a check using strstr() to make sure the user-inputted file paths don't contain ".." to prevent writing files outside the virtual mount point

**Testing performed**
Built and ran all tests

**Expected behavior changes**
Will block paths with ".."

**System(s) tested on**
OS: RHEL 8.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Tvisha Andharia - GSFC 582 intern