### PR TITLE
Fix #1503, Update timer interval comparison

### DIFF
--- a/.github/workflows/build-osal-documentation.yml
+++ b/.github/workflows/build-osal-documentation.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: sudo apt-get install doxygen graphviz -y
+        run: sudo apt-get update && sudo apt-get install doxygen graphviz -y
 
       - name: Checkout submodule
         uses: actions/checkout@v4

--- a/.github/workflows/standalone-build.yml
+++ b/.github/workflows/standalone-build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Coverage Analysis Tools
         if: ${{ matrix.build-type == 'Debug' }}
-        run: sudo apt-get install -y lcov xsltproc && echo "run_lcov=TRUE" >> $GITHUB_ENV
+        run: sudo apt-get update && sudo apt-get install -y lcov xsltproc && echo "run_lcov=TRUE" >> $GITHUB_ENV
 
       - name: Set up debug environment
         if: ${{ matrix.build-type == 'Debug' }}

--- a/src/unit-tests/ostimer-test/ut_ostimer_test.h
+++ b/src/unit-tests/ostimer-test/ut_ostimer_test.h
@@ -49,11 +49,29 @@
 extern const char *g_timerNames[UT_OS_TIMER_LIST_LEN];
 extern char        g_longTimerName[UT_OS_NAME_BUFF_SIZE];
 
-extern uint32    g_cbLoopCntMax;
-extern uint32    g_toleranceVal;
-extern uint32    g_timerFirst;
-extern int32     g_status;
-extern osal_id_t g_timerId;
+typedef enum UT_TimerState
+{
+    UT_TimerState_INIT,
+    UT_TimerState_ACTIVE,
+    UT_TimerState_FINISHED
+} UT_TimerState_t;
+
+typedef struct UT_TimerGlobal
+{
+    UT_TimerState_t state;
+
+    uint32    callbackCount;
+    uint32    callbackMax;
+    osal_id_t timerId;
+    int32     status;
+    OS_time_t startTime;
+    OS_time_t finishTime;
+    int32     minDiff;
+    int32     maxDiff;
+
+} UT_TimerGlobal_t;
+
+volatile extern UT_TimerGlobal_t g_timerGlobal;
 
 extern int32 TimerCreateRc;
 extern int32 TimerDeleteRc;

--- a/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
@@ -431,7 +431,7 @@ void       UT_os_timerset_test(void)
          * is going to vary per system, it may give you the minimum interval, or it may give
          * you a very jittery result, or in some cases it could even possibly work.
          */
-        startTime    = 1000;
+        startTime    = g_clkAccuracy*5;
         intervalTime = 5;
 
         UtPrintf("\nOS_TimerSet() - #3 Interval-too-short (clk_accuracy=%d)\n", (int)g_clkAccuracy);
@@ -467,7 +467,7 @@ void       UT_os_timerset_test(void)
         g_timerGlobal.callbackMax = 10;
         g_timerGlobal.state       = UT_TimerState_INIT;
 
-        startTime    = 1000;
+        startTime    = g_clkAccuracy*5;
         intervalTime = 500000;
 
         UtPrintf("\nOS_TimerSet() - #4 Nominal condition (clk_accuracy=%d)\n", (int)g_clkAccuracy);

--- a/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
+++ b/src/unit-tests/ostimer-test/ut_ostimer_timerio_test.c
@@ -168,7 +168,7 @@ void UT_os_reconftimercallback(osal_id_t timerId, void *arg)
 **   6) Expect the returned value to be
 **        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
-void UT_os_timercreate_test()
+void UT_os_timercreate_test(void)
 {
     int32 i = 0, j = 0;
     char  tmpStr[UT_OS_NAME_BUFF_SIZE];
@@ -251,7 +251,7 @@ void UT_os_timercreate_test()
 ** Test case to confirm that attempts to (re-)configure a timer from the context
 ** of a callback function should fail with OS_ERR_INCORRECT_OBJ_STATE
 **--------------------------------------------------------------------------------*/
-void UT_os_timerreconf_test()
+void UT_os_timerreconf_test(void)
 {
     UT_reconf_status_t reconf;
 
@@ -323,7 +323,7 @@ void UT_os_timerreconf_test()
 **   8) Expect the returned value to be
 **        (a) OS_SUCCESS
 **--------------------------------------------------------------------------------*/
-void UT_os_timerdelete_test()
+void UT_os_timerdelete_test(void)
 {
     /*-----------------------------------------------------*/
     /* #1 Invalid-id-arg */
@@ -399,9 +399,11 @@ void UT_os_timerdelete_test()
 **      is within +/- 5% of the set interval time
 **   5) Exit test when the timer callback registered in #1 gets call 10 times
 **--------------------------------------------------------------------------------*/
-void UT_os_timerset_test()
+extern int deltatimes[25];
+void       UT_os_timerset_test(void)
 {
     uint32 startTime = 0, intervalTime = 0;
+    int64  totalTime;
 
     /*-----------------------------------------------------*/
     /* #1 Invalid-id-arg */
@@ -419,23 +421,37 @@ void UT_os_timerset_test()
     {
         UT_RETVAL(OS_TimerSet(g_timerIds[3], 0, 0), OS_TIMER_ERR_INVALID_ARGS);
 
-        g_status       = 0;
-        g_timerId      = g_timerIds[3];
-        g_timerFirst   = 1;
-        g_cbLoopCntMax = 10;
-        startTime      = 1000;
-        intervalTime   = 5;
-        g_toleranceVal = 0;
+        g_timerGlobal.timerId     = g_timerIds[3];
+        g_timerGlobal.callbackMax = 100;
+        g_timerGlobal.state       = UT_TimerState_INIT;
+
+        /*
+         * This is programming the timer with a very short interval (5 usec) which is likely
+         * to be shorter than the period of the timer tick of the kernel.  What happens here
+         * is going to vary per system, it may give you the minimum interval, or it may give
+         * you a very jittery result, or in some cases it could even possibly work.
+         */
+        startTime    = 1000;
+        intervalTime = 5;
 
         UtPrintf("\nOS_TimerSet() - #3 Interval-too-short (clk_accuracy=%d)\n", (int)g_clkAccuracy);
         if (UT_NOMINAL(OS_TimerSet(g_timerIds[3], startTime, intervalTime)))
         {
-            while (g_status == 0)
+            while (g_timerGlobal.state != UT_TimerState_FINISHED)
             {
-                OS_TaskDelay(1);
+                OS_TaskDelay(5);
             }
 
-            UtAssert_True(g_status < 0, "4# Nominal - callback status %d", (int)g_status);
+            /* it should have produced the correct number of callbacks */
+            UtAssert_UINT32_EQ(g_timerGlobal.callbackCount, g_timerGlobal.callbackMax);
+
+            UtPrintf("The following MIR test cases characterize a timer configuration with the interval set to 5us "
+                     "(too short/invalid)");
+            UtAssert_MIR("Minimum Interval = %d usec", (int)g_timerGlobal.minDiff);
+            UtAssert_MIR("Maximum Interval = %d usec", (int)g_timerGlobal.maxDiff);
+            totalTime = OS_TimeGetTotalMicroseconds(OS_TimeSubtract(g_timerGlobal.finishTime, g_timerGlobal.startTime));
+            UtAssert_MIR("Total elapsed for %u ticks = %ld usec\n", (unsigned int)g_timerGlobal.callbackMax,
+                         (long)totalTime);
         }
 
         /* Reset test environment */
@@ -447,23 +463,36 @@ void UT_os_timerset_test()
 
     if (UT_SETUP(OS_TimerCreate(&g_timerIds[4], g_timerNames[4], &g_clkAccuracy, &UT_os_timercallback)))
     {
-        g_status       = 0;
-        g_timerId      = g_timerIds[4];
-        g_timerFirst   = 1;
-        g_cbLoopCntMax = 10;
-        startTime      = 1000;
-        intervalTime   = 500000;
-        g_toleranceVal = intervalTime / 20; /* 5% */
+        g_timerGlobal.timerId     = g_timerIds[4];
+        g_timerGlobal.callbackMax = 10;
+        g_timerGlobal.state       = UT_TimerState_INIT;
+
+        startTime    = 1000;
+        intervalTime = 500000;
 
         UtPrintf("\nOS_TimerSet() - #4 Nominal condition (clk_accuracy=%d)\n", (int)g_clkAccuracy);
         if (UT_NOMINAL(OS_TimerSet(g_timerIds[4], startTime, intervalTime)))
         {
-            while (g_status == 0)
+            while (g_timerGlobal.state != UT_TimerState_FINISHED)
             {
-                OS_TaskDelay(1);
+                OS_TaskDelay(5);
             }
 
-            UtAssert_True(g_status > 0, "4# Nominal - callback status %d", (int)g_status);
+            /* it should have produced the correct number of callbacks */
+            UtAssert_UINT32_EQ(g_timerGlobal.callbackCount, g_timerGlobal.callbackMax);
+
+            /*
+             * Ensure that the intervals were all within +/- 5% of the expected interval time
+             * This should be a very low bar for a native RTOS to meet, but this also could be
+             * running on a VM in a shared/loaded server, which needs more relaxed constraints.
+             */
+            UtAssert_INT32_GT(g_timerGlobal.minDiff, intervalTime - (intervalTime / 20));
+            UtAssert_INT32_LT(g_timerGlobal.maxDiff, intervalTime + (intervalTime / 20));
+
+            /* The average interval time should be closer to the target, as this averages out the jitter error */
+            totalTime = OS_TimeGetTotalMicroseconds(OS_TimeSubtract(g_timerGlobal.finishTime, g_timerGlobal.startTime));
+            UtAssert_INT32_GT(totalTime / g_timerGlobal.callbackMax, intervalTime - (intervalTime / 200));
+            UtAssert_INT32_LT(totalTime / g_timerGlobal.callbackMax, intervalTime + (intervalTime / 200));
         }
 
         /* Reset test environment */
@@ -513,7 +542,7 @@ void UT_os_timerset_test()
 **        (a) OS_SUCCESS __and__
 **        (b) the returned timer id is the same as the timer id returned in #1
 **--------------------------------------------------------------------------------*/
-void UT_os_timergetidbyname_test()
+void UT_os_timergetidbyname_test(void)
 {
     /*-----------------------------------------------------*/
     /* #1 Null-pointer-arg */
@@ -583,7 +612,7 @@ void UT_os_timergetidbyname_test()
 **       (a) OS_SUCCESS __and__
 **       (b) timer name returned for timer properties is the same as timer name used in #1
 **--------------------------------------------------------------------------------*/
-void UT_os_timergetinfo_test()
+void UT_os_timergetinfo_test(void)
 {
     OS_timer_prop_t timerProps;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

- Fixes #1503  The timer test logic was relying on undefined/non-guaranteed behavior.
- Also updated the start time used for timers to improve accuracy and make test pass on slower/less accurate systems.
- Updated workflow to do an apt update before the apt install

**Testing performed**
Steps taken to test the contribution:
1. Build and run tests

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - Test now passes on RTEMS / LEON3

**System(s) tested on**
 - RTEMS 5 / LEON3

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F Martinez Pedraza / GSFC 582
