### PR TITLE
Fix nasa/cFS#839, Update Workflows to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-osal-documentation.yml
+++ b/.github/workflows/build-osal-documentation.yml
@@ -24,7 +24,7 @@ jobs:
     #Continue if check-for-duplicates found no duplicates. Always runs for pull-requests.
     needs: check-for-duplicates
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/standalone-build.yml
+++ b/.github/workflows/standalone-build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         build-type: [Debug, Release]
-        base-os: [ubuntu-22.04, ubuntu-20.04]
+        base-os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.base-os }}
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes nasa/cFS#839

**Testing performed**
GitHub Actions. For example, https://github.com/arielswalker/cFS/actions/runs/14499022671.

**Expected behavior changes**
Workflows will not longer throw error `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101`

**System(s) tested on**
GitHub Actions

**Additional Context**

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
