### PR TITLE
Fix nasa#1484, corrected UT_SetHandlerFunction() documentation.

### DIFF
--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -317,12 +317,14 @@ void UT_SetHookFunction(UT_EntryKey_t FuncKey, UT_HookFunc_t HookFunc, void *Use
  *
  * This allows the user to completely replace the handler for a given function.
  *
+ * If both a handler and a hook function are set, the hook is called first, then the handler.
+ *
  * The handler assumes all responsibility for the final behavior of the stub,
  * including translating return values, and any outputs/side effects the stub
  * function should have.  The default handler for the stub is NOT used.
  *
  * \param FuncKey  The stub function to add the hook to.
- * \param HandlerFunc User defined hook function.  Set NULL to delete/clear an entry.
+ * \param HandlerFunc User defined handler function.  Set NULL to delete/clear an entry.
  * \param UserObj  Arbitrary user data object to pass to the hook function
  */
 void UT_SetHandlerFunction(UT_EntryKey_t FuncKey, UT_HandlerFunc_t HandlerFunc, void *UserObj);


### PR DESCRIPTION
**Describe the contribution**
fix #1484 - Fixed UT_SetHandlerFunction() incorrectly describe the parameters as hook instead of handler. Additionally clarified hook and handler call order.

**Testing performed**
None

**Expected behavior changes**
None
**System(s) tested on**
None

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Abdullah Al Sharji - Personal
