### PR TITLE
Re-format code using clang-format.

### DIFF
--- a/src/bsp/shared/inc/bsp-impl.h
+++ b/src/bsp/shared/inc/bsp-impl.h
@@ -64,7 +64,7 @@
 #define OS_BSP_CONSOLEMODE_BLUE      0x4 /**< Blue text, if terminal supports color */
 #define OS_BSP_CONSOLEMODE_HIGHLIGHT 0x8 /**< Highlighted/Emphasis text, if terminal supports it */
 
-#define OS_BSP_CONSOLEMODE_TO_ANSICOLOR(x) ((x)&0x07)
+#define OS_BSP_CONSOLEMODE_TO_ANSICOLOR(x) ((x) & 0x07)
 
 /*
  * Macro for BSP debug messages, similar to OS_DEBUG in OSAL code.
@@ -93,7 +93,7 @@
 typedef struct
 {
     uint32            ArgC;          /* number of boot/startup parameters in ArgV */
-    char **           ArgV;          /* strings for boot/startup parameters */
+    char            **ArgV;          /* strings for boot/startup parameters */
     int32             AppStatus;     /* value which can be returned to the OS (0=nominal) */
     osal_blockcount_t MaxQueueDepth; /* Queue depth limit supported by BSP (0=no limit) */
 

--- a/src/os/inc/common_types.h
+++ b/src/os/inc/common_types.h
@@ -30,8 +30,7 @@
 #define COMMON_TYPES_H
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 /*
@@ -71,34 +70,34 @@ extern "C"
 #include <stddef.h>
 #include <stdbool.h>
 
-    /*
+/*
      * NOTE - NOT DEFINING STRUCT_LOW_BIT_FIRST or STRUCT_HIGH_BIT_FIRST
      * We should not make assumptions about the bit order here
      */
 
-    typedef int8_t    int8;
-    typedef int16_t   int16;
-    typedef int32_t   int32;
-    typedef int64_t   int64;
-    typedef uint8_t   uint8;
-    typedef uint16_t  uint16;
-    typedef uint32_t  uint32;
-    typedef uint64_t  uint64;
-    typedef intptr_t  intptr;
-    typedef uintptr_t cpuaddr;
-    typedef size_t    cpusize;
-    typedef ptrdiff_t cpudiff;
+typedef int8_t    int8;
+typedef int16_t   int16;
+typedef int32_t   int32;
+typedef int64_t   int64;
+typedef uint8_t   uint8;
+typedef uint16_t  uint16;
+typedef uint32_t  uint32;
+typedef uint64_t  uint64;
+typedef intptr_t  intptr;
+typedef uintptr_t cpuaddr;
+typedef size_t    cpusize;
+typedef ptrdiff_t cpudiff;
 
 #ifdef OSAL_OMIT_DEPRECATED
-    /**
+/**
      * A type to be used for OSAL resource identifiers.
      * This is a type-safe ID, and cannot be implicitly converted to an integer.
      * Use the provided inline functions in osapi-idmap.h to interpret ID values.
      */
-    typedef struct
-    {
-        uint32_t v;
-    } osal_id_t;
+typedef struct
+{
+    uint32_t v;
+} osal_id_t;
 #else
 
 /**
@@ -108,14 +107,14 @@ extern "C"
 typedef uint32 osal_id_t;
 #endif
 
-    /**
+/**
      * A type used to represent a number of blocks or buffers
      *
      * This is used with file system and queue implementations.
      */
-    typedef size_t osal_blockcount_t;
+typedef size_t osal_blockcount_t;
 
-    /**
+/**
      * A type used to represent an index into a table structure
      *
      * This is used when referring directly to a table index as
@@ -123,37 +122,37 @@ typedef uint32 osal_id_t;
      * internal use, but is also output from public APIs such as
      * OS_ObjectIdToArrayIndex().
      */
-    typedef uint32 osal_index_t;
+typedef uint32 osal_index_t;
 
-    /**
+/**
      * A type used to represent the runtime type or category of an OSAL object
      */
-    typedef uint32 osal_objtype_t;
+typedef uint32 osal_objtype_t;
 
-    /**
+/**
      * The preferred type to represent OSAL status codes defined in osapi-error.h
      */
-    typedef int32 osal_status_t;
+typedef int32 osal_status_t;
 
-    /**
+/**
      * @brief General purpose OSAL callback function
      *
      * This may be used by multiple APIS
      */
-    typedef void (*OS_ArgCallback_t)(osal_id_t object_id, void *arg);
+typedef void (*OS_ArgCallback_t)(osal_id_t object_id, void *arg);
 
-    /*
+/*
     ** Check Sizes
     */
-    CompileTimeAssert(sizeof(uint8) == 1, TypeUint8WrongSize);
-    CompileTimeAssert(sizeof(uint16) == 2, TypeUint16WrongSize);
-    CompileTimeAssert(sizeof(uint32) == 4, TypeUint32WrongSize);
-    CompileTimeAssert(sizeof(uint64) == 8, TypeUint64WrongSize);
-    CompileTimeAssert(sizeof(int8) == 1, Typeint8WrongSize);
-    CompileTimeAssert(sizeof(int16) == 2, Typeint16WrongSize);
-    CompileTimeAssert(sizeof(int32) == 4, Typeint32WrongSize);
-    CompileTimeAssert(sizeof(int64) == 8, Typeint64WrongSize);
-    CompileTimeAssert(sizeof(cpuaddr) >= sizeof(void *), TypePtrWrongSize);
+CompileTimeAssert(sizeof(uint8) == 1, TypeUint8WrongSize);
+CompileTimeAssert(sizeof(uint16) == 2, TypeUint16WrongSize);
+CompileTimeAssert(sizeof(uint32) == 4, TypeUint32WrongSize);
+CompileTimeAssert(sizeof(uint64) == 8, TypeUint64WrongSize);
+CompileTimeAssert(sizeof(int8) == 1, Typeint8WrongSize);
+CompileTimeAssert(sizeof(int16) == 2, Typeint16WrongSize);
+CompileTimeAssert(sizeof(int32) == 4, Typeint32WrongSize);
+CompileTimeAssert(sizeof(int64) == 8, Typeint64WrongSize);
+CompileTimeAssert(sizeof(cpuaddr) >= sizeof(void *), TypePtrWrongSize);
 
 #ifdef __cplusplus
 }

--- a/src/os/inc/osapi-clock.h
+++ b/src/os/inc/osapi-clock.h
@@ -53,14 +53,14 @@ typedef struct
  * This is the largest positive (future) time that is representable
  * in an OS_time_t value.
  */
-#define OS_TIME_MAX ((OS_time_t) {INT64_MAX})
+#define OS_TIME_MAX ((OS_time_t) { INT64_MAX })
 
 /**
  * @brief The zero value for OS_time_t
  *
  * This is a reasonable initializer/placeholder value for an OS_time_t
  */
-#define OS_TIME_ZERO ((OS_time_t) {0})
+#define OS_TIME_ZERO ((OS_time_t) { 0 })
 
 /**
  * @brief The minimum value for OS_time_t
@@ -68,7 +68,7 @@ typedef struct
  * This is the largest negative (past) time that is representable
  * in an OS_time_t value.
  */
-#define OS_TIME_MIN ((OS_time_t) {INT64_MIN})
+#define OS_TIME_MIN ((OS_time_t) { INT64_MIN })
 
 /**
  * @brief Multipliers/divisors to convert ticks into standardized units
@@ -209,7 +209,7 @@ static inline int64 OS_TimeGetTotalSeconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalSeconds(int64 tm)
 {
-    OS_time_t ostm = {tm * OS_TIME_TICKS_PER_SECOND};
+    OS_time_t ostm = { tm * OS_TIME_TICKS_PER_SECOND };
     return ostm;
 }
 
@@ -243,7 +243,7 @@ static inline int64 OS_TimeGetTotalMilliseconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalMilliseconds(int64 tm)
 {
-    OS_time_t ostm = {tm * OS_TIME_TICKS_PER_MSEC};
+    OS_time_t ostm = { tm * OS_TIME_TICKS_PER_MSEC };
     return ostm;
 }
 
@@ -278,7 +278,7 @@ static inline int64 OS_TimeGetTotalMicroseconds(OS_time_t tm)
 static inline OS_time_t OS_TimeFromTotalMicroseconds(int64 tm)
 {
     /* SAD: Overflow is not considered a concern because tm would need to be over 29,227 years in microseconds */
-    OS_time_t ostm = {tm * OS_TIME_TICKS_PER_USEC};
+    OS_time_t ostm = { tm * OS_TIME_TICKS_PER_USEC };
     return ostm;
 }
 
@@ -316,7 +316,7 @@ static inline int64 OS_TimeGetTotalNanoseconds(OS_time_t tm)
  */
 static inline OS_time_t OS_TimeFromTotalNanoseconds(int64 tm)
 {
-    OS_time_t ostm = {tm / OS_TIME_TICK_RESOLUTION_NS};
+    OS_time_t ostm = { tm / OS_TIME_TICK_RESOLUTION_NS };
     return ostm;
 }
 
@@ -441,7 +441,7 @@ static inline uint32 OS_TimeGetNanosecondsPart(OS_time_t tm)
 static inline OS_time_t OS_TimeAssembleFromNanoseconds(int64 seconds, uint32 nanoseconds)
 {
     OS_time_t result;
-    result.ticks = seconds * OS_TIME_TICKS_PER_SECOND;
+    result.ticks  = seconds * OS_TIME_TICKS_PER_SECOND;
     result.ticks += nanoseconds / OS_TIME_TICK_RESOLUTION_NS;
     return result;
 }
@@ -465,7 +465,7 @@ static inline OS_time_t OS_TimeAssembleFromNanoseconds(int64 seconds, uint32 nan
 static inline OS_time_t OS_TimeAssembleFromMicroseconds(int64 seconds, uint32 microseconds)
 {
     OS_time_t result;
-    result.ticks = seconds * OS_TIME_TICKS_PER_SECOND;
+    result.ticks  = seconds * OS_TIME_TICKS_PER_SECOND;
     result.ticks += microseconds * OS_TIME_TICKS_PER_USEC;
     return result;
 }
@@ -489,7 +489,7 @@ static inline OS_time_t OS_TimeAssembleFromMicroseconds(int64 seconds, uint32 mi
 static inline OS_time_t OS_TimeAssembleFromMilliseconds(int64 seconds, uint32 milliseconds)
 {
     OS_time_t result;
-    result.ticks = seconds * OS_TIME_TICKS_PER_SECOND;
+    result.ticks  = seconds * OS_TIME_TICKS_PER_SECOND;
     result.ticks += milliseconds * OS_TIME_TICKS_PER_MSEC;
     return result;
 }
@@ -512,7 +512,7 @@ static inline OS_time_t OS_TimeAssembleFromMilliseconds(int64 seconds, uint32 mi
 static inline OS_time_t OS_TimeAssembleFromSubseconds(int64 seconds, uint32 subseconds)
 {
     OS_time_t result;
-    result.ticks = seconds * OS_TIME_TICKS_PER_SECOND;
+    result.ticks  = seconds * OS_TIME_TICKS_PER_SECOND;
     /* this should not round in any way, as the 32-bit input value has higher precision */
     result.ticks += ((int64)subseconds * (OS_TIME_TICKS_PER_SECOND >> 2)) >> 30;
     return result;
@@ -529,7 +529,7 @@ static inline OS_time_t OS_TimeAssembleFromSubseconds(int64 seconds, uint32 subs
  */
 static inline OS_time_t OS_TimeAdd(OS_time_t time1, OS_time_t time2)
 {
-    OS_time_t ostm = {time1.ticks + time2.ticks};
+    OS_time_t ostm = { time1.ticks + time2.ticks };
     return ostm;
 }
 
@@ -544,7 +544,7 @@ static inline OS_time_t OS_TimeAdd(OS_time_t time1, OS_time_t time2)
  */
 static inline OS_time_t OS_TimeSubtract(OS_time_t time1, OS_time_t time2)
 {
-    OS_time_t ostm = {time1.ticks - time2.ticks};
+    OS_time_t ostm = { time1.ticks - time2.ticks };
     return ostm;
 }
 

--- a/src/os/inc/osapi-constants.h
+++ b/src/os/inc/osapi-constants.h
@@ -37,7 +37,7 @@
 /**
  * @brief Initializer for the osal_id_t type which will not match any valid value
  */
-#define OS_OBJECT_ID_UNDEFINED ((osal_id_t) {0})
+#define OS_OBJECT_ID_UNDEFINED ((osal_id_t) { 0 })
 
 /**
  * @brief Constant that may be passed to OS_ForEachObject()/OS_ForEachObjectOfType() to match any

--- a/src/os/inc/osapi-file.h
+++ b/src/os/inc/osapi-file.h
@@ -85,19 +85,19 @@ enum
 };
 
 /** @brief Access file stat mode bits */
-#define OS_FILESTAT_MODE(x) ((x).FileModeBits)
+#define OS_FILESTAT_MODE(x)  ((x).FileModeBits)
 /** @brief File stat is directory logical */
 #define OS_FILESTAT_ISDIR(x) ((x).FileModeBits & OS_FILESTAT_MODE_DIR)
 /** @brief File stat is executable logical */
-#define OS_FILESTAT_EXEC(x) ((x).FileModeBits & OS_FILESTAT_MODE_EXEC)
+#define OS_FILESTAT_EXEC(x)  ((x).FileModeBits & OS_FILESTAT_MODE_EXEC)
 /** @brief File stat is write enabled logical */
 #define OS_FILESTAT_WRITE(x) ((x).FileModeBits & OS_FILESTAT_MODE_WRITE)
 /** @brief File stat is read enabled logical */
-#define OS_FILESTAT_READ(x) ((x).FileModeBits & OS_FILESTAT_MODE_READ)
+#define OS_FILESTAT_READ(x)  ((x).FileModeBits & OS_FILESTAT_MODE_READ)
 /** @brief Access file stat size field */
-#define OS_FILESTAT_SIZE(x) ((x).FileSize)
+#define OS_FILESTAT_SIZE(x)  ((x).FileSize)
 /** @brief Access file stat time field as a whole number of seconds */
-#define OS_FILESTAT_TIME(x) (OS_TimeGetTotalSeconds((x).FileTime))
+#define OS_FILESTAT_TIME(x)  (OS_TimeGetTotalSeconds((x).FileTime))
 
 /**
  * @brief Flags that can be used with opening of a file (bitmask)

--- a/src/os/inc/osapi-idmap.h
+++ b/src/os/inc/osapi-idmap.h
@@ -102,7 +102,7 @@ static inline unsigned long OS_ObjectIdToInteger(osal_id_t object_id)
 static inline osal_id_t OS_ObjectIdFromInteger(unsigned long value)
 {
 #ifdef OSAL_OMIT_DEPRECATED
-    osal_id_t idv = {(uint32)value};
+    osal_id_t idv = { (uint32)value };
 #else
     osal_id_t idv = (osal_id_t)value;
 #endif
@@ -270,8 +270,10 @@ void OS_ForEachObject(osal_id_t creator_id, OS_ArgCallback_t callback_ptr, void 
  * @param[in]  callback_ptr Function to invoke for each matching object ID
  * @param[in]  callback_arg Opaque Argument to pass to callback function (may be NULL)
  */
-void OS_ForEachObjectOfType(osal_objtype_t objtype, osal_id_t creator_id, OS_ArgCallback_t callback_ptr,
-                            void *callback_arg);
+void OS_ForEachObjectOfType(osal_objtype_t   objtype,
+                            osal_id_t        creator_id,
+                            OS_ArgCallback_t callback_ptr,
+                            void            *callback_arg);
 
 /**@}*/
 

--- a/src/os/inc/osapi-queue.h
+++ b/src/os/inc/osapi-queue.h
@@ -64,8 +64,11 @@ typedef struct
  * @retval #OS_QUEUE_INVALID_SIZE if the queue depth exceeds the limit
  * @retval #OS_ERROR if the OS create call fails
  */
-int32 OS_QueueCreate(osal_id_t *queue_id, const char *queue_name, osal_blockcount_t queue_depth, size_t data_size,
-                     uint32 flags);
+int32 OS_QueueCreate(osal_id_t        *queue_id,
+                     const char       *queue_name,
+                     osal_blockcount_t queue_depth,
+                     size_t            data_size,
+                     uint32            flags);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/inc/osapi-sockets.h
+++ b/src/os/inc/osapi-sockets.h
@@ -97,7 +97,7 @@ typedef union
 {
     uint8  Buffer[OS_SOCKADDR_MAX_LEN]; /**< @brief Ensures length of at least OS_SOCKADDR_MAX_LEN */
     uint32 AlignU32;                    /**< @brief Ensures uint32 alignment */
-    void * AlignPtr;                    /**< @brief Ensures pointer alignment */
+    void  *AlignPtr;                    /**< @brief Ensures pointer alignment */
 } OS_SockAddrData_t;
 
 /**
@@ -497,8 +497,11 @@ int32 OS_SocketAccept(osal_id_t sock_id, osal_id_t *connsock_id, OS_SockAddr_t *
  * @retval #OS_ERR_INVALID_ID if the sock_id parameter is not valid
  * @retval #OS_ERR_INCORRECT_OBJ_TYPE if the handle is not a socket
  */
-int32 OS_SocketRecvFromAbs(osal_id_t sock_id, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr,
-                           OS_time_t abs_timeout);
+int32 OS_SocketRecvFromAbs(osal_id_t      sock_id,
+                           void          *buffer,
+                           size_t         buflen,
+                           OS_SockAddr_t *RemoteAddr,
+                           OS_time_t      abs_timeout);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/inc/osapi-task.h
+++ b/src/os/inc/osapi-task.h
@@ -43,14 +43,14 @@
  */
 typedef uint8_t osal_priority_t;
 
-#define OSAL_PRIORITY_C(X) ((osal_priority_t) {X})
+#define OSAL_PRIORITY_C(X) ((osal_priority_t) { X })
 
 /**
  * @brief Type to be used for OSAL stack pointer.
  */
 typedef void *osal_stackptr_t;
 
-#define OSAL_STACKPTR_C(X)       ((osal_stackptr_t) {X})
+#define OSAL_STACKPTR_C(X)       ((osal_stackptr_t) { X })
 #define OSAL_TASK_STACK_ALLOCATE OSAL_STACKPTR_C(NULL)
 
 /** @brief OSAL task properties */
@@ -108,8 +108,13 @@ typedef osal_task((*osal_task_entry)(void)); /**< @brief For task entry point */
  * @retval #OS_ERR_NAME_TAKEN if the name specified is already used by a task
  * @retval #OS_ERROR if an unspecified/other error occurs @covtest
  */
-int32 OS_TaskCreate(osal_id_t *task_id, const char *task_name, osal_task_entry function_pointer,
-                    osal_stackptr_t stack_pointer, size_t stack_size, osal_priority_t priority, uint32 flags);
+int32 OS_TaskCreate(osal_id_t      *task_id,
+                    const char     *task_name,
+                    osal_task_entry function_pointer,
+                    osal_stackptr_t stack_pointer,
+                    size_t          stack_size,
+                    osal_priority_t priority,
+                    uint32          flags);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/inc/osapi-timer.h
+++ b/src/os/inc/osapi-timer.h
@@ -85,7 +85,9 @@ typedef struct
  * @retval #OS_ERR_INCORRECT_OBJ_STATE if invoked from a timer context
  * @retval #OS_TIMER_ERR_INTERNAL if there was an error programming the OS timer @covtest
  */
-int32 OS_TimerCreate(osal_id_t *timer_id, const char *timer_name, uint32 *clock_accuracy,
+int32 OS_TimerCreate(osal_id_t         *timer_id,
+                     const char        *timer_name,
+                     uint32            *clock_accuracy,
                      OS_TimerCallback_t callback_ptr);
 
 /*-------------------------------------------------------------------------------------*/
@@ -130,8 +132,11 @@ int32 OS_TimerCreate(osal_id_t *timer_id, const char *timer_name, uint32 *clock_
  * @retval #OS_ERR_INCORRECT_OBJ_STATE if invoked from a timer context
  * @retval #OS_TIMER_ERR_INTERNAL if there was an error programming the OS timer @covtest
  */
-int32 OS_TimerAdd(osal_id_t *timer_id, const char *timer_name, osal_id_t timebase_id, OS_ArgCallback_t callback_ptr,
-                  void *callback_arg);
+int32 OS_TimerAdd(osal_id_t       *timer_id,
+                  const char      *timer_name,
+                  osal_id_t        timebase_id,
+                  OS_ArgCallback_t callback_ptr,
+                  void            *callback_arg);
 
 /*-------------------------------------------------------------------------------------*/
 /**

--- a/src/os/inc/osapi-version.h
+++ b/src/os/inc/osapi-version.h
@@ -34,17 +34,17 @@
 /*
  * Development Build Macro Definitions
  */
-#define OS_BUILD_NUMBER     117
-#define OS_BUILD_BASELINE   "equuleus-rc1"
-#define OS_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define OS_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
+#define OS_BUILD_NUMBER    117
+#define OS_BUILD_BASELINE  "equuleus-rc1"
+#define OS_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define OS_BUILD_CODENAME  "Equuleus"     /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
-#define OS_MAJOR_VERSION 5  /*!< @brief Major version number */
-#define OS_MINOR_VERSION 0  /*!< @brief Minor version number */
-#define OS_REVISION      0  /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define OS_MAJOR_VERSION 5 /*!< @brief Major version number */
+#define OS_MINOR_VERSION 0 /*!< @brief Minor version number */
+#define OS_REVISION      0 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
 
 /**
  * @brief Last official release.

--- a/src/os/inc/osapi.h
+++ b/src/os/inc/osapi.h
@@ -27,8 +27,7 @@
 #define OSAPI_H
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 /*
@@ -86,7 +85,7 @@ extern "C"
 #include "osapi-timebase.h"
 #include "osapi-timer.h"
 
-    /*
+/*
      ******************************************************************************
      * Items below here are internal OSAL-use definitions and are not part of the
      * OSAL API

--- a/src/os/posix/inc/os-impl-tasks.h
+++ b/src/os/posix/inc/os-impl-tasks.h
@@ -40,7 +40,11 @@ typedef struct
 /* Tables where the OS object information is stored */
 extern OS_impl_task_internal_record_t OS_impl_task_table[OS_MAX_TASKS];
 
-int32 OS_Posix_InternalTaskCreate_Impl(pthread_t *pthr, osal_priority_t priority, osal_stackptr_t stackptr,
-                                       size_t stacksz, PthreadFuncPtr_t entry, void *entry_arg);
+int32 OS_Posix_InternalTaskCreate_Impl(pthread_t       *pthr,
+                                       osal_priority_t  priority,
+                                       osal_stackptr_t  stackptr,
+                                       size_t           stacksz,
+                                       PthreadFuncPtr_t entry,
+                                       void            *entry_arg);
 
 #endif /* OS_IMPL_TASKS_H */

--- a/src/os/shared/inc/os-shared-console.h
+++ b/src/os/shared/inc/os-shared-console.h
@@ -45,7 +45,7 @@ typedef struct
 {
     char device_name[OS_MAX_API_NAME];
 
-    char *          BufBase;        /**< Start of the buffer memory */
+    char           *BufBase;        /**< Start of the buffer memory */
     size_t          BufSize;        /**< Total size of the buffer */
     volatile size_t ReadPos;        /**< Offset of next byte to read */
     volatile size_t WritePos;       /**< Offset of next byte to write */

--- a/src/os/shared/inc/os-shared-filesys.h
+++ b/src/os/shared/inc/os-shared-filesys.h
@@ -84,13 +84,13 @@ enum
 
 typedef struct
 {
-    char device_name[OS_FS_DEV_NAME_LEN]; /**< The name of the underlying block device, if applicable */
-    char volume_name[OS_FS_VOL_NAME_LEN];
-    char system_mountpt[OS_MAX_LOCAL_PATH_LEN]; /**< The name/prefix where the contents are accessible in the host
+    char  device_name[OS_FS_DEV_NAME_LEN]; /**< The name of the underlying block device, if applicable */
+    char  volume_name[OS_FS_VOL_NAME_LEN];
+    char  system_mountpt[OS_MAX_LOCAL_PATH_LEN]; /**< The name/prefix where the contents are accessible in the host
                                                    operating system */
-    char virtual_mountpt[OS_MAX_PATH_LEN]; /**< The name/prefix in the OSAL Virtual File system exposed to applications
+    char  virtual_mountpt[OS_MAX_PATH_LEN]; /**< The name/prefix in the OSAL Virtual File system exposed to applications
                                             */
-    char *            address;
+    char *address;
     size_t            blocksize;
     osal_blockcount_t numblocks;
     uint8             flags;
@@ -179,8 +179,12 @@ int32 OS_FileSysUnmountVolume_Impl(const OS_object_token_t *token);
  */
 
 bool  OS_FileSys_FindVirtMountPoint(void *ref, const OS_object_token_t *token, const OS_common_record_t *obj);
-int32 OS_FileSys_Initialize(char *address, const char *fsdevname, const char *fsvolname, size_t blocksize,
-                            osal_blockcount_t numblocks, bool should_format);
+int32 OS_FileSys_Initialize(char             *address,
+                            const char       *fsdevname,
+                            const char       *fsvolname,
+                            size_t            blocksize,
+                            osal_blockcount_t numblocks,
+                            bool              should_format);
 bool  OS_FileSysFilterFree(void *ref, const OS_object_token_t *token, const OS_common_record_t *obj);
 
 #endif /* OS_SHARED_FILESYS_H */

--- a/src/os/shared/inc/os-shared-globaldefs.h
+++ b/src/os/shared/inc/os-shared-globaldefs.h
@@ -70,7 +70,7 @@ typedef struct OS_object_token OS_object_token_t;
  */
 typedef union
 {
-    void *           opaque_arg;
+    void            *opaque_arg;
     OS_ArgCallback_t arg_callback_func;
     osal_id_t        id;
     osal_index_t     idx;

--- a/src/os/shared/inc/os-shared-idmap.h
+++ b/src/os/shared/inc/os-shared-idmap.h
@@ -29,7 +29,7 @@
 #include "osapi-idmap.h"
 #include "os-shared-globaldefs.h"
 
-#define OS_OBJECT_ID_RESERVED ((osal_id_t) {0xFFFFFFFF})
+#define OS_OBJECT_ID_RESERVED ((osal_id_t) { 0xFFFFFFFF })
 
 /*
  * This supplies a non-abstract definition of "OS_common_record_t"
@@ -131,9 +131,9 @@ typedef int32 (*OS_ObjectIdIteratorProcessFunc_t)(osal_id_t, void *);
  */
 typedef struct
 {
-    OS_common_record_t * base;
+    OS_common_record_t  *base;
     OS_ObjectMatchFunc_t match;
-    void *               arg;
+    void                *arg;
     osal_index_t         limit;
     OS_object_token_t    token;
 } OS_object_iter_t;
@@ -395,8 +395,11 @@ int32 OS_ObjectIdFindByName(osal_objtype_t idtype, const char *name, osal_id_t *
 
    Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdGetBySearch(OS_lock_mode_t lock_mode, osal_objtype_t idtype, OS_ObjectMatchFunc_t MatchFunc, void *arg,
-                             OS_object_token_t *token);
+int32 OS_ObjectIdGetBySearch(OS_lock_mode_t       lock_mode,
+                             osal_objtype_t       idtype,
+                             OS_ObjectMatchFunc_t MatchFunc,
+                             void                *arg,
+                             OS_object_token_t   *token);
 
 /*----------------------------------------------------------------
 
@@ -475,8 +478,10 @@ int32 OS_ObjectIdFinalizeDelete(int32 operation_status, OS_object_token_t *token
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_ObjectIdIteratorInit(OS_ObjectMatchFunc_t matchfunc, void *matcharg, osal_objtype_t objtype,
-                              OS_object_iter_t *iter);
+int32 OS_ObjectIdIteratorInit(OS_ObjectMatchFunc_t matchfunc,
+                              void                *matcharg,
+                              osal_objtype_t       objtype,
+                              OS_object_iter_t    *iter);
 
 /*----------------------------------------------------------------
 

--- a/src/os/shared/inc/os-shared-sockets.h
+++ b/src/os/shared/inc/os-shared-sockets.h
@@ -74,8 +74,10 @@ int32 OS_SocketListen_Impl(const OS_object_token_t *token);
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketAccept_Impl(const OS_object_token_t *sock_token, const OS_object_token_t *conn_token,
-                           OS_SockAddr_t *Addr, OS_time_t abs_timeout);
+int32 OS_SocketAccept_Impl(const OS_object_token_t *sock_token,
+                           const OS_object_token_t *conn_token,
+                           OS_SockAddr_t           *Addr,
+                           OS_time_t                abs_timeout);
 
 /*----------------------------------------------------------------
 
@@ -104,8 +106,11 @@ int32 OS_SocketShutdown_Impl(const OS_object_token_t *token, OS_SocketShutdownMo
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketRecvFrom_Impl(const OS_object_token_t *token, void *buffer, size_t buflen, OS_SockAddr_t *RemoteAddr,
-                             OS_time_t abs_timeout);
+int32 OS_SocketRecvFrom_Impl(const OS_object_token_t *token,
+                             void                    *buffer,
+                             size_t                   buflen,
+                             OS_SockAddr_t           *RemoteAddr,
+                             OS_time_t                abs_timeout);
 
 /*----------------------------------------------------------------
 
@@ -115,8 +120,10 @@ int32 OS_SocketRecvFrom_Impl(const OS_object_token_t *token, void *buffer, size_
 
     Returns: OS_SUCCESS on success, or relevant error code
  ------------------------------------------------------------------*/
-int32 OS_SocketSendTo_Impl(const OS_object_token_t *token, const void *buffer, size_t buflen,
-                           const OS_SockAddr_t *RemoteAddr);
+int32 OS_SocketSendTo_Impl(const OS_object_token_t *token,
+                           const void              *buffer,
+                           size_t                   buflen,
+                           const OS_SockAddr_t     *RemoteAddr);
 
 /*----------------------------------------------------------------
 

--- a/src/os/shared/inc/os-shared-task.h
+++ b/src/os/shared/inc/os-shared-task.h
@@ -37,7 +37,7 @@ typedef struct
     osal_priority_t priority;
     osal_task_entry entry_function_pointer;
     osal_task_entry delete_hook_pointer;
-    void *          entry_arg;
+    void           *entry_arg;
     osal_stackptr_t stack_pointer;
 } OS_task_internal_record_t;
 

--- a/src/os/shared/inc/os-shared-time.h
+++ b/src/os/shared/inc/os-shared-time.h
@@ -44,7 +44,7 @@ typedef struct
     int32             wait_time;
     int32             interval_time;
     OS_ArgCallback_t  callback_ptr;
-    void *            callback_arg;
+    void             *callback_arg;
 } OS_timecb_internal_record_t;
 
 /*

--- a/src/os/vxworks/inc/os-impl-tasks.h
+++ b/src/os/vxworks/inc/os-impl-tasks.h
@@ -46,7 +46,7 @@ typedef struct
 {
     OS_VxWorks_TCB_t tcb; /* Must be first */
     TASK_ID          vxid;
-    void *           heap_block; /* set non-null if the stack was obtained with malloc() */
+    void            *heap_block; /* set non-null if the stack was obtained with malloc() */
     size_t           heap_block_size;
 } OS_impl_task_internal_record_t;
 

--- a/src/unit-test-coverage/shared/src/os-shared-coveragetest.h
+++ b/src/unit-test-coverage/shared/src/os-shared-coveragetest.h
@@ -54,12 +54,17 @@ typedef union
     uint32    val;
 } UT_idbuf_t;
 
-#define OSAPI_TEST_OBJID(act, op, exp)                                                              \
-    {                                                                                               \
-        UT_idbuf_t idexp = {.id = exp};                                                             \
-        UT_idbuf_t idact = {.id = act};                                                             \
-        UtAssert_True(memcmp(&idexp, &idact, sizeof(osal_id_t)) op 0, "%s (%lu) %s %s (%lu)", #act, \
-                      (unsigned long)idact.val, #op, #exp, (unsigned long)idexp.val);               \
+#define OSAPI_TEST_OBJID(act, op, exp)                                \
+    {                                                                 \
+        UT_idbuf_t idexp = { .id = exp };                             \
+        UT_idbuf_t idact = { .id = act };                             \
+        UtAssert_True(memcmp(&idexp, &idact, sizeof(osal_id_t)) op 0, \
+                      "%s (%lu) %s %s (%lu)",                         \
+                      #act,                                           \
+                      (unsigned long)idact.val,                       \
+                      #op,                                            \
+                      #exp,                                           \
+                      (unsigned long)idexp.val);                      \
     }
 
 /*
@@ -67,10 +72,10 @@ typedef union
  */
 #define ADD_TEST(test) UtTest_Add((Test_##test), Osapi_Test_Setup, Osapi_Test_Teardown, #test)
 
-#define UT_OBJID_1     ((osal_id_t) {1})
-#define UT_OBJID_2     ((osal_id_t) {2})
-#define UT_OBJID_OTHER ((osal_id_t) {0x12345})
-#define UT_OBJID_MAX   ((osal_id_t) {0xFFFFFFFF})
+#define UT_OBJID_1     ((osal_id_t) { 1 })
+#define UT_OBJID_2     ((osal_id_t) { 2 })
+#define UT_OBJID_OTHER ((osal_id_t) { 0x12345 })
+#define UT_OBJID_MAX   ((osal_id_t) { 0xFFFFFFFF })
 
 #define UT_INDEX_0 OSAL_INDEX_C(0)
 #define UT_INDEX_1 OSAL_INDEX_C(1)

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_dirent.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_dirent.h
@@ -48,7 +48,7 @@ struct OCS_dirent
 /* ----------------------------------------- */
 
 extern int                OCS_closedir(OCS_DIR *dirp);
-extern OCS_DIR *          OCS_opendir(const char *name);
+extern OCS_DIR           *OCS_opendir(const char *name);
 extern struct OCS_dirent *OCS_readdir(OCS_DIR *dirp);
 extern void               OCS_rewinddir(OCS_DIR *dirp);
 

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_fcntl.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_fcntl.h
@@ -59,7 +59,7 @@
 #define OCS_S_IWUSR 0x0040
 
 #define OCS_S_IFDIR    0x0001
-#define OCS_S_ISDIR(x) (((x)&OCS_S_IFDIR) == OCS_S_IFDIR)
+#define OCS_S_ISDIR(x) (((x) & OCS_S_IFDIR) == OCS_S_IFDIR)
 
 #define OCS_O_RDONLY   0x1501
 #define OCS_O_WRONLY   0x1502

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_mqueue.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_mqueue.h
@@ -53,9 +53,15 @@ struct OCS_mq_attr
 extern int         OCS_mq_close(OCS_mqd_t mqdes);
 extern OCS_mqd_t   OCS_mq_open(const char *name, int oflag, ...);
 extern OCS_ssize_t OCS_mq_receive(OCS_mqd_t mqdes, char *msg_ptr, size_t msg_len, unsigned int *msg_prio);
-extern OCS_ssize_t OCS_mq_timedreceive(OCS_mqd_t mqdes, char *msg_ptr, size_t msg_len, unsigned int *msg_prio,
+extern OCS_ssize_t OCS_mq_timedreceive(OCS_mqd_t                  mqdes,
+                                       char                      *msg_ptr,
+                                       size_t                     msg_len,
+                                       unsigned int              *msg_prio,
                                        const struct OCS_timespec *abs_timeout);
-extern int         OCS_mq_timedsend(OCS_mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned int msg_prio,
+extern int         OCS_mq_timedsend(OCS_mqd_t                  mqdes,
+                                    const char                *msg_ptr,
+                                    size_t                     msg_len,
+                                    unsigned int               msg_prio,
                                     const struct OCS_timespec *abs_timeout);
 extern int         OCS_mq_unlink(const char *name);
 

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_pthread.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_pthread.h
@@ -89,28 +89,31 @@ typedef struct OCS_pthread_key       OCS_pthread_key_t;
 /* prototypes normally declared in pthread.h */
 /* ----------------------------------------- */
 
-extern int  OCS_pthread_attr_destroy(OCS_pthread_attr_t *attr);
-extern int  OCS_pthread_attr_getschedparam(const OCS_pthread_attr_t *attr, struct OCS_sched_param *param);
-extern int  OCS_pthread_attr_init(OCS_pthread_attr_t *attr);
-extern int  OCS_pthread_attr_setinheritsched(OCS_pthread_attr_t *attr, int inherit);
-extern int  OCS_pthread_attr_setschedparam(OCS_pthread_attr_t *attr, const struct OCS_sched_param *param);
-extern int  OCS_pthread_attr_setschedpolicy(OCS_pthread_attr_t *attr, int policy);
-extern int  OCS_pthread_attr_setstacksize(OCS_pthread_attr_t *attr, size_t stacksize);
-extern int  OCS_pthread_cancel(OCS_pthread_t th);
-extern int  OCS_pthread_cond_broadcast(OCS_pthread_cond_t *cond);
-extern int  OCS_pthread_cond_destroy(OCS_pthread_cond_t *cond);
-extern int  OCS_pthread_cond_init(OCS_pthread_cond_t *cond, const OCS_pthread_condattr_t *cond_attr);
-extern int  OCS_pthread_cond_signal(OCS_pthread_cond_t *cond);
-extern int  OCS_pthread_cond_timedwait(OCS_pthread_cond_t *cond, OCS_pthread_mutex_t *mutex,
-                                       const struct OCS_timespec *abstime);
-extern int  OCS_pthread_cond_wait(OCS_pthread_cond_t *cond, OCS_pthread_mutex_t *mutex);
-extern int  OCS_pthread_create(OCS_pthread_t *newthread, const OCS_pthread_attr_t *attr, void *(*start_routine)(void *),
-                               void *arg);
-extern int  OCS_pthread_detach(OCS_pthread_t th);
-extern int  OCS_pthread_equal(OCS_pthread_t thread1, OCS_pthread_t thread2);
-extern void OCS_pthread_exit(void *retval);
-extern int  OCS_pthread_getschedparam(OCS_pthread_t target_thread, int *policy, struct OCS_sched_param *param);
-extern void *        OCS_pthread_getspecific(OCS_pthread_key_t key);
+extern int           OCS_pthread_attr_destroy(OCS_pthread_attr_t *attr);
+extern int           OCS_pthread_attr_getschedparam(const OCS_pthread_attr_t *attr, struct OCS_sched_param *param);
+extern int           OCS_pthread_attr_init(OCS_pthread_attr_t *attr);
+extern int           OCS_pthread_attr_setinheritsched(OCS_pthread_attr_t *attr, int inherit);
+extern int           OCS_pthread_attr_setschedparam(OCS_pthread_attr_t *attr, const struct OCS_sched_param *param);
+extern int           OCS_pthread_attr_setschedpolicy(OCS_pthread_attr_t *attr, int policy);
+extern int           OCS_pthread_attr_setstacksize(OCS_pthread_attr_t *attr, size_t stacksize);
+extern int           OCS_pthread_cancel(OCS_pthread_t th);
+extern int           OCS_pthread_cond_broadcast(OCS_pthread_cond_t *cond);
+extern int           OCS_pthread_cond_destroy(OCS_pthread_cond_t *cond);
+extern int           OCS_pthread_cond_init(OCS_pthread_cond_t *cond, const OCS_pthread_condattr_t *cond_attr);
+extern int           OCS_pthread_cond_signal(OCS_pthread_cond_t *cond);
+extern int           OCS_pthread_cond_timedwait(OCS_pthread_cond_t        *cond,
+                                                OCS_pthread_mutex_t       *mutex,
+                                                const struct OCS_timespec *abstime);
+extern int           OCS_pthread_cond_wait(OCS_pthread_cond_t *cond, OCS_pthread_mutex_t *mutex);
+extern int           OCS_pthread_create(OCS_pthread_t            *newthread,
+                                        const OCS_pthread_attr_t *attr,
+                                        void *(*start_routine)(void *),
+                                        void *arg);
+extern int           OCS_pthread_detach(OCS_pthread_t th);
+extern int           OCS_pthread_equal(OCS_pthread_t thread1, OCS_pthread_t thread2);
+extern void          OCS_pthread_exit(void *retval);
+extern int           OCS_pthread_getschedparam(OCS_pthread_t target_thread, int *policy, struct OCS_sched_param *param);
+extern void         *OCS_pthread_getspecific(OCS_pthread_key_t key);
 extern int           OCS_pthread_key_create(OCS_pthread_key_t *key, void (*destr_function)(void *));
 extern int           OCS_pthread_mutexattr_destroy(OCS_pthread_mutexattr_t *attr);
 extern int           OCS_pthread_mutexattr_init(OCS_pthread_mutexattr_t *attr);

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_shellLib.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_shellLib.h
@@ -41,7 +41,14 @@
 /* prototypes normally declared in shellLib.h */
 /* ----------------------------------------- */
 
-extern OCS_STATUS OCS_shellGenericInit(const char *config, int stackSize, const char *shellName, char **pShellName,
-                                       OCS_BOOL interactive, OCS_BOOL loginAccess, int fdin, int fdout, int fderr);
+extern OCS_STATUS OCS_shellGenericInit(const char *config,
+                                       int         stackSize,
+                                       const char *shellName,
+                                       char      **pShellName,
+                                       OCS_BOOL    interactive,
+                                       OCS_BOOL    loginAccess,
+                                       int         fdin,
+                                       int         fdout,
+                                       int         fderr);
 
 #endif /* OCS_SHELLLIB_H */

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_stdio.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_stdio.h
@@ -43,7 +43,7 @@ typedef struct OCS_FILE OCS_FILE;
 /* ----------------------------------------- */
 
 extern int       OCS_fclose(OCS_FILE *stream);
-extern char *    OCS_fgets(char *s, int n, OCS_FILE *stream);
+extern char     *OCS_fgets(char *s, int n, OCS_FILE *stream);
 extern OCS_FILE *OCS_fopen(const char *filename, const char *modes);
 extern int       OCS_fputs(const char *s, OCS_FILE *stream);
 extern int       OCS_remove(const char *filename);

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_stdlib.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_stdlib.h
@@ -47,7 +47,7 @@ extern void              OCS_abort(void);
 extern void              OCS_exit(int status);
 extern unsigned long int OCS_strtoul(const char *nptr, char **endptr, int base);
 extern int               OCS_system(const char *command);
-extern void *            OCS_malloc(size_t sz);
+extern void             *OCS_malloc(size_t sz);
 extern void              OCS_free(void *ptr);
 
 #endif /* OCS_STDLIB_H */

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_string.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_string.h
@@ -40,19 +40,19 @@
 /* prototypes normally declared in string.h */
 /* ----------------------------------------- */
 
-extern void * OCS_memchr(const void *s, int c, size_t n);
-extern void * OCS_memcpy(void *dest, const void *src, size_t n);
-extern void * OCS_memset(void *s, int c, size_t n);
+extern void  *OCS_memchr(const void *s, int c, size_t n);
+extern void  *OCS_memcpy(void *dest, const void *src, size_t n);
+extern void  *OCS_memset(void *s, int c, size_t n);
 extern int    OCS_strcmp(const char *s1, const char *s2);
-extern char * OCS_strcpy(char *dest, const char *src);
+extern char  *OCS_strcpy(char *dest, const char *src);
 extern size_t OCS_strlen(const char *s);
 extern int    OCS_strncmp(const char *s1, const char *s2, size_t n);
-extern char * OCS_strncpy(char *dest, const char *src, size_t n);
-extern char * OCS_strchr(const char *s, int c);
-extern char * OCS_strrchr(const char *s, int c);
-extern char * OCS_strstr(const char *haystack, const char *needle);
-extern char * OCS_strcat(char *dest, const char *src);
-extern char * OCS_strncat(char *dest, const char *src, size_t n);
-extern char * OCS_strerror(int errnum);
+extern char  *OCS_strncpy(char *dest, const char *src, size_t n);
+extern char  *OCS_strchr(const char *s, int c);
+extern char  *OCS_strrchr(const char *s, int c);
+extern char  *OCS_strstr(const char *haystack, const char *needle);
+extern char  *OCS_strcat(char *dest, const char *src);
+extern char  *OCS_strncat(char *dest, const char *src, size_t n);
+extern char  *OCS_strerror(int errnum);
 
 #endif /* OCS_STRING_H */

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_symLib.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_symLib.h
@@ -51,7 +51,7 @@ typedef OCS_SYMBOL *OCS_SYMBOL_ID;
 typedef struct OCS_SYMBOL_DESC
 {
     unsigned int  mask;
-    char *        name;
+    char         *name;
     OCS_SYM_VALUE value;
 } OCS_SYMBOL_DESC;
 

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_sys_select.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_sys_select.h
@@ -47,7 +47,10 @@ typedef struct
 /* prototypes normally declared in sys/select.h */
 /* ----------------------------------------- */
 
-extern int OCS_select(int nfds, OCS_fd_set *readfds, OCS_fd_set *writefds, OCS_fd_set *exceptfds,
+extern int OCS_select(int                 nfds,
+                      OCS_fd_set         *readfds,
+                      OCS_fd_set         *writefds,
+                      OCS_fd_set         *exceptfds,
                       struct OCS_timeval *timeout);
 
 extern void OCS_FD_SET(int fd, OCS_fd_set *set);

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_sys_socket.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_sys_socket.h
@@ -86,10 +86,18 @@ extern int         OCS_bind(int fd, const struct OCS_sockaddr *addr, OCS_socklen
 extern int         OCS_connect(int fd, const struct OCS_sockaddr *addr, OCS_socklen_t len);
 extern int         OCS_getsockopt(int fd, int level, int optname, void *optval, OCS_socklen_t *optlen);
 extern int         OCS_listen(int fd, int n);
-extern OCS_ssize_t OCS_recvfrom(int fd, void *buf, size_t n, int flags, struct OCS_sockaddr *addr,
-                                OCS_socklen_t *addr_len);
-extern OCS_ssize_t OCS_sendto(int fd, const void *buf, size_t n, int flags, const struct OCS_sockaddr *addr,
-                              OCS_socklen_t addr_len);
+extern OCS_ssize_t OCS_recvfrom(int                  fd,
+                                void                *buf,
+                                size_t               n,
+                                int                  flags,
+                                struct OCS_sockaddr *addr,
+                                OCS_socklen_t       *addr_len);
+extern OCS_ssize_t OCS_sendto(int                        fd,
+                              const void                *buf,
+                              size_t                     n,
+                              int                        flags,
+                              const struct OCS_sockaddr *addr,
+                              OCS_socklen_t              addr_len);
 extern int         OCS_setsockopt(int fd, int level, int optname, const void *optval, OCS_socklen_t optlen);
 extern int         OCS_shutdown(int fd, int how);
 extern int         OCS_socket(int domain, int type, int protocol);

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_taskLib.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_taskLib.h
@@ -73,13 +73,39 @@ extern OCS_STATUS  OCS_taskDeleteForce(OCS_TASK_ID tid);
 extern OCS_STATUS  OCS_taskSuspend(OCS_TASK_ID tid);
 extern OCS_STATUS  OCS_taskResume(OCS_TASK_ID tid);
 extern OCS_STATUS  OCS_taskPrioritySet(OCS_TASK_ID tid, int newPriority);
-extern OCS_TASK_ID OCS_taskSpawn(char *name, int priority, int options, int stackSize, OCS_FUNCPTR entryPt, int arg1,
-                                 int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9,
-                                 int arg10);
+extern OCS_TASK_ID OCS_taskSpawn(char       *name,
+                                 int         priority,
+                                 int         options,
+                                 int         stackSize,
+                                 OCS_FUNCPTR entryPt,
+                                 int         arg1,
+                                 int         arg2,
+                                 int         arg3,
+                                 int         arg4,
+                                 int         arg5,
+                                 int         arg6,
+                                 int         arg7,
+                                 int         arg8,
+                                 int         arg9,
+                                 int         arg10);
 
-OCS_STATUS OCS_taskInit(OCS_WIND_TCB *pTcb, char *name, int priority, int options, char *pStackBase, int stackSize,
-                        OCS_FUNCPTR entryPt, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7,
-                        int arg8, int arg9, int arg10);
+OCS_STATUS OCS_taskInit(OCS_WIND_TCB *pTcb,
+                        char         *name,
+                        int           priority,
+                        int           options,
+                        char         *pStackBase,
+                        int           stackSize,
+                        OCS_FUNCPTR   entryPt,
+                        int           arg1,
+                        int           arg2,
+                        int           arg3,
+                        int           arg4,
+                        int           arg5,
+                        int           arg6,
+                        int           arg7,
+                        int           arg8,
+                        int           arg9,
+                        int           arg10);
 
 OCS_WIND_TCB *OCS_taskTcb(OCS_TASK_ID tid);
 

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_time.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_time.h
@@ -72,14 +72,18 @@ typedef void (*OCS_TIMER_CONNECT_FUNC)(OCS_timer_t, int arg);
 
 extern int OCS_clock_getres(OCS_clockid_t clock_id, struct OCS_timespec *res);
 extern int OCS_clock_gettime(OCS_clockid_t clock_id, struct OCS_timespec *tp);
-extern int OCS_clock_nanosleep(OCS_clockid_t clock_id, int flags, const struct OCS_timespec *req,
-                               struct OCS_timespec *rem);
+extern int OCS_clock_nanosleep(OCS_clockid_t              clock_id,
+                               int                        flags,
+                               const struct OCS_timespec *req,
+                               struct OCS_timespec       *rem);
 extern int OCS_clock_settime(OCS_clockid_t clock_id, const struct OCS_timespec *tp);
 extern int OCS_timer_create(OCS_clockid_t clock_id, struct OCS_sigevent *evp, OCS_timer_t *timerid);
 extern int OCS_timer_delete(OCS_timer_t timerid);
 extern int OCS_timer_gettime(OCS_timer_t timerid, struct OCS_itimerspec *value);
-extern int OCS_timer_settime(OCS_timer_t timerid, int flags, const struct OCS_itimerspec *value,
-                             struct OCS_itimerspec *ovalue);
+extern int OCS_timer_settime(OCS_timer_t                  timerid,
+                             int                          flags,
+                             const struct OCS_itimerspec *value,
+                             struct OCS_itimerspec       *ovalue);
 
 extern int OCS_timer_connect(OCS_timer_t timerid, OCS_TIMER_CONNECT_FUNC func, int arg);
 

--- a/src/unit-test-coverage/vxworks/src/os-vxworks-coveragetest.h
+++ b/src/unit-test-coverage/vxworks/src/os-vxworks-coveragetest.h
@@ -45,21 +45,9 @@
 #define UT_INDEX_1 OSAL_INDEX_C(1)
 #define UT_INDEX_2 OSAL_INDEX_C(2)
 
-#define UT_TOKEN_0                                    \
-    (OS_object_token_t)                               \
-    {                                                 \
-        .obj_id = (osal_id_t) {0x10000}, .obj_idx = 0 \
-    }
-#define UT_TOKEN_1                                    \
-    (OS_object_token_t)                               \
-    {                                                 \
-        .obj_id = (osal_id_t) {0x10001}, .obj_idx = 1 \
-    }
-#define UT_TOKEN_2                                    \
-    (OS_object_token_t)                               \
-    {                                                 \
-        .obj_id = (osal_id_t) {0x10002}, .obj_idx = 2 \
-    }
+#define UT_TOKEN_0 (OS_object_token_t) { .obj_id = (osal_id_t) { 0x10000 }, .obj_idx = 0 }
+#define UT_TOKEN_1 (OS_object_token_t) { .obj_id = (osal_id_t) { 0x10001 }, .obj_idx = 1 }
+#define UT_TOKEN_2 (OS_object_token_t) { .obj_id = (osal_id_t) { 0x10002 }, .obj_idx = 2 }
 
 /* Osapi_Test_Setup
  *

--- a/src/unit-tests/inc/ut_os_support.h
+++ b/src/unit-tests/inc/ut_os_support.h
@@ -59,8 +59,14 @@
  */
 #define UT_OS_IO_BUFF_SIZE 128
 
-static inline bool UtOsalRetVal(int32 Fn, int32 Exp, bool NotImplAllowed, UtAssert_CaseType_t casetype,
-                                const char *File, uint32 Line, const char *FnTxt, const char *ExpTxt)
+static inline bool UtOsalRetVal(int32               Fn,
+                                int32               Exp,
+                                bool                NotImplAllowed,
+                                UtAssert_CaseType_t casetype,
+                                const char         *File,
+                                uint32              Line,
+                                const char         *FnTxt,
+                                const char         *ExpTxt)
 {
     /* If "not implemented" is acceptable, override the casetype to be N/A */
     if (NotImplAllowed && (Fn == OS_ERR_NOT_IMPLEMENTED || Fn == OS_ERR_OPERATION_NOT_SUPPORTED))
@@ -71,8 +77,11 @@ static inline bool UtOsalRetVal(int32 Fn, int32 Exp, bool NotImplAllowed, UtAsse
     return UtAssertEx(Fn == Exp, casetype, File, Line, "%s (%d) == %s (%d)", FnTxt, (int)Fn, ExpTxt, (int)Exp);
 }
 
-static inline bool UtOsalNotSuccess(int32 Fn, UtAssert_CaseType_t casetype, const char *File, uint32 Line,
-                                    const char *FnTxt)
+static inline bool UtOsalNotSuccess(int32               Fn,
+                                    UtAssert_CaseType_t casetype,
+                                    const char         *File,
+                                    uint32              Line,
+                                    const char         *FnTxt)
 {
     /* Check result is negative to support APIs that return nonzero on success (e.g. read/write) */
     return UtAssertEx(Fn < 0, casetype, File, Line, "%s (%d) not successful", FnTxt, (int)Fn);
@@ -139,7 +148,7 @@ static inline bool UtOsalImplemented(int32 Fn, const char *File, uint32 Line)
  *
  * This is used to test for proper rejection of bad ID values.
  */
-#define UT_OBJID_INCORRECT ((osal_id_t) {0xDEADBEEF})
+#define UT_OBJID_INCORRECT ((osal_id_t) { 0xDEADBEEF })
 
 /*--------------------------------------------------------------------------------*
 ** Data types

--- a/src/ut-stubs/utstub-helpers.h
+++ b/src/ut-stubs/utstub-helpers.h
@@ -50,7 +50,7 @@
 /*
  * A constant to use in stubs where no other value is applicable
  */
-#define UT_STUB_FAKE_OBJECT_ID ((osal_id_t) {0xDEADBEEFU})
+#define UT_STUB_FAKE_OBJECT_ID ((osal_id_t) { 0xDEADBEEFU })
 
 /*
  * Size of the bitmask for the OSAL fake object ID validity table

--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -266,10 +266,17 @@ typedef struct
  * \par Assumptions, External Events, and Notes:
  *        None
  */
-#define UtAssert_INTVAL(type, actual, op, ref, radix)                                                                \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (UT_IntCheck_t)(type)(actual), UtAssert_Compare_##op, \
-                                   (UT_IntCheck_t)(type)(ref), __FILE__, __LINE__, UtAssert_Radix_##radix, #type,    \
-                                   #actual, #ref)
+#define UtAssert_INTVAL(type, actual, op, ref, radix)             \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)),    \
+                                   (UT_IntCheck_t)(type)(actual), \
+                                   UtAssert_Compare_##op,         \
+                                   (UT_IntCheck_t)(type)(ref),    \
+                                   __FILE__,                      \
+                                   __LINE__,                      \
+                                   UtAssert_Radix_##radix,        \
+                                   #type,                         \
+                                   #actual,                       \
+                                   #ref)
 
 /**
  * \brief Asserts the expression/function evaluates as logically true
@@ -282,9 +289,16 @@ typedef struct
  * \par Assumptions, External Events, and Notes:
  *        None
  */
-#define UtAssert_BOOL_TRUE(expr)                                                                               \
-    UtAssert_GenericUnsignedCompare((bool)(expr), UtAssert_Compare_EQ, true, UtAssert_Radix_DECIMAL, __FILE__, \
-                                    __LINE__, "", #expr, "true")
+#define UtAssert_BOOL_TRUE(expr)                            \
+    UtAssert_GenericUnsignedCompare((bool)(expr),           \
+                                    UtAssert_Compare_EQ,    \
+                                    true,                   \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #expr,                  \
+                                    "true")
 
 /**
  * \brief Asserts the expression/function evaluates as logically false
@@ -298,9 +312,16 @@ typedef struct
  *        None
  *
  */
-#define UtAssert_BOOL_FALSE(expr)                                                                               \
-    UtAssert_GenericUnsignedCompare((bool)(expr), UtAssert_Compare_EQ, false, UtAssert_Radix_DECIMAL, __FILE__, \
-                                    __LINE__, "", #expr, "false")
+#define UtAssert_BOOL_FALSE(expr)                           \
+    UtAssert_GenericUnsignedCompare((bool)(expr),           \
+                                    UtAssert_Compare_EQ,    \
+                                    false,                  \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #expr,                  \
+                                    "false")
 
 /**
  * \brief Compare two values for equality with an auto-generated description message
@@ -312,9 +333,17 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_EQ(type, actual, ref)                                                                           \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (type)(actual), UtAssert_Compare_EQ, (type)(ref), \
-                                   __FILE__, __LINE__, UtAssert_Radix_DECIMAL, #type, #actual, #ref)
+#define UtAssert_EQ(type, actual, ref)                         \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), \
+                                   (type)(actual),             \
+                                   UtAssert_Compare_EQ,        \
+                                   (type)(ref),                \
+                                   __FILE__,                   \
+                                   __LINE__,                   \
+                                   UtAssert_Radix_DECIMAL,     \
+                                   #type,                      \
+                                   #actual,                    \
+                                   #ref)
 
 /**
  * \brief Compare two values for inequality with an auto-generated description message
@@ -326,9 +355,17 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_NEQ(type, actual, ref)                                                                           \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (type)(actual), UtAssert_Compare_NEQ, (type)(ref), \
-                                   __FILE__, __LINE__, UtAssert_Radix_DECIMAL, #type, #actual, #ref)
+#define UtAssert_NEQ(type, actual, ref)                        \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), \
+                                   (type)(actual),             \
+                                   UtAssert_Compare_NEQ,       \
+                                   (type)(ref),                \
+                                   __FILE__,                   \
+                                   __LINE__,                   \
+                                   UtAssert_Radix_DECIMAL,     \
+                                   #type,                      \
+                                   #actual,                    \
+                                   #ref)
 
 /**
  * \brief Asserts the minimum value of a given function or expression
@@ -340,9 +377,17 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_GTEQ(type, actual, ref)                                                                           \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (type)(actual), UtAssert_Compare_GTEQ, (type)(ref), \
-                                   __FILE__, __LINE__, UtAssert_Radix_DECIMAL, #type, #actual, #ref)
+#define UtAssert_GTEQ(type, actual, ref)                       \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), \
+                                   (type)(actual),             \
+                                   UtAssert_Compare_GTEQ,      \
+                                   (type)(ref),                \
+                                   __FILE__,                   \
+                                   __LINE__,                   \
+                                   UtAssert_Radix_DECIMAL,     \
+                                   #type,                      \
+                                   #actual,                    \
+                                   #ref)
 
 /**
  * \brief Asserts the maximum value of a given function or expression
@@ -354,9 +399,17 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_LTEQ(type, actual, ref)                                                                           \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (type)(actual), UtAssert_Compare_LTEQ, (type)(ref), \
-                                   __FILE__, __LINE__, UtAssert_Radix_DECIMAL, #type, #actual, #ref)
+#define UtAssert_LTEQ(type, actual, ref)                       \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), \
+                                   (type)(actual),             \
+                                   UtAssert_Compare_LTEQ,      \
+                                   (type)(ref),                \
+                                   __FILE__,                   \
+                                   __LINE__,                   \
+                                   UtAssert_Radix_DECIMAL,     \
+                                   #type,                      \
+                                   #actual,                    \
+                                   #ref)
 
 /**
  * \brief Asserts the value of a given function or expression is less than the reference value
@@ -368,9 +421,17 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_LT(type, actual, ref)                                                                           \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (type)(actual), UtAssert_Compare_LT, (type)(ref), \
-                                   __FILE__, __LINE__, UtAssert_Radix_DECIMAL, #type, #actual, #ref)
+#define UtAssert_LT(type, actual, ref)                         \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), \
+                                   (type)(actual),             \
+                                   UtAssert_Compare_LT,        \
+                                   (type)(ref),                \
+                                   __FILE__,                   \
+                                   __LINE__,                   \
+                                   UtAssert_Radix_DECIMAL,     \
+                                   #type,                      \
+                                   #actual,                    \
+                                   #ref)
 
 /**
  * \brief Asserts the value of a given function or expression is greater than the reference value
@@ -382,9 +443,17 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_GT(type, actual, ref)                                                                           \
-    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), (type)(actual), UtAssert_Compare_GT, (type)(ref), \
-                                   __FILE__, __LINE__, UtAssert_Radix_DECIMAL, #type, #actual, #ref)
+#define UtAssert_GT(type, actual, ref)                         \
+    UtAssert_GenericIntegerCompare(((type)(-1)) > ((type)(0)), \
+                                   (type)(actual),             \
+                                   UtAssert_Compare_GT,        \
+                                   (type)(ref),                \
+                                   __FILE__,                   \
+                                   __LINE__,                   \
+                                   UtAssert_Radix_DECIMAL,     \
+                                   #type,                      \
+                                   #actual,                    \
+                                   #ref)
 
 /**
  * \brief Compare two values for equality with an auto-generated description message
@@ -396,9 +465,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_INT32_EQ(actual, ref)                                                                        \
-    UtAssert_GenericSignedCompare((int32)(actual), UtAssert_Compare_EQ, (int32)(ref), UtAssert_Radix_DECIMAL, \
-                                  __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_INT32_EQ(actual, ref)                    \
+    UtAssert_GenericSignedCompare((int32)(actual),        \
+                                  UtAssert_Compare_EQ,    \
+                                  (int32)(ref),           \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  #ref)
 
 /**
  * \brief Compare two values for inequality with an auto-generated description message
@@ -410,9 +486,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_INT32_NEQ(actual, ref)                                                                        \
-    UtAssert_GenericSignedCompare((int32)(actual), UtAssert_Compare_NEQ, (int32)(ref), UtAssert_Radix_DECIMAL, \
-                                  __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_INT32_NEQ(actual, ref)                   \
+    UtAssert_GenericSignedCompare((int32)(actual),        \
+                                  UtAssert_Compare_NEQ,   \
+                                  (int32)(ref),           \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  #ref)
 
 /**
  * \brief Asserts the minimum value of a given function or expression
@@ -424,9 +507,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_INT32_GTEQ(actual, ref)                                                                        \
-    UtAssert_GenericSignedCompare((int32)(actual), UtAssert_Compare_GTEQ, (int32)(ref), UtAssert_Radix_DECIMAL, \
-                                  __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_INT32_GTEQ(actual, ref)                  \
+    UtAssert_GenericSignedCompare((int32)(actual),        \
+                                  UtAssert_Compare_GTEQ,  \
+                                  (int32)(ref),           \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  #ref)
 
 /**
  * \brief Asserts the maximum value of a given function or expression
@@ -438,9 +528,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_INT32_LTEQ(actual, ref)                                                                        \
-    UtAssert_GenericSignedCompare((int32)(actual), UtAssert_Compare_LTEQ, (int32)(ref), UtAssert_Radix_DECIMAL, \
-                                  __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_INT32_LTEQ(actual, ref)                  \
+    UtAssert_GenericSignedCompare((int32)(actual),        \
+                                  UtAssert_Compare_LTEQ,  \
+                                  (int32)(ref),           \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  #ref)
 
 /**
  * \brief Asserts the value of a given function or expression is less than the reference value
@@ -452,9 +549,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_INT32_LT(actual, ref)                                                                        \
-    UtAssert_GenericSignedCompare((int32)(actual), UtAssert_Compare_LT, (int32)(ref), UtAssert_Radix_DECIMAL, \
-                                  __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_INT32_LT(actual, ref)                    \
+    UtAssert_GenericSignedCompare((int32)(actual),        \
+                                  UtAssert_Compare_LT,    \
+                                  (int32)(ref),           \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  #ref)
 
 /**
  * \brief Asserts the value of a given function or expression is greater than the reference value
@@ -466,9 +570,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_INT32_GT(actual, ref)                                                                        \
-    UtAssert_GenericSignedCompare((int32)(actual), UtAssert_Compare_GT, (int32)(ref), UtAssert_Radix_DECIMAL, \
-                                  __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_INT32_GT(actual, ref)                    \
+    UtAssert_GenericSignedCompare((int32)(actual),        \
+                                  UtAssert_Compare_GT,    \
+                                  (int32)(ref),           \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  #ref)
 
 /**
  * \brief Compare two values for equality with an auto-generated description message
@@ -480,9 +591,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT32_EQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint32)(actual), UtAssert_Compare_EQ, (uint32)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_UINT32_EQ(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint32)(actual),       \
+                                    UtAssert_Compare_EQ,    \
+                                    (uint32)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Compare two values for inequality with an auto-generated description message
@@ -494,9 +612,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT32_NEQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint32)(actual), UtAssert_Compare_NEQ, (uint32)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_UINT32_NEQ(actual, ref)                    \
+    UtAssert_GenericUnsignedCompare((uint32)(actual),       \
+                                    UtAssert_Compare_NEQ,   \
+                                    (uint32)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the minimum value of a given function or expression
@@ -507,9 +632,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT32_GTEQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint32)(actual), UtAssert_Compare_GTEQ, (uint32)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_UINT32_GTEQ(actual, ref)                   \
+    UtAssert_GenericUnsignedCompare((uint32)(actual),       \
+                                    UtAssert_Compare_GTEQ,  \
+                                    (uint32)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the maximum value of a given function or expression
@@ -520,9 +652,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT32_LTEQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint32)(actual), UtAssert_Compare_LTEQ, (uint32)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_UINT32_LTEQ(actual, ref)                   \
+    UtAssert_GenericUnsignedCompare((uint32)(actual),       \
+                                    UtAssert_Compare_LTEQ,  \
+                                    (uint32)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the value of a given function or expression is less than the reference value
@@ -533,9 +672,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT32_LT(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint32)(actual), UtAssert_Compare_LT, (uint32)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_UINT32_LT(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint32)(actual),       \
+                                    UtAssert_Compare_LT,    \
+                                    (uint32)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the value of a given function or expression is greater than the reference value
@@ -546,9 +692,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT32_GT(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint32)(actual), UtAssert_Compare_GT, (uint32)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "", #actual, #ref)
+#define UtAssert_UINT32_GT(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint32)(actual),       \
+                                    UtAssert_Compare_GT,    \
+                                    (uint32)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "",                     \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Compare two 16-bit values for equality with an auto-generated description message
@@ -560,9 +713,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT16_EQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint16)(actual), UtAssert_Compare_EQ, (uint16)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint16", #actual, #ref)
+#define UtAssert_UINT16_EQ(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint16)(actual),       \
+                                    UtAssert_Compare_EQ,    \
+                                    (uint16)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint16",               \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Compare two 16-bit values for inequality with an auto-generated description message
@@ -574,9 +734,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT16_NEQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint16)(actual), UtAssert_Compare_NEQ, (uint16)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint16", #actual, #ref)
+#define UtAssert_UINT16_NEQ(actual, ref)                    \
+    UtAssert_GenericUnsignedCompare((uint16)(actual),       \
+                                    UtAssert_Compare_NEQ,   \
+                                    (uint16)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint16",               \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the minimum 16-bit value of a given function or expression
@@ -587,9 +754,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT16_GTEQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint16)(actual), UtAssert_Compare_GTEQ, (uint16)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint16", #actual, #ref)
+#define UtAssert_UINT16_GTEQ(actual, ref)                   \
+    UtAssert_GenericUnsignedCompare((uint16)(actual),       \
+                                    UtAssert_Compare_GTEQ,  \
+                                    (uint16)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint16",               \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the maximum 16-bit value of a given function or expression
@@ -600,9 +774,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT16_LTEQ(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint16)(actual), UtAssert_Compare_LTEQ, (uint16)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint16", #actual, #ref)
+#define UtAssert_UINT16_LTEQ(actual, ref)                   \
+    UtAssert_GenericUnsignedCompare((uint16)(actual),       \
+                                    UtAssert_Compare_LTEQ,  \
+                                    (uint16)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint16",               \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the 16-bit value of a given function or expression is less than the 16-bit reference value
@@ -613,9 +794,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT16_LT(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint16)(actual), UtAssert_Compare_LT, (uint16)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint16", #actual, #ref)
+#define UtAssert_UINT16_LT(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint16)(actual),       \
+                                    UtAssert_Compare_LT,    \
+                                    (uint16)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint16",               \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the 16-bit value of a given function or expression is greater than the 16-bit reference value
@@ -626,9 +814,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT16_GT(actual, ref)                                                                           \
-    UtAssert_GenericUnsignedCompare((uint16)(actual), UtAssert_Compare_GT, (uint16)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint16", #actual, #ref)
+#define UtAssert_UINT16_GT(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint16)(actual),       \
+                                    UtAssert_Compare_GT,    \
+                                    (uint16)(ref),          \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint16",               \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Compare two 8-bit values for equality with an auto-generated description message
@@ -640,9 +835,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT8_EQ(actual, ref)                                                                          \
-    UtAssert_GenericUnsignedCompare((uint8)(actual), UtAssert_Compare_EQ, (uint8)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint8", #actual, #ref)
+#define UtAssert_UINT8_EQ(actual, ref)                      \
+    UtAssert_GenericUnsignedCompare((uint8)(actual),        \
+                                    UtAssert_Compare_EQ,    \
+                                    (uint8)(ref),           \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint8",                \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Compare two 8-bit values for inequality with an auto-generated description message
@@ -654,9 +856,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT8_NEQ(actual, ref)                                                                          \
-    UtAssert_GenericUnsignedCompare((uint8)(actual), UtAssert_Compare_NEQ, (uint8)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint8", #actual, #ref)
+#define UtAssert_UINT8_NEQ(actual, ref)                     \
+    UtAssert_GenericUnsignedCompare((uint8)(actual),        \
+                                    UtAssert_Compare_NEQ,   \
+                                    (uint8)(ref),           \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint8",                \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the minimum 8-bit value of a given function or expression
@@ -667,9 +876,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT8_GTEQ(actual, ref)                                                                          \
-    UtAssert_GenericUnsignedCompare((uint8)(actual), UtAssert_Compare_GTEQ, (uint8)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint8", #actual, #ref)
+#define UtAssert_UINT8_GTEQ(actual, ref)                    \
+    UtAssert_GenericUnsignedCompare((uint8)(actual),        \
+                                    UtAssert_Compare_GTEQ,  \
+                                    (uint8)(ref),           \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint8",                \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the maximum 8-bit value of a given function or expression
@@ -680,9 +896,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT8_LTEQ(actual, ref)                                                                          \
-    UtAssert_GenericUnsignedCompare((uint8)(actual), UtAssert_Compare_LTEQ, (uint8)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint8", #actual, #ref)
+#define UtAssert_UINT8_LTEQ(actual, ref)                    \
+    UtAssert_GenericUnsignedCompare((uint8)(actual),        \
+                                    UtAssert_Compare_LTEQ,  \
+                                    (uint8)(ref),           \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint8",                \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the 8-bit value of a given function or expression is less than the 8-bit reference value
@@ -693,9 +916,16 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT8_LT(actual, ref)                                                                          \
-    UtAssert_GenericUnsignedCompare((uint8)(actual), UtAssert_Compare_LT, (uint8)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint8", #actual, #ref)
+#define UtAssert_UINT8_LT(actual, ref)                      \
+    UtAssert_GenericUnsignedCompare((uint8)(actual),        \
+                                    UtAssert_Compare_LT,    \
+                                    (uint8)(ref),           \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint8",                \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Asserts the 8-bit value of a given function or expression is greater than the 8-bit reference value
@@ -706,27 +936,48 @@ typedef struct
  * \param actual The value from the unit under test
  * \param ref    The expected value from the unit under test
  */
-#define UtAssert_UINT8_GT(actual, ref)                                                                          \
-    UtAssert_GenericUnsignedCompare((uint8)(actual), UtAssert_Compare_GT, (uint8)(ref), UtAssert_Radix_DECIMAL, \
-                                    __FILE__, __LINE__, "uint8", #actual, #ref)
+#define UtAssert_UINT8_GT(actual, ref)                      \
+    UtAssert_GenericUnsignedCompare((uint8)(actual),        \
+                                    UtAssert_Compare_GT,    \
+                                    (uint8)(ref),           \
+                                    UtAssert_Radix_DECIMAL, \
+                                    __FILE__,               \
+                                    __LINE__,               \
+                                    "uint8",                \
+                                    #actual,                \
+                                    #ref)
 
 /**
  * \brief Macro for checking that bits in a bit field are set
  *
  * Test Passes if all the bits specified in "mask" are set in "rawval"
  */
-#define UtAssert_BITMASK_SET(rawval, mask)                                                          \
-    UtAssert_GenericUnsignedCompare((uint32)(rawval), UtAssert_Compare_BITMASK_SET, (uint32)(mask), \
-                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "", #rawval, #mask)
+#define UtAssert_BITMASK_SET(rawval, mask)                        \
+    UtAssert_GenericUnsignedCompare((uint32)(rawval),             \
+                                    UtAssert_Compare_BITMASK_SET, \
+                                    (uint32)(mask),               \
+                                    UtAssert_Radix_HEX,           \
+                                    __FILE__,                     \
+                                    __LINE__,                     \
+                                    "",                           \
+                                    #rawval,                      \
+                                    #mask)
 
 /**
  * \brief Macro for checking that bits in a bit field are unset
  *
  * Test Passes if none of the bits specified in "mask" are set in "rawval"
  */
-#define UtAssert_BITMASK_UNSET(rawval, mask)                                                          \
-    UtAssert_GenericUnsignedCompare((uint32)(rawval), UtAssert_Compare_BITMASK_UNSET, (uint32)(mask), \
-                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "", #rawval, #mask)
+#define UtAssert_BITMASK_UNSET(rawval, mask)                        \
+    UtAssert_GenericUnsignedCompare((uint32)(rawval),               \
+                                    UtAssert_Compare_BITMASK_UNSET, \
+                                    (uint32)(mask),                 \
+                                    UtAssert_Radix_HEX,             \
+                                    __FILE__,                       \
+                                    __LINE__,                       \
+                                    "",                             \
+                                    #rawval,                        \
+                                    #mask)
 
 /**
  * \brief Macro for logging calls to a "void" function
@@ -766,45 +1017,86 @@ typedef struct
 /**
  * \brief Compare addresses for equality with an auto-generated description message
  */
-#define UtAssert_ADDRESS_EQ(actual, expect)                                                                      \
-    UtAssert_GenericUnsignedCompare((unsigned long)(void *)(actual), UtAssert_Compare_EQ,                        \
-                                    (unsigned long)(void *)(expect), UtAssert_Radix_HEX, __FILE__, __LINE__, "", \
-                                    #actual, #expect)
+#define UtAssert_ADDRESS_EQ(actual, expect)                          \
+    UtAssert_GenericUnsignedCompare((unsigned long)(void *)(actual), \
+                                    UtAssert_Compare_EQ,             \
+                                    (unsigned long)(void *)(expect), \
+                                    UtAssert_Radix_HEX,              \
+                                    __FILE__,                        \
+                                    __LINE__,                        \
+                                    "",                              \
+                                    #actual,                         \
+                                    #expect)
 
 /**
  * \brief Confirm a pointer value is not NULL
  */
-#define UtAssert_NOT_NULL(actual)                                                                                 \
-    UtAssert_GenericUnsignedCompare((unsigned long)(void *)(actual), UtAssert_Compare_NEQ, 0, UtAssert_Radix_HEX, \
-                                    __FILE__, __LINE__, "", #actual, "NULL")
+#define UtAssert_NOT_NULL(actual)                                    \
+    UtAssert_GenericUnsignedCompare((unsigned long)(void *)(actual), \
+                                    UtAssert_Compare_NEQ,            \
+                                    0,                               \
+                                    UtAssert_Radix_HEX,              \
+                                    __FILE__,                        \
+                                    __LINE__,                        \
+                                    "",                              \
+                                    #actual,                         \
+                                    "NULL")
 
 /**
  * \brief Confirm a pointer value is NULL
  */
-#define UtAssert_NULL(actual)                                                                                    \
-    UtAssert_GenericUnsignedCompare((unsigned long)(void *)(actual), UtAssert_Compare_EQ, 0, UtAssert_Radix_HEX, \
-                                    __FILE__, __LINE__, "", #actual, "NULL")
+#define UtAssert_NULL(actual)                                        \
+    UtAssert_GenericUnsignedCompare((unsigned long)(void *)(actual), \
+                                    UtAssert_Compare_EQ,             \
+                                    0,                               \
+                                    UtAssert_Radix_HEX,              \
+                                    __FILE__,                        \
+                                    __LINE__,                        \
+                                    "",                              \
+                                    #actual,                         \
+                                    "NULL")
 
 /**
  * \brief Confirm an integer value is nonzero
  */
-#define UtAssert_NONZERO(actual)                                                                                   \
-    UtAssert_GenericSignedCompare(actual, UtAssert_Compare_NEQ, 0, UtAssert_Radix_DECIMAL, __FILE__, __LINE__, "", \
-                                  #actual, "ZERO")
+#define UtAssert_NONZERO(actual)                          \
+    UtAssert_GenericSignedCompare(actual,                 \
+                                  UtAssert_Compare_NEQ,   \
+                                  0,                      \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  "ZERO")
 
 /**
  * \brief Confirm an integer value is zero
  */
-#define UtAssert_ZERO(actual)                                                                                     \
-    UtAssert_GenericSignedCompare(actual, UtAssert_Compare_EQ, 0, UtAssert_Radix_DECIMAL, __FILE__, __LINE__, "", \
-                                  #actual, "ZERO")
+#define UtAssert_ZERO(actual)                             \
+    UtAssert_GenericSignedCompare(actual,                 \
+                                  UtAssert_Compare_EQ,    \
+                                  0,                      \
+                                  UtAssert_Radix_DECIMAL, \
+                                  __FILE__,               \
+                                  __LINE__,               \
+                                  "",                     \
+                                  #actual,                \
+                                  "ZERO")
 
 /**
  * \brief Confirm that a stub function has been invoked the expected number of times
  */
-#define UtAssert_STUB_COUNT(stub, expected)                                                     \
-    UtAssert_GenericSignedCompare(UT_GetStubCount(UT_KEY(stub)), UtAssert_Compare_EQ, expected, \
-                                  UtAssert_Radix_DECIMAL, __FILE__, __LINE__, "CallCount", #stub "()", #expected)
+#define UtAssert_STUB_COUNT(stub, expected)                      \
+    UtAssert_GenericSignedCompare(UT_GetStubCount(UT_KEY(stub)), \
+                                  UtAssert_Compare_EQ,           \
+                                  expected,                      \
+                                  UtAssert_Radix_DECIMAL,        \
+                                  __FILE__,                      \
+                                  __LINE__,                      \
+                                  "CallCount",                   \
+                                  #stub "()",                    \
+                                  #expected)
 
 /*
  * Exported Functions
@@ -908,7 +1200,11 @@ bool UtAssert(bool Expression, const char *Description, const char *File, uint32
  * \param Line          The source line number in which the test case appears
  * \param MessageFormat a free form printf-style format string describing the test case
  */
-bool UtAssertEx(bool Expression, UtAssert_CaseType_t CaseType, const char *File, uint32 Line, const char *MessageFormat,
+bool UtAssertEx(bool                Expression,
+                UtAssert_CaseType_t CaseType,
+                const char         *File,
+                uint32              Line,
+                const char         *MessageFormat,
                 ...) OS_PRINTF(5, 6);
 
 /**
@@ -970,8 +1266,13 @@ void UtAssert_Message(uint8 MessageType, const char *File, uint32 Line, const ch
  * \param SegmentNum   Sequence among the overall/global test Segments
  * \param SegmentSeq   Sequence within the current test Segment
  */
-void UtAssert_DoReport(const char *File, uint32 LineNum, uint32 SegmentNum, uint32 SegmentSeq, uint8 MessageType,
-                       const char *SubsysName, const char *ShortDesc);
+void UtAssert_DoReport(const char *File,
+                       uint32      LineNum,
+                       uint32      SegmentNum,
+                       uint32      SegmentSeq,
+                       uint8       MessageType,
+                       const char *SubsysName,
+                       const char *ShortDesc);
 
 /**
  * The BSP overall test reporting function.
@@ -1001,8 +1302,13 @@ void UtAssert_DoTestSegmentReport(const char *SegmentName, const UtAssert_TestCo
  * \returns Test pass status, returns true if status was successful, false if it failed.
  *
  */
-bool UtAssert_StringBufCompare(const char *String1, size_t String1Max, const char *String2, size_t String2Max,
-                               UtAssert_Compare_t CompareType, const char *File, uint32 Line);
+bool UtAssert_StringBufCompare(const char        *String1,
+                               size_t             String1Max,
+                               const char        *String2,
+                               size_t             String2Max,
+                               UtAssert_Compare_t CompareType,
+                               const char        *File,
+                               uint32             Line);
 
 /**
  * \brief Helper function for generic integer value checks
@@ -1030,10 +1336,16 @@ bool UtAssert_StringBufCompare(const char *String1, size_t String1Max, const cha
  * \returns Test pass status, returns true if status was successful, false if it failed.
  *
  */
-bool UtAssert_GenericIntegerCompare(bool IsUnsigned, UT_IntCheck_t ActualValue, UtAssert_Compare_t CompareType,
-                                    UT_IntCheck_t ReferenceValue, const char *File, uint32 Line,
-                                    UtAssert_Radix_t RadixType, const char *Typename, const char *ActualText,
-                                    const char *ReferenceText);
+bool UtAssert_GenericIntegerCompare(bool               IsUnsigned,
+                                    UT_IntCheck_t      ActualValue,
+                                    UtAssert_Compare_t CompareType,
+                                    UT_IntCheck_t      ReferenceValue,
+                                    const char        *File,
+                                    uint32             Line,
+                                    UtAssert_Radix_t   RadixType,
+                                    const char        *Typename,
+                                    const char        *ActualText,
+                                    const char        *ReferenceText);
 
 /**
  * \brief Helper function for generic unsigned integer value checks
@@ -1050,9 +1362,15 @@ bool UtAssert_GenericIntegerCompare(bool IsUnsigned, UT_IntCheck_t ActualValue, 
  * \returns Test pass status, returns true if status was successful, false if it failed.
  *
  */
-bool UtAssert_GenericUnsignedCompare(unsigned long ActualValue, UtAssert_Compare_t CompareType,
-                                     unsigned long ReferenceValue, UtAssert_Radix_t RadixType, const char *File,
-                                     uint32 Line, const char *Desc, const char *ActualText, const char *ReferenceText);
+bool UtAssert_GenericUnsignedCompare(unsigned long      ActualValue,
+                                     UtAssert_Compare_t CompareType,
+                                     unsigned long      ReferenceValue,
+                                     UtAssert_Radix_t   RadixType,
+                                     const char        *File,
+                                     uint32             Line,
+                                     const char        *Desc,
+                                     const char        *ActualText,
+                                     const char        *ReferenceText);
 
 /**
  * \brief Helper function for generic signed integer value checks
@@ -1069,8 +1387,14 @@ bool UtAssert_GenericUnsignedCompare(unsigned long ActualValue, UtAssert_Compare
  * \returns Test pass status, returns true if status was successful, false if it failed.
  *
  */
-bool UtAssert_GenericSignedCompare(long ActualValue, UtAssert_Compare_t CompareType, long ReferenceValue,
-                                   UtAssert_Radix_t RadixType, const char *File, uint32 Line, const char *Desc,
-                                   const char *ActualText, const char *ReferenceText);
+bool UtAssert_GenericSignedCompare(long               ActualValue,
+                                   UtAssert_Compare_t CompareType,
+                                   long               ReferenceValue,
+                                   UtAssert_Radix_t   RadixType,
+                                   const char        *File,
+                                   uint32             Line,
+                                   const char        *Desc,
+                                   const char        *ActualText,
+                                   const char        *ReferenceText);
 
 #endif /* UTASSERT_H */

--- a/ut_assert/inc/utgenstub.h
+++ b/ut_assert/inc/utgenstub.h
@@ -62,8 +62,11 @@
  * \param ParamType  The type of the parameter
  * \param ParamName  The name of the parameter
  */
-#define UT_GenStub_AddParam(FuncName, ParamType, ParamName)                                                           \
-    UT_Stub_RegisterContextWithMetaData(UT_KEY(FuncName), #ParamName, UT_STUBCONTEXT_ARG_TYPE_INDIRECT, &(ParamName), \
+#define UT_GenStub_AddParam(FuncName, ParamType, ParamName)               \
+    UT_Stub_RegisterContextWithMetaData(UT_KEY(FuncName),                 \
+                                        #ParamName,                       \
+                                        UT_STUBCONTEXT_ARG_TYPE_INDIRECT, \
+                                        &(ParamName),                     \
                                         sizeof(ParamType))
 
 /**

--- a/ut_assert/inc/utlist.h
+++ b/ut_assert/inc/utlist.h
@@ -56,7 +56,7 @@ typedef struct UtListNodeTag
 {
     struct UtListNodeTag *Next;
     struct UtListNodeTag *Prev;
-    void *                Data;
+    void                 *Data;
     uint32                DataSize;
     uint32                Tag;
 } UtListNode_t;

--- a/ut_assert/inc/utstubs.h
+++ b/ut_assert/inc/utstubs.h
@@ -59,7 +59,7 @@ typedef ptrdiff_t UT_IntReturn_t;
 /**
  * Macro to obtain a UT_EntryKey_t value from any function name
  */
-#define UT_KEY(Func) ((UT_EntryKey_t)&Func)
+#define UT_KEY(Func) ((UT_EntryKey_t) & Func)
 
 /**
  * Maximum size of a callback hook context list
@@ -97,7 +97,7 @@ typedef enum UT_ValueGenre
 typedef struct
 {
     UT_StubContext_Arg_Type_t Type;
-    const char *              Name;
+    const char               *Name;
     size_t                    Size;
 } UT_StubArgMetaData_t;
 
@@ -109,7 +109,7 @@ typedef struct
     int32                Int32StatusCode;
     bool                 Int32StatusIsSet;
     uint32               ArgCount;
-    const void *         ArgPtr[UT_STUBCONTEXT_MAXSIZE];
+    const void          *ArgPtr[UT_STUBCONTEXT_MAXSIZE];
     UT_StubArgMetaData_t Meta[UT_STUBCONTEXT_MAXSIZE];
 } UT_StubContext_t;
 
@@ -129,8 +129,8 @@ typedef int32 (*UT_HookFunc_t)(void *UserObj, int32 StubRetcode, uint32 CallCoun
  *
  * \copydoc UT_HookFunc_t
  */
-typedef int32 (*UT_VaHookFunc_t)(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context,
-                                 va_list va);
+typedef int32 (
+    *UT_VaHookFunc_t)(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context, va_list va);
 
 /**
  * Function pointer for user-specified stub handlers
@@ -230,8 +230,12 @@ void UT_SetDeferredRetcode(UT_EntryKey_t FuncKey, int32 Count, UT_IntReturn_t Re
  * \param DeferCount Number of times the stub needs to be called until this value is used
  * \param TypeName   Data type as an ASCII string, for possible type matching (may be set from a preprocessor macro)
  */
-void UT_ConfigureGenericStubReturnValue(UT_EntryKey_t FuncKey, const void *ValuePtr, size_t ValueSize,
-                                        UT_ValueGenre_t ValueGenre, int32 DeferCount, const char *TypeName);
+void UT_ConfigureGenericStubReturnValue(UT_EntryKey_t   FuncKey,
+                                        const void     *ValuePtr,
+                                        size_t          ValueSize,
+                                        UT_ValueGenre_t ValueGenre,
+                                        int32           DeferCount,
+                                        const char     *TypeName);
 
 /**
  * Add a data buffer for a given stub function
@@ -454,8 +458,11 @@ size_t UT_Stub_CopyFromLocal(UT_EntryKey_t FuncKey, const void *LocalBuffer, siz
  * A pointer to the stack value is actually stored into the context,
  * which can be dereferenced in the hook.
  */
-#define UT_Stub_RegisterContextGenericArg(FuncKey, Parameter)                                              \
-    UT_Stub_RegisterContextWithMetaData(FuncKey, #Parameter, UT_STUBCONTEXT_ARG_TYPE_INDIRECT, &Parameter, \
+#define UT_Stub_RegisterContextGenericArg(FuncKey, Parameter)             \
+    UT_Stub_RegisterContextWithMetaData(FuncKey,                          \
+                                        #Parameter,                       \
+                                        UT_STUBCONTEXT_ARG_TYPE_INDIRECT, \
+                                        &Parameter,                       \
                                         sizeof(Parameter))
 
 /**
@@ -568,8 +575,11 @@ bool UT_Stub_GetInt32StatusCode(const UT_StubContext_t *Context, int32 *StatusCo
  * \param ParamPtr  Pointer to argument data
  * \param ParamSize The size of the object pointed to, or zero if not known
  */
-void UT_Stub_RegisterContextWithMetaData(UT_EntryKey_t FuncKey, const char *Name, UT_StubContext_Arg_Type_t ParamType,
-                                         const void *ParamPtr, size_t ParamSize);
+void UT_Stub_RegisterContextWithMetaData(UT_EntryKey_t             FuncKey,
+                                         const char               *Name,
+                                         UT_StubContext_Arg_Type_t ParamType,
+                                         const void               *ParamPtr,
+                                         size_t                    ParamSize);
 
 /**
  * Retrieve a context argument value by name
@@ -640,8 +650,10 @@ int32 UT_DefaultStubImplWithArgs(const char *FunctionName, UT_EntryKey_t FuncKey
  * \param DefaultHandler The default handler
  * \param VaList         Argument list
  */
-void UT_ExecuteVaHandler(UT_EntryKey_t FuncKey, const char *FunctionName, UT_VaHandlerFunc_t DefaultHandler,
-                         va_list VaList);
+void UT_ExecuteVaHandler(UT_EntryKey_t      FuncKey,
+                         const char        *FunctionName,
+                         UT_VaHandlerFunc_t DefaultHandler,
+                         va_list            VaList);
 
 /**
  * Default implementation for a stub function that should be useful for most cases.

--- a/ut_assert/inc/uttest.h
+++ b/ut_assert/inc/uttest.h
@@ -91,7 +91,10 @@ void UtTest_AddTeardown(void (*Teardown)(void), const char *SequenceName);
  * \param GroupName Name of group for logging purposes
  * \param TestName Name of test for logging purposes
  */
-void UtTest_AddSubTest(void (*Test)(void), void (*Setup)(void), void (*Teardown)(void), const char *GroupName,
+void UtTest_AddSubTest(void (*Test)(void),
+                       void (*Setup)(void),
+                       void (*Teardown)(void),
+                       const char *GroupName,
                        const char *TestName);
 
 /**


### PR DESCRIPTION
Re-format cFE using clang-format.

This PR is for evaluation only.

The following `.clang-format` file was used:

```
---
BasedOnStyle: Google
AccessModifierOffset: '-4'
AlignAfterOpenBracket: Align
AlignArrayOfStructures: Left
AlignConsecutiveAssignments:
  Enabled: true
  AcrossEmptyLines: false
  AcrossComments: true
  AlignCompound: true
  PadOperators: true
AlignConsecutiveDeclarations:
  Enabled: true
  AcrossEmptyLines: false
  AcrossComments: true
  AlignCompound: true
  PadOperators: true
AlignConsecutiveMacros:
  Enabled: true
  AcrossEmptyLines: false
  AcrossComments: true
  AlignCompound: true
  PadOperators: true
AlignEscapedNewlines: Left
AlignConsecutiveBitFields: true
AlignOperands: AlignAfterOperator
AlignTrailingComments: 'true'
AllowAllArgumentsOnNextLine: 'false'
AllowAllConstructorInitializersOnNextLine: 'false'
AllowAllParametersOfDeclarationOnNextLine: 'false'
AllowShortBlocksOnASingleLine: 'false'
AllowShortCaseLabelsOnASingleLine: 'false'
AllowShortFunctionsOnASingleLine: InlineOnly
AllowShortIfStatementsOnASingleLine: 'false'
AllowShortLoopsOnASingleLine: 'false'
AlwaysBreakAfterReturnType: None
AlwaysBreakBeforeMultilineStrings: 'false'
AlwaysBreakTemplateDeclarations: 'Yes'
BinPackArguments: 'false'
BinPackParameters: 'false'
BraceWrapping:
  AfterCaseLabel: true
  AfterClass: true
  AfterControlStatement: Always
  AfterEnum: true
  AfterFunction: true
  AfterNamespace: true
  AfterStruct: true
  AfterUnion: true
  BeforeCatch: true
  BeforeElse: true
  BeforeWhile: false
  SplitEmptyFunction: true
  SplitEmptyRecord: true
BreakBeforeBinaryOperators: NonAssignment
BreakBeforeBraces: Custom
BreakBeforeTernaryOperators: 'false'
BreakConstructorInitializers: AfterColon
BreakInheritanceList: AfterColon
ColumnLimit: '120'
CompactNamespaces: 'false'
ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
ConstructorInitializerIndentWidth: '4'
ContinuationIndentWidth: '4'
Cpp11BracedListStyle: 'false'
DerivePointerAlignment: 'false'
ExperimentalAutoDetectBinPacking: 'false'
FixNamespaceComments: 'true'
IncludeBlocks: Preserve
IndentCaseLabels: 'true'
IndentPPDirectives: None
IndentWidth: '4'
KeepEmptyLinesAtTheStartOfBlocks: 'false'
Language: Cpp
MaxEmptyLinesToKeep: 2
NamespaceIndentation: None
PointerAlignment: Right
ReflowComments: 'false'
SortIncludes: 'false'
SortUsingDeclarations: 'false'
SpaceAfterCStyleCast: 'false'
SpaceAfterTemplateKeyword: 'false'
SpaceBeforeAssignmentOperators: 'true'
SpaceBeforeCpp11BracedList: 'true'
SpaceBeforeCtorInitializerColon: 'true'
SpaceBeforeInheritanceColon: 'true'
SpaceBeforeParens: ControlStatements
SpaceBeforeRangeBasedForLoopColon: 'false'
SpaceInEmptyParentheses: 'false'
SpacesBeforeTrailingComments: '1'
SpacesInAngles: 'false'
SpacesInCStyleCastParentheses: 'false'
SpacesInContainerLiterals: 'false'
SpacesInParentheses: 'false'
SpacesInSquareBrackets: 'false'
Standard: Cpp11
TabWidth: '4'
UseTab: Never

...
```