### PR TITLE
Fix #1527, Remove Obsolete Doxygen Tags

### DIFF
--- a/docs/src/default-settings.doxyfile
+++ b/docs/src/default-settings.doxyfile
@@ -41,7 +41,6 @@ PAPER_TYPE             = letter
 COMPACT_RTF            = YES
 
 # Dot tool
-CLASS_DIAGRAMS         = NO
 HAVE_DOT               = YES
 CLASS_GRAPH            = NO
 COLLABORATION_GRAPH    = NO


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1527 

**Testing performed**
In my test, I simply updated the cFE workflow to use this change by pointing to this fix-1527-remove-obsolete-doxygen-tags branch. The successful test workflow can be seen [here](https://github.com/arielswalker/cFE/actions/runs/25122057286). The original failed workflow without this change can be seen [here](https://github.com/nasa/cFE/actions/runs/25110794654/job/73584140994?pr=2701). 

**Expected behavior changes**
Workflows using [build-doc-reusable.yml](https://github.com/nasa/cFS/blob/dev/.github/workflows/build-doc-reusable.yml) will run successfully. 

**System(s) tested on**
GitHub Actions

**Additional context**
This workflow failure was not seen internally because an older version of doxygen was used. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
