### PR TITLE
Fix nasa#1542, removed unnecessary call to UT_GetStubEntry() in UT_Co…

### DIFF
--- a/ut_assert/src/utstubs.c
+++ b/ut_assert/src/utstubs.c
@@ -361,8 +361,6 @@ void UT_ConfigureGenericStubReturnValue(UT_EntryKey_t   FuncKey,
     UT_StubTableEntry_t *StubPtr;
     UT_EntryType_t       ReqEntryType;
 
-    StubPtr = UT_GetStubEntry(FuncKey, UT_ENTRYTYPE_UNUSED);
-
     /*
      * For deferred retval configs, this always adds a new entry.  But
      * for constant retval configs, it should replace the existing entry if


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes nasa#1542 by removing unnecessary call to UT_GetStubEntry() in UT_ConfigureGenericStubReturnValue() in ut_assert/src/utstubs.c because the return value will simply be overwritten by the following if-else statement

**Testing performed**

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
