### PR TITLE
Fix nasa#1545, osal use of strcpy

### DIFF
--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -180,11 +180,7 @@ void UtAssert_EndTest(void)
         }
         memcpy(&Local_SegmentCounters, &UT_SegmentCounters, sizeof(Local_SegmentCounters));
 
-        /*
-         * note, strcpy is OK because both are fixed size buffers of the same size,
-         * and the null termination on CurrentSegment was locally enforced already
-         */
-        strcpy(Local_SegmentName, CurrentSegment);
+        strncpy(Local_SegmentName, CurrentSegment, sizeof(Local_SegmentName)-1);
     }
 
     memset(&UT_SegmentCounters, 0, sizeof(UT_SegmentCounters));

--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -180,7 +180,12 @@ void UtAssert_EndTest(void)
         }
         memcpy(&Local_SegmentCounters, &UT_SegmentCounters, sizeof(Local_SegmentCounters));
 
-        strncpy(Local_SegmentName, CurrentSegment, sizeof(Local_SegmentName) - 1);
+        /*
+         * note, strcpy is OK because both are fixed size buffers of the same size,
+         * and the null termination on CurrentSegment was locally enforced already
+         * SAD: This should be ignored by CodeSonar.
+         */
+        strcpy(Local_SegmentName, CurrentSegment);
     }
 
     memset(&UT_SegmentCounters, 0, sizeof(UT_SegmentCounters));

--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -180,7 +180,7 @@ void UtAssert_EndTest(void)
         }
         memcpy(&Local_SegmentCounters, &UT_SegmentCounters, sizeof(Local_SegmentCounters));
 
-        strncpy(Local_SegmentName, CurrentSegment, sizeof(Local_SegmentName)-1);
+        strncpy(Local_SegmentName, CurrentSegment, sizeof(Local_SegmentName) - 1);
     }
 
     memset(&UT_SegmentCounters, 0, sizeof(UT_SegmentCounters));


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov. (This issue was discussed in a cfs meeting. I think that counts!)

**Describe the contribution**
Static analyzer via CodeSonar found a usage of 'strcpy' in osal. Strcpy() does not check bounds and should be replaced with something that does, like strncpy(). strncpy(dest, src, sizeof(dest)-1); 
Note: When using strncpy, it’s safer to pass _sizeof(dest) - 1_ instead of _sizeof(dest)_ to reserve space for the null terminator and avoid unterminated strings.
Fixes #1545  

**Testing performed**
1. make distclean
2. make native_std.prep
3. make native_std.install
4. make native_std.runtest (just in case)
5. Note: ~~I still can't log into CodeSonar to check the static analysis results. It would be great if a reviewer could check what CodeSonar has to say.~~ Update: I have CodeSonar access now!