### PR TITLE
Fix #1548, Adding SMP API to OSAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,7 @@ set(OSAL_SRCLIST
     src/os/shared/src/osapi-mutex.c
     src/os/shared/src/osapi-network.c
     src/os/shared/src/osapi-printf.c
+    src/os/shared/src/osapi-task-affinity.c
     src/os/shared/src/osapi-queue.c
     src/os/shared/src/osapi-rwlock.c
     src/os/shared/src/osapi-select.c

--- a/default_config.cmake
+++ b/default_config.cmake
@@ -395,6 +395,11 @@ set(OSAL_CONFIG_QUEUE_MAX_DEPTH         50
     CACHE STRING "Maximum depth of message queue"
 )
 
+# The maximum number of CPUs supported.
+set(OSAL_CONFIG_MAX_CPUS                  8
+    CACHE STRING "Maximum number of CPUs supported"
+)
+
 # Flags added to all tasks on creation
 #
 # Some OS's use floating point under the hood, this supports

--- a/osconfig.h.in
+++ b/osconfig.h.in
@@ -233,6 +233,13 @@
 #define OS_QUEUE_MAX_DEPTH              @OSAL_CONFIG_QUEUE_MAX_DEPTH@
 
  /**
+  * \brief The maximum number of CPUs to support
+  *
+  * Based on the OSAL_CONFIG_MAX_CPUS configuration option
+  */
+#define OS_MAX_CPUS                     @OSAL_CONFIG_MAX_CPUS@
+
+ /**
   * \brief The name of the temporary file used to store shell commands
   *
   * This configuration is only applicable if shell support is enabled, and

--- a/src/os/inc/osapi-task-affinity.h
+++ b/src/os/inc/osapi-task-affinity.h
@@ -1,0 +1,116 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * Declarations and prototypes for file objects
+ */
+
+#ifndef OSAPI_TASK_AFFINITY_H
+#define OSAPI_TASK_AFFINITY_H
+
+#include "common_types.h"
+#include "osconfig.h"
+
+/**
+ * @brief An abstract structure capable of holding a cpuset
+ * Because standard integer types max out at 64 bits
+ * OSAL uses an array of 8-bit bytes to store the mask so it can scale
+ * to support any number of cores. Currently the max is 64 but this can
+ * be used for more in the future.
+ * if the number of bits doesn't divide perfectly by 8,
+ * add one extra byte to the end to hold the remainders
+ */
+typedef struct
+{
+    uint8 affinity_mask[(OS_MAX_CPUS + 7) / 8];
+} OS_cpuset_t;
+
+/**
+ * @name OSAL CPU Set Manipulation Macros
+ * @{
+ */
+
+/** @brief Initializes the CPU set to empty (clears all CPUs) */
+#define OS_CPUSET_ZERO(cpusetptr) memset((cpusetptr)->affinity_mask, 0, sizeof((cpusetptr)->affinity_mask))
+
+/** @brief Adds a specific CPU to the CPU set */
+#define OS_CPUSET_SET(cpu, cpusetptr)                                     \
+    do                                                                    \
+    {                                                                     \
+        if ((cpu) < OS_MAX_CPUS)                                          \
+        {                                                                 \
+            (cpusetptr)->affinity_mask[(cpu) / 8] |= (1U << ((cpu) % 8)); \
+        }                                                                 \
+    } while (0)
+
+/** @brief Removes a specific CPU from the CPU set */
+#define OS_CPUSET_CLR(cpu, cpusetptr)                                      \
+    do                                                                     \
+    {                                                                      \
+        if ((cpu) < OS_MAX_CPUS)                                           \
+        {                                                                  \
+            (cpusetptr)->affinity_mask[(cpu) / 8] &= ~(1U << ((cpu) % 8)); \
+        }                                                                  \
+    } while (0)
+
+/** @brief Checks if a specific CPU is in the CPU set (Evaluates to true/false) */
+#define OS_CPUSET_ISSET(cpu, cpusetptr) \
+    (((cpu) < OS_MAX_CPUS) ? (((cpusetptr)->affinity_mask[(cpu) / 8] & (1U << ((cpu) % 8))) != 0) : 0)
+
+/** @} */
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetCoresConfigured() is an api call  to obtain information from OS
+ * for the number of configured cores
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured(void);
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityCoresConfigured() is an api call  to return global information
+ * from OSAL set at init for the number of configured cores.
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityCoresConfigured(void);
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinitySetAffinity() is an api call to set affinity to a task
+ *
+ * Sets an affinity from cpuset to task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity(osal_id_t task_id, const OS_cpuset_t cpuset);
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetAffinity() is an api call to get affinity to a task
+ *
+ * Writes affinity to cpuset from task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity(osal_id_t task_id, OS_cpuset_t *cpuset);
+
+#endif /* OSAPI_TASK_AFFINITY_H */

--- a/src/os/inc/osapi.h
+++ b/src/os/inc/osapi.h
@@ -84,6 +84,7 @@ extern "C"
 #include "osapi-shell.h"
 #include "osapi-sockets.h"
 #include "osapi-task.h"
+#include "osapi-task-affinity.h"
 #include "osapi-timebase.h"
 #include "osapi-timer.h"
 

--- a/src/os/portable/os-impl-pthread-affinity-np.c
+++ b/src/os/portable/os-impl-pthread-affinity-np.c
@@ -1,0 +1,149 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * This file Contains all of the api calls for manipulating files
+ * in a file system / C library that implements the POSIX-style file API
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+/*
+ * Inclusions Defined by OSAL layer.
+ *
+ */
+
+#include "os-impl-taskaffinity.h"
+#include "os-impl-tasks.h"
+#include "os-shared-idmap.h"
+#include "osapi-task-affinity.h"
+
+/*
+**  System Include Files
+*/
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <stdlib.h>
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                 Named File API
+ ***************************************************************************************/
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetCoresConfigured() is an api call  to obtain information from OS
+ * for the number of configured cores
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured_Impl(void)
+{
+    return OS_TaskAffinity_Proc_Conf();
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinitySetAffinity() is an api call to set affinity to a task
+ *
+ * Sets an affinity from cpuset to task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity_Impl(const OS_object_token_t *token, const OS_cpuset_t cpuset)
+{
+    cpu_set_t                       lcl_cpuset;
+    OS_impl_task_internal_record_t *impl;
+    int32                           return_value;
+    uint32                          i;
+
+    impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
+
+    CPU_ZERO(&lcl_cpuset);
+
+    /* Populate POSIX cpuset from OSAL CPU Set using the macro */
+    for (i = 0; (i < OS_MAX_CPUS) && (i < OS_TaskAffinityGetCoresConfigured()); i++)
+    {
+        /* Check if the bit is set in the OSAL structure */
+        if (OS_CPUSET_ISSET(i, &cpuset))
+        {
+            /* If it is, set the corresponding bit in the POSIX structure */
+            CPU_SET(i, &lcl_cpuset);
+        }
+    }
+
+    return_value = pthread_setaffinity_np(impl->id, sizeof(lcl_cpuset), &lcl_cpuset);
+
+    if (return_value == 0)
+    {
+        return OS_SUCCESS;
+    }
+    else
+    {
+        return OS_ERROR;
+    }
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetAffinity() is an api call to get affinity to a task
+ *
+ * Writes affinity to cpuset from task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity_Impl(const OS_object_token_t *token, OS_cpuset_t *cpuset)
+{
+    cpu_set_t                       local_cpuset;
+    OS_impl_task_internal_record_t *impl;
+    int32                           return_value;
+    uint32                          i;
+
+    impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
+
+    CPU_ZERO(&local_cpuset);
+    return_value = pthread_getaffinity_np(impl->id, sizeof(local_cpuset), &local_cpuset);
+
+    if (return_value == 0)
+    {
+        /* Clear the OSAL affinity mask using the macro */
+        OS_CPUSET_ZERO(cpuset);
+
+        /* Populate the OSAL affinity mask from the POSIX mask */
+        for (i = 0; (i < OS_MAX_CPUS) && (i < OS_TaskAffinityGetCoresConfigured()); i++)
+        {
+            /* If the bit is set in the POSIX structure */
+            if (CPU_ISSET(i, &local_cpuset))
+            {
+                /* set the corresponding bit in the OSAL structure */
+                OS_CPUSET_SET(i, cpuset);
+            }
+        }
+
+        return OS_SUCCESS;
+    }
+
+    return OS_ERROR;
+}

--- a/src/os/portable/os-impl-pthread-no-affinity-np.c
+++ b/src/os/portable/os-impl-pthread-no-affinity-np.c
@@ -1,0 +1,89 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * This file Contains all of the api calls for manipulating files
+ * in a file system / C library that implements the POSIX-style file API
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+/*
+ * Inclusions Defined by OSAL layer.
+ *
+ */
+
+#include "os-shared-idmap.h"
+#include "osapi-task-affinity.h"
+
+/*
+**  System Include Files
+*/
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <stdlib.h>
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                 Named File API
+ ***************************************************************************************/
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetCoresConfigured() is an api call  to obtain information from OS
+ * for the number of configured cores
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured_Impl(void)
+{
+    return 1;
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinitySetAffinity() is an api call to set affinity to a task
+ *
+ * Sets an affinity from cpuset to task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity_Impl(const OS_object_token_t *token, const OS_cpuset_t cpuset)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetAffinity() is an api call to get affinity to a task
+ *
+ * Writes affinity to cpuset from task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity_Impl(const OS_object_token_t *token, OS_cpuset_t *cpuset)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+}

--- a/src/os/posix/CMakeLists.txt
+++ b/src/os/posix/CMakeLists.txt
@@ -94,6 +94,22 @@ else ()
     )
 endif ()
 
+if (OSAL_CONFIG_MAX_CPUS GREATER 1)
+    list(APPEND POSIX_IMPL_SRCLIST
+        ../portable/os-impl-pthread-affinity-np.c #    use the real affinity code
+    )
+    
+    # _GNU_SOURCE is required for pthread_setaffinity_np and CPU_SET macros
+    set_source_files_properties(
+        ../portable/os-impl-pthread-affinity-np.c 
+        PROPERTIES COMPILE_DEFINITIONS "_GNU_SOURCE"
+    )
+else()
+    list(APPEND POSIX_IMPL_SRCLIST
+        ../portable/os-impl-pthread-no-affinity-np.c
+    )
+endif()
+
 # Defines an OBJECT target named "osal_posix_impl" with selected source files
 add_library(osal_posix_impl OBJECT
     ${POSIX_BASE_SRCLIST}

--- a/src/os/posix/inc/os-impl-taskaffinity.h
+++ b/src/os/posix/inc/os-impl-taskaffinity.h
@@ -18,28 +18,23 @@
 
 /**
  * \file
- * \ingroup  ut-stubs
- * \author   joseph.p.hickey@nasa.gov
+ *
+ * \ingroup  posix
  *
  */
-#include <string.h>
-#include <stdlib.h>
-#include "utstubs.h"
 
-#include "os-shared-common.h"
-#include "OCS_semLib.h"
+#ifndef OS_IMPL_TASKAFFINITY_H
+#define OS_IMPL_TASKAFFINITY_H
 
-int32 OS_API_Impl_Init(osal_objtype_t idtype)
+#include <pthread.h>
+
+#include <unistd.h>
+#include "os-posix.h"
+
+/* Define the function used by the OSAL initialization */
+static inline uint32 OS_TaskAffinity_Proc_Conf(void)
 {
-    return UT_DEFAULT_IMPL(OS_API_Impl_Init);
+    return (uint32)sysconf(_SC_NPROCESSORS_CONF);
 }
 
-int OS_VxWorks_GenericSemTake(OCS_SEM_ID vxid, int sys_ticks)
-{
-    return UT_DEFAULT_IMPL(OS_VxWorks_GenericSemTake);
-}
-
-int OS_VxWorks_GenericSemGive(OCS_SEM_ID vxid)
-{
-    return UT_DEFAULT_IMPL(OS_VxWorks_GenericSemGive);
-}
+#endif /* OS_IMPL_TASKAFFINITY_H */

--- a/src/os/posix/src/os-impl-tasks.c
+++ b/src/os/posix/src/os-impl-tasks.c
@@ -34,7 +34,9 @@
 #include "os-impl-tasks.h"
 
 #include "os-shared-task.h"
+#include "os-shared-task-affinity.h"
 #include "os-shared-idmap.h"
+#include "os-shared-common.h"
 
 /*
  * Extra Stack Space for overhead -
@@ -242,6 +244,11 @@ int32 OS_Posix_TaskAPI_Impl_Init(void)
      */
     memset(&sched_fifo_limits, 0, sizeof(sched_fifo_limits));
     memset(&sched_rr_limits, 0, sizeof(sched_rr_limits));
+
+    /*
+     * Get number of configured cores
+     */
+    OS_SharedGlobalVars.CoresConfigured = OS_TaskAffinityGetCoresConfigured_Impl();
 
     /*
      * Create the key used to store OSAL task IDs

--- a/src/os/qnx/CMakeLists.txt
+++ b/src/os/qnx/CMakeLists.txt
@@ -22,6 +22,7 @@ set(POSIX_BASE_SRCLIST
     ../posix/src/os-impl-queues.c
     ../posix/src/os-impl-tasks.c
     ../posix/src/os-impl-timebase.c
+    ../portable/os-impl-pthread-no-affinity-np.c
 )
 
 # Use portable blocks for basic I/O

--- a/src/os/rtems/CMakeLists.txt
+++ b/src/os/rtems/CMakeLists.txt
@@ -35,7 +35,7 @@ set(RTEMS_IMPL_SRCLIST
     ../portable/os-impl-posix-dirs.c
     ../portable/os-impl-no-condvar.c
     ../portable/os-impl-no-rwlock.c
-    ../portable/os-impl-no-file-allocate.c
+    ../portable/os-impl-no-file-allocate.c    
 )
 
 # Currently the "shell output to file" for RTEMS is not implemented
@@ -92,6 +92,22 @@ else()
         ../portable/os-impl-no-select.c
     )
 endif ()
+
+if (OSAL_CONFIG_MAX_CPUS GREATER 1)
+    list(APPEND RTEMS_IMPL_SRCLIST
+        ../portable/os-impl-pthread-affinity-np.c #    use the real affinity code
+    )
+    
+    # _GNU_SOURCE is required for pthread_setaffinity_np and CPU_SET macros
+    set_source_files_properties(
+        ../portable/os-impl-pthread-affinity-np.c 
+        PROPERTIES COMPILE_DEFINITIONS "_GNU_SOURCE"
+    )
+else()
+    list(APPEND RTEMS_IMPL_SRCLIST
+        ../portable/os-impl-pthread-no-affinity-np.c
+    )
+endif()
 
 # Defines an OBJECT target named "osal_rtems_impl" with selected source files
 add_library(osal_rtems_impl OBJECT

--- a/src/os/rtems/inc/os-impl-taskaffinity.h
+++ b/src/os/rtems/inc/os-impl-taskaffinity.h
@@ -18,28 +18,24 @@
 
 /**
  * \file
- * \ingroup  ut-stubs
- * \author   joseph.p.hickey@nasa.gov
+ *
+ * \ingroup  rtems
  *
  */
-#include <string.h>
-#include <stdlib.h>
-#include "utstubs.h"
 
-#include "os-shared-common.h"
-#include "OCS_semLib.h"
+#ifndef OS_IMPL_TASKAFFINITY_H
+#define OS_IMPL_TASKAFFINITY_H
 
-int32 OS_API_Impl_Init(osal_objtype_t idtype)
+#include <pthread.h>
+#include <rtems.h>
+#include <rtems/score/smpimpl.h>
+
+#include "common_types.h"
+
+/* Define the function used by the OSAL initialization */
+static inline uint32 OS_TaskAffinity_Proc_Conf(void)
 {
-    return UT_DEFAULT_IMPL(OS_API_Impl_Init);
+    return (uint32)rtems_scheduler_get_processor_maximum();
 }
 
-int OS_VxWorks_GenericSemTake(OCS_SEM_ID vxid, int sys_ticks)
-{
-    return UT_DEFAULT_IMPL(OS_VxWorks_GenericSemTake);
-}
-
-int OS_VxWorks_GenericSemGive(OCS_SEM_ID vxid)
-{
-    return UT_DEFAULT_IMPL(OS_VxWorks_GenericSemGive);
-}
+#endif /* OS_IMPL_TASKAFFINITY_H */

--- a/src/os/rtems/src/os-impl-tasks.c
+++ b/src/os/rtems/src/os-impl-tasks.c
@@ -40,8 +40,10 @@
 #include "os-impl-tasks.h"
 
 #include "os-shared-task.h"
+#include "os-shared-task-affinity.h"
 #include "os-shared-idmap.h"
 #include "os-shared-timebase.h"
+#include "os-shared-common.h"
 
 #include "osapi-printf.h"
 
@@ -80,6 +82,12 @@ static rtems_task OS_RtemsEntry(rtems_task_argument arg)
 int32 OS_Rtems_TaskAPI_Impl_Init(void)
 {
     memset(OS_impl_task_table, 0, sizeof(OS_impl_task_table));
+
+    /*
+     * Get number of configured cores
+     */
+    OS_SharedGlobalVars.CoresConfigured = OS_TaskAffinityGetCoresConfigured_Impl();
+
     return OS_SUCCESS;
 }
 

--- a/src/os/shared/inc/os-shared-common.h
+++ b/src/os/shared/inc/os-shared-common.h
@@ -70,6 +70,10 @@ struct OS_shared_global_vars
 #ifdef OSAL_CONFIG_DEBUG_PRINTF
     uint8 DebugLevel;
 #endif
+    /*
+     * The numbers of cores configured recognized by the OS
+     */
+    uint32 CoresConfigured;
 };
 
 /*

--- a/src/os/shared/inc/os-shared-task-affinity.h
+++ b/src/os/shared/inc/os-shared-task-affinity.h
@@ -1,0 +1,55 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+#ifndef OS_SHARED_TASK_AFFINITY_H
+#define OS_SHARED_TASK_AFFINITY_H
+
+/*
+**  System Include Files
+*/
+#include <stdlib.h>
+
+#include "osapi-task-affinity.h"
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetCoresConfigured() is an api call  to obtain information from OS
+ * for the number of configured cores
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured_Impl(void);
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinitySetAffinity() is an api call to set affinity to a task
+ *
+ * Sets an affinity from cpuset to task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity_Impl(const OS_object_token_t *token, const OS_cpuset_t cpuset);
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetAffinity() is an api call to get affinity to a task
+ *
+ * Writes affinity to cpuset from task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity_Impl(const OS_object_token_t *token, OS_cpuset_t *cpuset);
+
+#endif /* OS_SHARED_TASK_AFFINITY_H */

--- a/src/os/shared/src/osapi-common.c
+++ b/src/os/shared/src/osapi-common.c
@@ -65,6 +65,7 @@ OS_SharedGlobalVars_t OS_SharedGlobalVars = {
 #if defined(OSAL_CONFIG_DEBUG_PRINTF)
     .DebugLevel = 1,
 #endif
+    .CoresConfigured = 1,
 };
 
 /*----------------------------------------------------------------

--- a/src/os/shared/src/osapi-task-affinity.c
+++ b/src/os/shared/src/osapi-task-affinity.c
@@ -1,0 +1,120 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ * \ingroup  shared
+ *
+ *         This file  contains some of the OS APIs abstraction layer code
+ *         that is shared/common across all OS-specific implementations.
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "common_types.h"
+
+#include "osapi.h"
+#include "os-shared-globaldefs.h"
+
+#include "osapi-task-affinity.h"
+#include "os-shared-task-affinity.h"
+
+/*
+ * User defined include files
+ */
+#include "os-shared-task.h"
+#include "os-shared-common.h"
+#include "os-shared-idmap.h"
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetCoresConfigured() is an api call  to obtain information from OS
+ * for the number of configured cores
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured(void)
+{
+    return OS_TaskAffinityGetCoresConfigured_Impl();
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityCoresConfigured() is an api call  to return global information
+ * from OSAL set at init for the number of configured cores.
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityCoresConfigured(void)
+{
+    return OS_SharedGlobalVars.CoresConfigured;
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinitySetAffinity() is an api call to set affinity to a task
+ *
+ * Sets an affinity from cpuset to task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity(osal_id_t task_id, const OS_cpuset_t cpuset)
+{
+    int32             OsStatus;
+    OS_object_token_t token;
+
+    OsStatus = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, OS_OBJECT_TYPE_OS_TASK, task_id, &token);
+    if (OsStatus == OS_SUCCESS)
+    {
+        OsStatus = OS_TaskAffinitySetAffinity_Impl(&token, cpuset);
+    }
+
+    OS_ObjectIdRelease(&token);
+
+    return OsStatus;
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetAffinity() is an api call to get affinity to a task
+ *
+ * Writes affinity to cpuset from task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity(osal_id_t task_id, OS_cpuset_t *cpuset)
+{
+    int32             OsStatus;
+    OS_object_token_t token;
+
+    OsStatus = OS_ObjectIdGetById(OS_LOCK_MODE_GLOBAL, OS_OBJECT_TYPE_OS_TASK, task_id, &token);
+    if (OsStatus == OS_SUCCESS)
+    {
+        OsStatus = OS_TaskAffinityGetAffinity_Impl(&token, cpuset);
+    }
+
+    OS_ObjectIdRelease(&token);
+
+    return OsStatus;
+}

--- a/src/os/vxworks-rtp/CMakeLists.txt
+++ b/src/os/vxworks-rtp/CMakeLists.txt
@@ -23,6 +23,7 @@ set(POSIX_BASE_SRCLIST
     ../posix/src/os-impl-timebase.c
     src/os-impl-filesys.c     # VxWorks RTP specific implementation
     src/os-impl-files.c       # VxWorks RTP specific implementation
+    ../portable/os-impl-pthread-no-affinity-np.c
 )
 
 # Use portable blocks for basic I/O

--- a/src/os/vxworks/CMakeLists.txt
+++ b/src/os/vxworks/CMakeLists.txt
@@ -86,6 +86,17 @@ else()
     )
 endif ()
 
+
+if (OSAL_CONFIG_MAX_CPUS GREATER 1)
+    list(APPEND VXWORKS_IMPL_SRCLIST
+        src/os-impl-pthread-affinity.c #    use the real affinity code
+    )
+else()
+    list(APPEND VXWORKS_IMPL_SRCLIST
+        ../portable/os-impl-pthread-no-affinity-np.c
+    )
+endif()
+
 # Defines an OBJECT target named "osal_vxworks_impl" with selected source files
 add_library(osal_vxworks_impl OBJECT
     ${VXWORKS_BASE_SRCLIST}

--- a/src/os/vxworks/inc/os-impl-taskaffinity.h
+++ b/src/os/vxworks/inc/os-impl-taskaffinity.h
@@ -18,28 +18,27 @@
 
 /**
  * \file
- * \ingroup  ut-stubs
- * \author   joseph.p.hickey@nasa.gov
+ *
+ * \ingroup  vxworks
  *
  */
-#include <string.h>
-#include <stdlib.h>
-#include "utstubs.h"
 
-#include "os-shared-common.h"
-#include "OCS_semLib.h"
+#ifndef OS_IMPL_TASKAFFINITY_H
+#define OS_IMPL_TASKAFFINITY_H
 
-int32 OS_API_Impl_Init(osal_objtype_t idtype)
+/* VxWorks Native Headers */
+#include <vxWorks.h>
+#include <taskLib.h>
+
+#include "common_types.h"
+
+/* Explicitly declare to avoid implicit declaration warnings */
+extern unsigned int vxCpuConfiguredGet(void);
+
+/* Define the function used by the OSAL initialization */
+static inline uint32 OS_TaskAffinity_Proc_Conf(void)
 {
-    return UT_DEFAULT_IMPL(OS_API_Impl_Init);
+    return (uint32)vxCpuConfiguredGet();
 }
 
-int OS_VxWorks_GenericSemTake(OCS_SEM_ID vxid, int sys_ticks)
-{
-    return UT_DEFAULT_IMPL(OS_VxWorks_GenericSemTake);
-}
-
-int OS_VxWorks_GenericSemGive(OCS_SEM_ID vxid)
-{
-    return UT_DEFAULT_IMPL(OS_VxWorks_GenericSemGive);
-}
+#endif /* OS_IMPL_TASKAFFINITY_H */

--- a/src/os/vxworks/src/os-impl-pthread-affinity.c
+++ b/src/os/vxworks/src/os-impl-pthread-affinity.c
@@ -1,0 +1,138 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *
+ * This file Contains all of the api calls for manipulating files
+ * in a file system / C library that implements the POSIX-style file API
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+/*
+ * Inclusions Defined by OSAL layer.
+ *
+ * This must include whatever is required to get the prototypes of these functions:
+ *
+ *   open()
+ *   stat()
+ *   chmod()
+ *   remove()
+ *   rename()
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+
+#include "os-impl-taskaffinity.h"
+#include "osapi-task-affinity.h"
+
+#include "os-impl-tasks.h"
+#include "os-shared-file.h"
+#include "os-shared-idmap.h"
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                 Named File API
+ ***************************************************************************************/
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetCoresConfigured() is an api call  to obtain information from OS
+ * for the number of configured cores
+ *
+ * Returns the number of configured cores
+ * ----------------------------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured_Impl(void)
+{
+    return OS_TaskAffinity_Proc_Conf();
+}
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinitySetAffinity() is an api call to set affinity to a task
+ *
+ * Sets an affinity from cpuset to task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity_Impl(const OS_object_token_t *token, const OS_cpuset_t cpuset)
+{
+    cpuset_t                        local_cpuset;
+    OS_impl_task_internal_record_t *impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
+    uint32                          i;
+    int32                           return_value;
+
+    CPUSET_ZERO(local_cpuset);
+    for (i = 0; (i < OS_MAX_CPUS) && (i < OS_TaskAffinityGetCoresConfigured()); i++)
+    {
+        if (OS_CPUSET_ISSET(i, &cpuset))
+        {
+            CPUSET_SET(local_cpuset, i);
+        }
+    }
+
+    return_value = taskCpuAffinitySet(impl->vxid, local_cpuset);
+
+    if (return_value == 0)
+    {
+        return OS_SUCCESS;
+    }
+    else
+    {
+        return OS_ERROR;
+    }
+}
+
+/*
+ * ----------------------------------------------------------------------
+ * The OS_TaskAffinityGetAffinity() is an api call to get affinity to a task
+ *
+ * Writes affinity to cpuset from task with provided task_id
+ * ----------------------------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity_Impl(const OS_object_token_t *token, OS_cpuset_t *cpuset)
+{
+    cpuset_t                        local_cpuset;
+    OS_impl_task_internal_record_t *impl = OS_OBJECT_TABLE_GET(OS_impl_task_table, *token);
+    uint32                          i;
+    int32                           return_value;
+
+    CPUSET_ZERO(local_cpuset);
+    return_value = taskCpuAffinityGet(impl->vxid, &local_cpuset);
+
+    if (return_value == 0)
+    {
+        OS_CPUSET_ZERO(cpuset);
+        for (i = 0; (i < OS_MAX_CPUS) && (i < OS_TaskAffinityGetCoresConfigured()); i++)
+        {
+            if (CPUSET_ISSET(local_cpuset, i))
+            {
+                OS_CPUSET_SET(i, cpuset);
+            }
+        }
+        return OS_SUCCESS;
+    }
+    return OS_ERROR;
+}

--- a/src/os/vxworks/src/os-impl-tasks.c
+++ b/src/os/vxworks/src/os-impl-tasks.c
@@ -28,10 +28,14 @@
 
 #include "os-vxworks.h"
 #include "os-impl-tasks.h"
+#include "osapi-task-affinity.h"
 
 #include "os-shared-task.h"
+#include "os-shared-task-affinity.h"
 #include "os-shared-idmap.h"
 #include "os-shared-timebase.h"
+#include "os-shared-common.h"
+
 #include "osapi-bsp.h"
 
 #include <errnoLib.h>
@@ -90,7 +94,6 @@ int OS_VxWorks_TaskEntry(int arg)
 /****************************************************************************************
                                     TASK API
 ****************************************************************************************/
-
 /*----------------------------------------------------------------
  *
  *  Purpose: Local helper routine, not part of OSAL API.
@@ -99,6 +102,12 @@ int OS_VxWorks_TaskEntry(int arg)
 int32 OS_VxWorks_TaskAPI_Impl_Init(void)
 {
     memset(OS_impl_task_table, 0, sizeof(OS_impl_task_table));
+
+    /*
+     * Get number of configured cores
+     */
+    OS_SharedGlobalVars.CoresConfigured = OS_TaskAffinityGetCoresConfigured_Impl();
+
     return OS_SUCCESS;
 }
 

--- a/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
+++ b/src/unit-test-coverage/vxworks/src/coveragetest-tasks.c
@@ -31,6 +31,11 @@
 
 #include "OCS_stdlib.h"
 
+uint32 OS_TaskAffinityGetCoresConfigured_Impl(void)
+{
+    return 1; /* Return a safe default number of cores for the test */
+}
+
 /*
  * A chunk of memory usable as a heap for malloc() emulation
  */

--- a/src/ut-stubs/CMakeLists.txt
+++ b/src/ut-stubs/CMakeLists.txt
@@ -34,6 +34,7 @@ set(OSAL_PUBLIC_API_HEADERS
     ${OSAL_SOURCE_DIR}/src/os/inc/osapi-shell.h
     ${OSAL_SOURCE_DIR}/src/os/inc/osapi-sockets.h
     ${OSAL_SOURCE_DIR}/src/os/inc/osapi-task.h
+    ${OSAL_SOURCE_DIR}/src/os/inc/osapi-task-affinity.h
     ${OSAL_SOURCE_DIR}/src/os/inc/osapi-timebase.h
     ${OSAL_SOURCE_DIR}/src/os/inc/osapi-timer.h
     ${OSAL_SOURCE_DIR}/src/os/inc/osapi-version.h
@@ -95,6 +96,8 @@ add_library(ut_osapi_stubs STATIC
     osapi-sockets-handlers.c
     osapi-task-stubs.c
     osapi-task-handlers.c
+    osapi-task-affinity-stubs.c
+    osapi-task-affinity-handlers.c
     osapi-timer-stubs.c
     osapi-timer-handlers.c
     osapi-timebase-stubs.c

--- a/src/ut-stubs/osapi-task-affinity-handlers.c
+++ b/src/ut-stubs/osapi-task-affinity-handlers.c
@@ -1,0 +1,26 @@
+/*
+ * File: osapi-task-affinity-handlers.c
+ * Purpose: Custom UT handlers for OSAL task affinity functions
+ */
+
+#include "osapi.h"
+#include "utstubs.h"
+#include "utgenstub.h"
+
+/*
+ * Custom handler for OS_TaskAffinityGetAffinity
+ * (Allows the unit tests to pass back mock cpuset arrays)
+ */
+void UT_DefaultHandler_OS_TaskAffinityGetAffinity(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    OS_cpuset_t *AffinityMask = UT_Hook_GetArgValueByName(Context, "cpuset", OS_cpuset_t *);
+    int32        status;
+
+    UT_Stub_GetInt32StatusCode(Context, &status);
+
+    if (status == OS_SUCCESS && AffinityMask != NULL)
+    {
+        /* Safely copy the mock data provided by UT_SetDataBuffer in the test into the pointer */
+        UT_Stub_CopyToLocal(FuncKey, AffinityMask, sizeof(*AffinityMask));
+    }
+}

--- a/src/ut-stubs/osapi-task-affinity-stubs.c
+++ b/src/ut-stubs/osapi-task-affinity-stubs.c
@@ -1,0 +1,90 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in osapi-task-affinity header
+ */
+
+#include "osapi-task-affinity.h"
+#include "utgenstub.h"
+
+void UT_DefaultHandler_OS_TaskAffinityGetAffinity(void *, UT_EntryKey_t, const UT_StubContext_t *);
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_TaskAffinityCoresConfigured()
+ * ----------------------------------------------------
+ */
+uint32 OS_TaskAffinityCoresConfigured(void)
+{
+    UT_GenStub_SetupReturnBuffer(OS_TaskAffinityCoresConfigured, uint32);
+
+    UT_GenStub_Execute(OS_TaskAffinityCoresConfigured, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(OS_TaskAffinityCoresConfigured, uint32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_TaskAffinityGetAffinity()
+ * ----------------------------------------------------
+ */
+int32 OS_TaskAffinityGetAffinity(osal_id_t task_id, OS_cpuset_t *cpuset)
+{
+    UT_GenStub_SetupReturnBuffer(OS_TaskAffinityGetAffinity, int32);
+
+    UT_GenStub_AddParam(OS_TaskAffinityGetAffinity, osal_id_t, task_id);
+    UT_GenStub_AddParam(OS_TaskAffinityGetAffinity, OS_cpuset_t *, cpuset);
+
+    UT_GenStub_Execute(OS_TaskAffinityGetAffinity, Basic, UT_DefaultHandler_OS_TaskAffinityGetAffinity);
+
+    return UT_GenStub_GetReturnValue(OS_TaskAffinityGetAffinity, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_TaskAffinityGetCoresConfigured()
+ * ----------------------------------------------------
+ */
+uint32 OS_TaskAffinityGetCoresConfigured(void)
+{
+    UT_GenStub_SetupReturnBuffer(OS_TaskAffinityGetCoresConfigured, uint32);
+
+    UT_GenStub_Execute(OS_TaskAffinityGetCoresConfigured, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(OS_TaskAffinityGetCoresConfigured, uint32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for OS_TaskAffinitySetAffinity()
+ * ----------------------------------------------------
+ */
+int32 OS_TaskAffinitySetAffinity(osal_id_t task_id, const OS_cpuset_t cpuset)
+{
+    UT_GenStub_SetupReturnBuffer(OS_TaskAffinitySetAffinity, int32);
+
+    UT_GenStub_AddParam(OS_TaskAffinitySetAffinity, osal_id_t, task_id);
+    UT_GenStub_AddParam(OS_TaskAffinitySetAffinity, const OS_cpuset_t, cpuset);
+
+    UT_GenStub_Execute(OS_TaskAffinitySetAffinity, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(OS_TaskAffinitySetAffinity, int32);
+}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adding SMP API to OSAL for POSIX, VxWorks, RTEMS. Also added a no-impl for those configurations that don't support SMP or that there isn't an implementation for it yet.

**Testing performed**
Built with the 3 different OS Linux, RTEMS, VxWorks. Checked for functionality of API using the new cFE module TA. 

**Expected behavior changes**
Able to change task affinity and get core num information

**System(s) tested on**
 - Hardware: PC, VxSIM(on a linux VM), GR740
 - OS: Debian, VxWorks, RTEMS

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Adrian Rodriguez NASA GSFC
