### PR TITLE
Fix #1551, Set default OSAL_CONFIG_MAX_CPUS to 1

### DIFF
--- a/default_config.cmake
+++ b/default_config.cmake
@@ -396,7 +396,7 @@ set(OSAL_CONFIG_QUEUE_MAX_DEPTH         50
 )
 
 # The maximum number of CPUs supported.
-set(OSAL_CONFIG_MAX_CPUS                  8
+set(OSAL_CONFIG_MAX_CPUS                  1
     CACHE STRING "Maximum number of CPUs supported"
 )
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Change the default max cpus in osconfig to from 8 to 1. Fixes #1551

**Expected behavior changes**
makes the OSAL use the implementation: os-impl-pthread-no-affinity-np by default instead of os-impl-pthread-affinity-np.

**System(s) tested on**
 - Hardware: PC
 - OS: Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Adrian Rodriguez NASA GSFC