### PR TITLE
Fix #1547, Use statvfs f_frsize for reported block size

### DIFF
--- a/src/os/posix/src/os-impl-filesys.c
+++ b/src/os/posix/src/os-impl-filesys.c
@@ -321,7 +321,13 @@ int32 OS_FileSysStatVolume_Impl(const OS_object_token_t *token, OS_statvfs_t *re
         return OS_ERROR;
     }
 
-    result->block_size   = OSAL_SIZE_C(stat_buf.f_bsize);
+    /*
+     * Per POSIX, the block counts (f_blocks, f_bfree) are expressed in units of
+     * f_frsize, not f_bsize.  f_bsize is only the preferred I/O transfer size and
+     * is not guaranteed to equal f_frsize.  Use f_frsize so that the reported
+     * block_size is consistent with the block counts (e.g. bytes = blocks * block_size).
+     */
+    result->block_size   = OSAL_SIZE_C(stat_buf.f_frsize);
     result->blocks_free  = OSAL_BLOCKCOUNT_C(stat_buf.f_bfree);
     result->total_blocks = OSAL_BLOCKCOUNT_C(stat_buf.f_blocks);
 

--- a/src/os/qnx/src/os-impl-filesys.c
+++ b/src/os/qnx/src/os-impl-filesys.c
@@ -326,7 +326,13 @@ int32 OS_FileSysStatVolume_Impl(const OS_object_token_t *token, OS_statvfs_t *re
         return OS_ERROR;
     }
 
-    result->block_size   = OSAL_SIZE_C(stat_buf.f_bsize);
+    /*
+     * Per POSIX, the block counts (f_blocks, f_bfree) are expressed in units of
+     * f_frsize, not f_bsize.  f_bsize is only the preferred I/O transfer size and
+     * is not guaranteed to equal f_frsize.  Use f_frsize so that the reported
+     * block_size is consistent with the block counts (e.g. bytes = blocks * block_size).
+     */
+    result->block_size   = OSAL_SIZE_C(stat_buf.f_frsize);
     result->blocks_free  = OSAL_BLOCKCOUNT_C(stat_buf.f_bfree);
     result->total_blocks = OSAL_BLOCKCOUNT_C(stat_buf.f_blocks);
 

--- a/src/os/rtems/src/os-impl-filesys.c
+++ b/src/os/rtems/src/os-impl-filesys.c
@@ -407,7 +407,13 @@ int32 OS_FileSysStatVolume_Impl(const OS_object_token_t *token, OS_statvfs_t *re
     }
     else
     {
-        result->block_size   = stat_buf.f_bsize;
+        /*
+         * Per POSIX, the block counts (f_blocks, f_bfree) are expressed in units of
+         * f_frsize, not f_bsize.  f_bsize is only the preferred I/O transfer size and
+         * is not guaranteed to equal f_frsize.  Use f_frsize so that the reported
+         * block_size is consistent with the block counts (e.g. bytes = blocks * block_size).
+         */
+        result->block_size   = stat_buf.f_frsize;
         result->blocks_free  = stat_buf.f_bfree;
         result->total_blocks = stat_buf.f_blocks;
 


### PR DESCRIPTION
Fix #1547

## Describe the contribution
`OS_FileSysStatVolume_Impl()` on the **posix**, **qnx**, and **rtems** implementations reads volume statistics via `statvfs()`. Per POSIX, the block counts (`f_blocks`, `f_bfree`) are expressed in units of **`f_frsize`**, but the reported `block_size` was taken from **`f_bsize`**, which is only the *preferred I/O transfer size* and is not guaranteed to equal `f_frsize`.

On filesystems where the two differ (e.g. very large drives), byte calculations such as `OS_fsBytesFree()` (`blocks_free * block_size`) produce incorrect results.

This PR changes those three implementations to report `block_size` from `f_frsize`, making it consistent with the block counts. A short comment is added at each site to prevent regressions.

The **vxworks** implementation uses `statfs()` (whose `f_bsize` *is* the fundamental block size that the counts are based on) and is intentionally left unchanged.

## Testing performed
- Builds cleanly.
- No behavior change on filesystems where `f_bsize == f_frsize` (the common case, e.g. typical Linux dev hosts), so existing functional tests are unaffected.
- The fix corrects the reported size on filesystems where `f_frsize > f_bsize` (the condition described in the issue, observed on large drives).

## Expected behavior changes
`OS_FileSysStatVolume()` (and derived `OS_fsBytesFree()` / `OS_fsBlocksFree()`) report correct sizes on filesystems where `f_frsize` differs from `f_bsize`. No change otherwise.

## System the issue was observed on
- OS: Oracle Linux 8 (per reporter), large-capacity drives
- cFS: Draco 2.4

## Additional context
Files changed:
- `src/os/posix/src/os-impl-filesys.c`
- `src/os/qnx/src/os-impl-filesys.c`
- `src/os/rtems/src/os-impl-filesys.c`

## Contributor Info
GitHub: @sg20180546