### PR TITLE
Fix #1556, Initialize Variables in osapi-clock.c

### DIFF
--- a/src/os/shared/src/osapi-clock.c
+++ b/src/os/shared/src/osapi-clock.c
@@ -90,7 +90,7 @@ int32 OS_SetLocalTime(const OS_time_t *time_struct)
  *-----------------------------------------------------------------*/
 OS_time_t OS_TimeFromRelativeMilliseconds(int32 relative_msec)
 {
-    OS_time_t abs_time;
+    OS_time_t abs_time = OS_TIME_ZERO;
 
     if (relative_msec == OS_CHECK)
     {
@@ -120,7 +120,7 @@ OS_time_t OS_TimeFromRelativeMilliseconds(int32 relative_msec)
 int32 OS_TimeToRelativeMilliseconds(OS_time_t time)
 {
     int64     relative_msec;
-    OS_time_t curr_time;
+    OS_time_t curr_time = OS_TIME_ZERO;
 
     /*
      * This is an optimization that assumes all negative time values are


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1556 

**Testing performed**
GitHub Actions and CodeSonar

**Expected behavior changes**
Resolve CodeSonar warnings on uninitialized variables

**System(s) tested on**
GitHub Actions and CodeSonar. CodeSonar results will be posted on the internal ticket.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.