### PR TITLE
Fix #1410, Apply fabs to full relative error in UtAssert_DoubleCmpRel

### DIFF
--- a/ut_assert/inc/utassert.h
+++ b/ut_assert/inc/utassert.h
@@ -198,7 +198,7 @@ typedef struct
  * \brief Compares two floating point numbers and determines if they are equal within a specified relative tolerance.
  */
 #define UtAssert_DoubleCmpRel(x, y, Ratio, ...) \
-    UtAssertEx((fabs((x) - (y)) / (x) <= (Ratio)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
+    UtAssertEx((fabs(((x) - (y)) / (x)) <= (Ratio)), UtAssert_GetContext(), __FILE__, __LINE__, __VA_ARGS__)
 
 /**
  * \brief  Compares two strings and determines if they are equal.


### PR DESCRIPTION
Fix #1410

## Describe the contribution
`UtAssert_DoubleCmpRel` computed `fabs((x) - (y)) / (x)`, applying `fabs` only to the numerator. Because the divisor `(x)` keeps its sign, the relative-error expression becomes negative whenever `x < 0`, so the comparison `(negative) <= Ratio` is always true and the assertion passes no matter how far apart `x` and `y` are (false positive).

This wraps the entire relative-error expression in `fabs` so the comparison uses the magnitude of the relative difference:

```c
fabs(((x) - (y)) / (x)) <= (Ratio)
```

This matches the fix concurred with by the maintainer in #1410.

## Testing performed
- Builds cleanly.
- Example from the issue: `x = -1000`, `y = 1000`, `Ratio = 1e-10`
  - Before: `fabs(-1000 - 1000) / (-1000)` = `-2.0` → `-2.0 <= 1e-10` is **true** (incorrectly passes)
  - After: `fabs((-1000 - 1000) / (-1000))` = `2.0` → `2.0 <= 1e-10` is **false** (correctly fails)
- Behavior is unchanged for positive `x`.

## Expected behavior changes
`UtAssert_DoubleCmpRel` now correctly fails when the relative difference exceeds `Ratio` for negative `x`, instead of always passing. No change for positive `x`.

## System the issue was observed on
- N/A (logic/macro defect, platform-independent)

## Additional context
File changed:
- `ut_assert/inc/utassert.h`

Per the issue discussion, this macro is not currently exercised by any active tests, so existing tests are unaffected.

## Contributor Info
GitHub: @sg20180546