### PR TITLE
fix: stack-buffer-overflow (#1550), wrong statvfs block_size (#1547), path traversal (#1516)

### DIFF
--- a/src/os/posix/src/os-impl-filesys.c
+++ b/src/os/posix/src/os-impl-filesys.c
@@ -321,7 +321,7 @@ int32 OS_FileSysStatVolume_Impl(const OS_object_token_t *token, OS_statvfs_t *re
         return OS_ERROR;
     }
 
-    result->block_size   = OSAL_SIZE_C(stat_buf.f_bsize);
+    result->block_size   = OSAL_SIZE_C(stat_buf.f_frsize);
     result->blocks_free  = OSAL_BLOCKCOUNT_C(stat_buf.f_bfree);
     result->total_blocks = OSAL_BLOCKCOUNT_C(stat_buf.f_blocks);
 

--- a/src/os/qnx/src/os-impl-filesys.c
+++ b/src/os/qnx/src/os-impl-filesys.c
@@ -326,7 +326,7 @@ int32 OS_FileSysStatVolume_Impl(const OS_object_token_t *token, OS_statvfs_t *re
         return OS_ERROR;
     }
 
-    result->block_size   = OSAL_SIZE_C(stat_buf.f_bsize);
+    result->block_size   = OSAL_SIZE_C(stat_buf.f_frsize);
     result->blocks_free  = OSAL_BLOCKCOUNT_C(stat_buf.f_bfree);
     result->total_blocks = OSAL_BLOCKCOUNT_C(stat_buf.f_blocks);
 

--- a/src/os/rtems/src/os-impl-filesys.c
+++ b/src/os/rtems/src/os-impl-filesys.c
@@ -407,7 +407,7 @@ int32 OS_FileSysStatVolume_Impl(const OS_object_token_t *token, OS_statvfs_t *re
     }
     else
     {
-        result->block_size   = stat_buf.f_bsize;
+        result->block_size   = stat_buf.f_frsize;
         result->blocks_free  = stat_buf.f_bfree;
         result->total_blocks = stat_buf.f_blocks;
 

--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -88,11 +88,32 @@ bool OS_FileSys_FindVirtMountPoint(void *ref, const OS_object_token_t *token, co
 {
     OS_filesys_internal_record_t *filesys;
     const char                   *target = (const char *)ref;
+    const char                   *p;
     size_t                        mplen;
 
     filesys = OS_OBJECT_TABLE_GET(OS_filesys_table, *token);
 
     if ((filesys->flags & OS_FILESYS_FLAG_IS_MOUNTED_VIRTUAL) == 0)
+    {
+        return false;
+    }
+
+    /*
+     * Reject any path that contains a ".." component to prevent path
+     * traversal attacks that could escape the virtual mount point (#1516).
+     * Check for "/../", leading "/../", and trailing "/.."
+     */
+    p = target;
+    while (*p != 0)
+    {
+        if (p[0] == '/' && p[1] == '.' && p[2] == '.' && (p[3] == '/' || p[3] == 0))
+        {
+            return false;
+        }
+        ++p;
+    }
+    /* Also reject a path that starts with "../" or is exactly ".." */
+    if (target[0] == '.' && target[1] == '.' && (target[2] == '/' || target[2] == 0))
     {
         return false;
     }

--- a/ut_assert/src/utassert.c
+++ b/ut_assert/src/utassert.c
@@ -758,6 +758,11 @@ bool UtAssert_StringBufCompare(const char        *String1,
     /* Check for a newline within the string, and if present, end the string there instead */
     if (FormatLen1 > 0)
     {
+        /* Clamp to buffer capacity before any memcpy to prevent stack-buffer-overflow (#1550) */
+        if (FormatLen1 > sizeof(ScrubbedString1) - 1)
+        {
+            FormatLen1 = sizeof(ScrubbedString1) - 1;
+        }
         EndPtr1 = memchr(String1, '\n', FormatLen1);
         if (EndPtr1 != NULL)
         {
@@ -769,6 +774,11 @@ bool UtAssert_StringBufCompare(const char        *String1,
 
     if (FormatLen2 > 0)
     {
+        /* Clamp to buffer capacity before any memcpy to prevent stack-buffer-overflow (#1550) */
+        if (FormatLen2 > sizeof(ScrubbedString2) - 1)
+        {
+            FormatLen2 = sizeof(ScrubbedString2) - 1;
+        }
         EndPtr2 = memchr(String2, '\n', FormatLen2);
         if (EndPtr2 != NULL)
         {


### PR DESCRIPTION
## Summary

This PR fixes three bugs found in the `dev` branch:

### Fix #1550 — Stack-buffer-overflow in `UtAssert_StringBufCompare()`

**File:** `ut_assert/src/utassert.c`

**Root cause:** `ScrubbedString1[256]` and `ScrubbedString2[256]` are fixed 256-byte stack buffers. When a fixed-length buffer longer than 255 bytes contains no NUL within the requested bound, `FormatLen1`/`FormatLen2` are set directly from the caller-supplied `String1Max`/`String2Max`. The subsequent `memcpy` writes past the end of the stack buffers causing a stack-buffer-overflow.

**Fix:** Clamp `FormatLen1` and `FormatLen2` to `sizeof(ScrubbedString) - 1` (255) immediately before any `memcpy`, ensuring the copy never exceeds the buffer boundary.

---

### Fix #1547 — `OS_FileSysStatVolume_Impl()` uses wrong `statvfs` field for block size

**Files:** `src/os/posix/src/os-impl-filesys.c`, `src/os/qnx/src/os-impl-filesys.c`, `src/os/rtems/src/os-impl-filesys.c`

**Root cause:** After migrating to `statvfs()`, the POSIX, QNX, and RTEMS implementations still assign `stat_buf.f_bsize` to `result->block_size`. Per POSIX, `f_bsize` is the *preferred I/O transfer block size* while `f_frsize` is the *fundamental file system block size* used to compute actual storage (i.e. `total_blocks * f_frsize` = total bytes). On large drives these values are not guaranteed to be equal, causing incorrect free/total byte calculations.

**Fix:** Replace `stat_buf.f_bsize` with `stat_buf.f_frsize` in all three affected OS ports.

---

### Fix #1516 — Path traversal via unchecked `..` components in `OS_FileSys_FindVirtMountPoint()`

**File:** `src/os/shared/src/osapi-filesys.c`

**Root cause:** `OS_FileSys_FindVirtMountPoint()` performed only a prefix match against the virtual mount point. A path such as `/mnt/abc/../secret` would match the `/mnt/abc` mount point because the prefix check passes and `target[mplen] == '/'`. An attacker could craft a path that traverses outside the virtual mount boundary.

**Fix:** Before performing the prefix match, scan the target path for any `/../` or trailing `/..` sequence and return `false` immediately if found. Also rejects paths starting with `../`.

## Files Changed

| File | Issue | Change |
|------|-------|--------|
| `ut_assert/src/utassert.c` | #1550 | Clamp `FormatLen` before `memcpy` |
| `src/os/posix/src/os-impl-filesys.c` | #1547 | `f_bsize` → `f_frsize` |
| `src/os/qnx/src/os-impl-filesys.c` | #1547 | `f_bsize` → `f_frsize` |
| `src/os/rtems/src/os-impl-filesys.c` | #1547 | `f_bsize` → `f_frsize` |
| `src/os/shared/src/osapi-filesys.c` | #1516 | Reject paths with `..` components |

## Test plan

- [ ] `UtAssert_STRINGBUF_EQ()` with buffers longer than 255 bytes no longer causes stack-buffer-overflow
- [ ] `OS_FileSysStatVolume()` returns correct byte counts on large drives where `f_frsize != f_bsize`
- [ ] `OS_FileSys_FindVirtMountPoint()` returns `false` for paths containing `/../` or `..` traversal
- [ ] Existing unit tests pass with no regressions