### PR TITLE
Fix #1566, correct const pointer returns

### DIFF
--- a/src/os/shared/src/osapi-filesys.c
+++ b/src/os/shared/src/osapi-filesys.c
@@ -675,7 +675,7 @@ int32 OS_TranslatePath(const char *VirtualPath, char *LocalPath)
     OS_object_token_t             token;
     int32                         return_code;
     const char                   *name_ptr;
-    char                         *result;
+    const char                   *result;
     OS_filesys_internal_record_t *filesys;
     size_t                        SysMountPointLen;
     size_t                        VirtPathLen;

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_string.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_string.h
@@ -40,19 +40,19 @@
 /* prototypes normally declared in string.h */
 /* ----------------------------------------- */
 
-extern void  *OCS_memchr(const void *s, int c, size_t n);
-extern void  *OCS_memcpy(void *dest, const void *src, size_t n);
-extern void  *OCS_memset(void *s, int c, size_t n);
-extern int    OCS_strcmp(const char *s1, const char *s2);
-extern char  *OCS_strcpy(char *dest, const char *src);
-extern size_t OCS_strlen(const char *s);
-extern int    OCS_strncmp(const char *s1, const char *s2, size_t n);
-extern char  *OCS_strncpy(char *dest, const char *src, size_t n);
-extern char  *OCS_strchr(const char *s, int c);
-extern char  *OCS_strrchr(const char *s, int c);
-extern char  *OCS_strstr(const char *haystack, const char *needle);
-extern char  *OCS_strcat(char *dest, const char *src);
-extern char  *OCS_strncat(char *dest, const char *src, size_t n);
-extern char  *OCS_strerror(int errnum);
+extern const void *OCS_memchr(const void *s, int c, size_t n);
+extern void       *OCS_memcpy(void *dest, const void *src, size_t n);
+extern void       *OCS_memset(void *s, int c, size_t n);
+extern int         OCS_strcmp(const char *s1, const char *s2);
+extern char       *OCS_strcpy(char *dest, const char *src);
+extern size_t      OCS_strlen(const char *s);
+extern int         OCS_strncmp(const char *s1, const char *s2, size_t n);
+extern char       *OCS_strncpy(char *dest, const char *src, size_t n);
+extern const char *OCS_strchr(const char *s, int c);
+extern const char *OCS_strstr(const char *haystack, const char *needle);
+extern const char *OCS_strrchr(const char *s, int c);
+extern char       *OCS_strcat(char *dest, const char *src);
+extern char       *OCS_strncat(char *dest, const char *src, size_t n);
+extern char       *OCS_strerror(int errnum);
 
 #endif /* OCS_STRING_H */

--- a/src/unit-test-coverage/ut-stubs/src/libc-string-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/libc-string-stubs.c
@@ -43,10 +43,10 @@ void *OCS_memset(void *s, int c, size_t n)
     return Result;
 }
 
-void *OCS_memchr(const void *s, int c, size_t n)
+const void *OCS_memchr(const void *s, int c, size_t n)
 {
-    int32 Status;
-    void *Result;
+    int32       Status;
+    const void *Result;
 
     Status = UT_DEFAULT_IMPL(OCS_memchr);
     if (Status == 0)
@@ -80,7 +80,7 @@ void *OCS_memcpy(void *dest, const void *src, size_t n)
     return Result;
 }
 
-char *OCS_strchr(const char *s, int c)
+const char *OCS_strchr(const char *s, int c)
 {
     int32 Status;
 
@@ -99,7 +99,7 @@ char *OCS_strchr(const char *s, int c)
     return (char *)&s[Status - 1];
 }
 
-char *OCS_strrchr(const char *s, int c)
+const char *OCS_strrchr(const char *s, int c)
 {
     int32 Status;
 
@@ -115,10 +115,10 @@ char *OCS_strrchr(const char *s, int c)
         return (char *)0;
     }
 
-    return (char *)&s[Status - 1];
+    return (const char *)&s[Status - 1];
 }
 
-char *OCS_strstr(const char *haystack, const char *needle)
+const char *OCS_strstr(const char *haystack, const char *needle)
 {
     int32 Status;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
In some C libraries these routines are defined as returning a const pointer (which is correct).

This is incompatible with the traditional definition which returned a non-const pointer.

Fixes #1566

**Testing performed**
Build on latest C library

**Expected behavior changes**
Build is successful and all tests pass

**System(s) tested on**
Fedora 44

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
