### PR TITLE
Fix #1553, guard POSIX state-change waits against spurious wakeups

### DIFF
--- a/src/os/posix/inc/os-impl-idmap.h
+++ b/src/os/posix/inc/os-impl-idmap.h
@@ -34,6 +34,7 @@ typedef struct
 {
     pthread_mutex_t mutex;
     pthread_cond_t  cond;
+    uint32          change_count; /* Updated with the mutex held before notifying waiters. */
 } OS_impl_objtype_lock_t;
 
 /* Tables where the lock state information is stored */

--- a/src/os/posix/src/os-impl-idmap.c
+++ b/src/os/posix/src/os-impl-idmap.c
@@ -112,6 +112,8 @@ void OS_Unlock_Global_Impl(osal_objtype_t idtype)
 
     if (impl != NULL)
     {
+        ++impl->change_count;
+
         /* Notify any waiting threads that the state _may_ have changed */
         ret = pthread_cond_broadcast(&impl->cond);
         if (ret != 0)
@@ -138,6 +140,8 @@ void OS_WaitForStateChange_Impl(osal_objtype_t objtype, uint32 attempts)
 {
     OS_impl_objtype_lock_t *impl;
     struct timespec         ts;
+    uint32                  change_count;
+    int                     wait_status;
 
     impl = OS_impl_objtype_lock_table[objtype];
 
@@ -166,7 +170,14 @@ void OS_WaitForStateChange_Impl(osal_objtype_t objtype, uint32 attempts)
         ++ts.tv_sec;
     }
 
-    pthread_cond_timedwait(&impl->cond, &impl->mutex, &ts);
+    /* A wake-up alone is not evidence that a table owner released the lock.
+     * Keep the original deadline across spurious wakes so the retry backoff
+     * neither expires early nor grows indefinitely. */
+    change_count = impl->change_count;
+    do
+    {
+        wait_status = pthread_cond_timedwait(&impl->cond, &impl->mutex, &ts);
+    } while (wait_status == 0 && impl->change_count == change_count);
 
     pthread_cleanup_pop(false);
 }

--- a/src/unit-test-coverage/CMakeLists.txt
+++ b/src/unit-test-coverage/CMakeLists.txt
@@ -29,7 +29,7 @@ enable_testing()
 # code coverage analysis.  Because the actual underlying OS calls are stubbed out, there
 # is no dependency on the actual underlying OS.  Note that RTEMS is not included as the
 # coverage test is not implemented at this time.
-set(OSALCOVERAGE_TARGET_OSTYPE "vxworks;shared" CACHE STRING "OSAL target(s) to build coverage tests for (default=all)")
+set(OSALCOVERAGE_TARGET_OSTYPE "vxworks;shared;posix" CACHE STRING "OSAL target(s) to build coverage tests for (default=all)")
 
 # Check that coverage has been implemented for this OSTYPE
 foreach(OSTYPE ${OSALCOVERAGE_TARGET_OSTYPE})

--- a/src/unit-test-coverage/posix/CMakeLists.txt
+++ b/src/unit-test-coverage/posix/CMakeLists.txt
@@ -1,0 +1,12 @@
+# POSIX object-table synchronization tests, using the existing pthread stubs.
+add_coverage_testrunner(
+    coverage-posix-idmap
+    ${OSAL_SOURCE_DIR}/src/os/posix/src/os-impl-idmap.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/coveragetest-idmap.c
+    ut_osapi_shared_stubs
+    ut_osapi_stubs
+    ut_libc_stubs
+)
+target_include_directories(utobj_coverage-posix-idmap PRIVATE
+    ${OSAL_SOURCE_DIR}/src/os/posix/inc
+)

--- a/src/unit-test-coverage/posix/src/coveragetest-idmap.c
+++ b/src/unit-test-coverage/posix/src/coveragetest-idmap.c
@@ -1,0 +1,158 @@
+
+#include "os-shared-idmap.h"
+#include "utassert.h"
+#include "uttest.h"
+#include "utstubs.h"
+#include "OCS_pthread.h"
+#include "OCS_errno.h"
+#include "OCS_time.h"
+
+extern int32 OS_Posix_TableMutex_Init(osal_objtype_t idtype);
+extern void  OS_Posix_ReleaseTableMutex(void *mut);
+
+static struct OCS_timespec Deadline;
+static osal_objtype_t      WakeType;
+static uint32              WakeCall;
+static uint32              WaitCalls;
+static uint32              WaitLimit;
+static int32               WaitError;
+static void               *Condition;
+static void               *Mutex;
+
+static int32 WaitHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
+{
+    const struct OCS_timespec *limit = UT_Hook_GetArgValueByName(Context, "abstime", const struct OCS_timespec *);
+    void                      *cond  = UT_Hook_GetArgValueByName(Context, "cond", OCS_pthread_cond_t *);
+    void                      *mutex = UT_Hook_GetArgValueByName(Context, "mutex", OCS_pthread_mutex_t *);
+
+    UtAssert_True(limit->tv_sec == Deadline.tv_sec && limit->tv_nsec == Deadline.tv_nsec,
+                  "Every wait uses the original absolute deadline");
+    Condition = cond;
+    Mutex     = mutex;
+    ++WaitCalls;
+    if (WaitCalls == WakeCall)
+    {
+        /* Model a table owner releasing the mutex while this waiter sleeps. */
+        OS_Unlock_Global_Impl(WakeType);
+        OS_Lock_Global_Impl(WakeType);
+    }
+    return WaitCalls < WaitLimit ? 0 : WaitError;
+}
+
+static void Setup(void)
+{
+    UT_ResetState(0);
+    Deadline.tv_sec  = 0;
+    Deadline.tv_nsec = 10000000;
+    WakeType         = OS_OBJECT_TYPE_OS_TASK;
+    WakeCall         = 0;
+    WaitCalls        = 0;
+    WaitLimit        = 1;
+    WaitError        = OCS_ETIMEDOUT;
+    UT_SetHookFunction(UT_KEY(OCS_pthread_cond_timedwait), WaitHook, NULL);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_pthread_cond_timedwait), OCS_ETIMEDOUT);
+}
+
+static void TestSpuriousWakeups(void)
+{
+    WaitLimit = 3;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_timedwait, 3);
+    UtAssert_STUB_COUNT(OCS_clock_gettime, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cleanup_push, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cleanup_pop, 1);
+}
+
+static void TestStateChange(void)
+{
+    WakeCall  = 2;
+    WaitLimit = 3;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_timedwait, 2);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_broadcast, 1);
+}
+
+static void TestOtherTableChange(void)
+{
+    WakeCall  = 1;
+    WakeType  = OS_OBJECT_TYPE_OS_QUEUE;
+    WaitLimit = 2;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_timedwait, 2);
+}
+
+static void TestTimeoutAndError(void)
+{
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_timedwait, 1);
+    WaitError = OCS_EINVAL;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_timedwait, 2);
+}
+
+static void TestDeadlineAndIndependentTables(void)
+{
+    void               *task_cond;
+    void               *task_mutex;
+    struct OCS_timespec now = { 10, 999000000 };
+    UT_SetDataBuffer(UT_KEY(OCS_clock_gettime), &now, sizeof(now), false);
+    Deadline.tv_sec  = 11;
+    Deadline.tv_nsec = 9000000;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 1);
+    task_cond        = Condition;
+    task_mutex       = Mutex;
+    Deadline.tv_sec  = 1;
+    Deadline.tv_nsec = 0;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_QUEUE, 11);
+    UtAssert_True(Condition != task_cond && Mutex != task_mutex, "Object types have distinct synchronization objects");
+    Deadline.tv_sec = 0;
+    OS_WaitForStateChange_Impl(OS_OBJECT_TYPE_OS_TASK, 0);
+}
+
+static void TestMutexOperations(void)
+{
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_UNDEFINED);
+    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_UNDEFINED);
+    UtAssert_STUB_COUNT(OCS_pthread_mutex_lock, 0);
+    UtAssert_STUB_COUNT(OCS_pthread_mutex_unlock, 0);
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+    UtAssert_STUB_COUNT(OCS_pthread_mutex_lock, 1);
+    UtAssert_STUB_COUNT(OCS_pthread_cond_broadcast, 1);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_pthread_mutex_lock), OCS_EINVAL);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_pthread_mutex_unlock), OCS_EINVAL);
+    UT_SetDefaultReturnValue(UT_KEY(OCS_pthread_cond_broadcast), OCS_EINVAL);
+    OS_Lock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+    OS_Unlock_Global_Impl(OS_OBJECT_TYPE_OS_TASK);
+    OS_Posix_ReleaseTableMutex(NULL);
+    UtAssert_STUB_COUNT(OCS_pthread_mutex_unlock, 3);
+}
+
+static void TestInitialization(void)
+{
+    UT_EntryKey_t failures[] = { UT_KEY(OCS_pthread_mutexattr_init),
+                                 UT_KEY(OCS_pthread_mutexattr_setprotocol),
+                                 UT_KEY(OCS_pthread_mutexattr_settype),
+                                 UT_KEY(OCS_pthread_mutex_init),
+                                 UT_KEY(OCS_pthread_cond_init) };
+    size_t        i;
+    UtAssert_INT32_EQ(OS_Posix_TableMutex_Init(OS_OBJECT_TYPE_UNDEFINED), OS_SUCCESS);
+    UtAssert_INT32_EQ(OS_Posix_TableMutex_Init(OS_OBJECT_TYPE_OS_TASK), OS_SUCCESS);
+    for (i = 0; i < sizeof(failures) / sizeof(failures[0]); ++i)
+    {
+        UT_SetDefaultReturnValue(failures[i], OCS_EINVAL);
+        UtAssert_INT32_EQ(OS_Posix_TableMutex_Init(OS_OBJECT_TYPE_OS_TASK), OS_ERROR);
+        UT_ClearDefaultReturnValue(failures[i]);
+    }
+}
+
+void UtTest_Setup(void)
+{
+    UtTest_Add(TestSpuriousWakeups, Setup, NULL, "Spurious wakeups retain the original wait");
+    UtTest_Add(TestStateChange, Setup, NULL, "A notified state change releases the wait");
+    UtTest_Add(TestOtherTableChange, Setup, NULL, "Other object types cannot release the wait");
+    UtTest_Add(TestTimeoutAndError, Setup, NULL, "Timeouts and errors stop waiting");
+    UtTest_Add(TestDeadlineAndIndependentTables, Setup, NULL, "Deadlines and per-type isolation");
+    UtTest_Add(TestMutexOperations, Setup, NULL, "Mutex and cleanup paths");
+    UtTest_Add(TestInitialization, Setup, NULL, "Table initialization");
+}

--- a/src/unit-test-coverage/ut-stubs/inc/OCS_pthread.h
+++ b/src/unit-test-coverage/ut-stubs/inc/OCS_pthread.h
@@ -37,6 +37,7 @@
 #define OCS_PTHREAD_PRIO_INHERIT    0x1000
 #define OCS_PTHREAD_MUTEX_RECURSIVE 0x1001
 #define OCS_PTHREAD_EXPLICIT_SCHED  0x1002
+#define OCS_PTHREAD_MUTEX_NORMAL    0x1003
 
 /* ----------------------------------------- */
 /* types normally defined in pthread.h */
@@ -88,6 +89,9 @@ typedef struct OCS_pthread_key       OCS_pthread_key_t;
 /* ----------------------------------------- */
 /* prototypes normally declared in pthread.h */
 /* ----------------------------------------- */
+
+extern void OCS_pthread_cleanup_push(void (*routine)(void *), void *arg);
+extern void OCS_pthread_cleanup_pop(int execute);
 
 extern int OCS_pthread_attr_destroy(OCS_pthread_attr_t *attr);
 extern int OCS_pthread_attr_getschedparam(const OCS_pthread_attr_t *attr, struct OCS_sched_param *param);

--- a/src/unit-test-coverage/ut-stubs/override_inc/pthread.h
+++ b/src/unit-test-coverage/ut-stubs/override_inc/pthread.h
@@ -36,6 +36,7 @@
 #define PTHREAD_PRIO_INHERIT    OCS_PTHREAD_PRIO_INHERIT
 #define PTHREAD_MUTEX_RECURSIVE OCS_PTHREAD_MUTEX_RECURSIVE
 #define PTHREAD_EXPLICIT_SCHED  OCS_PTHREAD_EXPLICIT_SCHED
+#define PTHREAD_MUTEX_NORMAL    OCS_PTHREAD_MUTEX_NORMAL
 
 #define pthread_t           OCS_pthread_t
 #define pthread_attr_t      OCS_pthread_attr_t
@@ -44,6 +45,9 @@
 #define pthread_cond_t      OCS_pthread_cond_t
 #define pthread_condattr_t  OCS_pthread_condattr_t
 #define pthread_key_t       OCS_pthread_key_t
+
+#define pthread_cleanup_push OCS_pthread_cleanup_push
+#define pthread_cleanup_pop  OCS_pthread_cleanup_pop
 
 #define pthread_attr_destroy          OCS_pthread_attr_destroy
 #define pthread_attr_getschedparam    OCS_pthread_attr_getschedparam

--- a/src/unit-test-coverage/ut-stubs/src/posix-pthread-stubs.c
+++ b/src/unit-test-coverage/ut-stubs/src/posix-pthread-stubs.c
@@ -134,6 +134,10 @@ int OCS_pthread_cond_timedwait(OCS_pthread_cond_t *cond, OCS_pthread_mutex_t *mu
 {
     int32 Status;
 
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OCS_pthread_cond_timedwait), cond);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OCS_pthread_cond_timedwait), mutex);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OCS_pthread_cond_timedwait), abstime);
+
     Status = UT_DEFAULT_IMPL(OCS_pthread_cond_timedwait);
 
     return Status;
@@ -336,4 +340,17 @@ int OCS_pthread_sigmask(int how, const OCS_sigset_t *set, OCS_sigset_t *oldset)
     Status = UT_DEFAULT_IMPL(OCS_pthread_sigmask);
 
     return Status;
+}
+
+void OCS_pthread_cleanup_push(void (*routine)(void *), void *arg)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OCS_pthread_cleanup_push), routine);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OCS_pthread_cleanup_push), arg);
+    UT_DEFAULT_IMPL(OCS_pthread_cleanup_push);
+}
+
+void OCS_pthread_cleanup_pop(int execute)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(OCS_pthread_cleanup_pop), execute);
+    UT_DEFAULT_IMPL(OCS_pthread_cleanup_pop);
 }


### PR DESCRIPTION
Fixes #1553.

## Contribution

Track object-table notifications under the existing POSIX mutex and keep waiting through spurious condition-variable wakeups. Reuse the original absolute deadline, stop on timeout/error, and preserve cancellation cleanup.

The binary-semaphore wait already checks its value/flush predicate. Public condition-variable waits retain their documented caller-owned predicate semantics; no public API changes.

## Testing

Debian 12 arm64, GCC 12.2, CMake 3.25:
- All 60 coverage targets passed, including seven new POSIX idmap cases with 34 assertions.
- The final regression tests fail against unchanged upstream implementation in an isolated build, then pass with the fix.
- Full CTest run: 75/86 passed. The same 11 functional-test failures/timeouts also occur on unchanged upstream in this container; the baseline additionally fails the new regression target.
- Changed C/C++ lines formatted with the cFS configuration; `git diff --check` passed.

Tests cover repeated spurious wakes, actual notifications, unrelated object types, timeout/error exits, fixed deadlines, mutex isolation, and cleanup/initialization paths.

## Checklist

- [x] Contributing guide reviewed.
- [x] Issue and existing pull requests checked for overlap.
- [x] Regression coverage added and exercised.
- [ ] Contributor License Agreement submission verified.

Contributor: Sylvester Kaczmarek, Personal.
No third-party code added.
